### PR TITLE
Match property name to name used in specification.

### DIFF
--- a/src/bacnet/bactext.c
+++ b/src/bacnet/bactext.c
@@ -223,7 +223,7 @@ INDTEXT_DATA bacnet_property_names[] = {
     { PROP_CONTROLLED_VARIABLE_REFERENCE, "controlled-variable-reference" },
     { PROP_CONTROLLED_VARIABLE_UNITS, "controlled-variable-units" },
     { PROP_CONTROLLED_VARIABLE_VALUE, "controlled-variable-value" },
-    { PROP_COV_INCREMENT, "COV-increment" }, { PROP_DATE_LIST, "datelist" },
+    { PROP_COV_INCREMENT, "cov-increment" }, { PROP_DATE_LIST, "datelist" },
     { PROP_DAYLIGHT_SAVINGS_STATUS, "daylight-savings-status" },
     { PROP_DEADBAND, "deadband" },
     { PROP_DERIVATIVE_CONSTANT, "derivative-constant" },


### PR DESCRIPTION
The `bacnet_property_names` in bactext.c match the values in the specification, with the exception of `COV-increment`. This changes it to `cov-increment` to match the specification.