### PR TITLE
readprop - allow text strings for object-type and property arguments.

### DIFF
--- a/apps/readprop/main.c
+++ b/apps/readprop/main.c
@@ -197,19 +197,23 @@ static void print_help(char *filename)
            "I-Am services.  For example, if you were reading\n"
            "Device Object 123, the device-instance would be 123.\n"
            "\nobject-type:\n"
-           "The object type is the integer value of the enumeration\n"
-           "BACNET_OBJECT_TYPE in bacenum.h.  It is the object\n"
-           "that you are reading.  For example if you were\n"
-           "reading Analog Output 2, the object-type would be 1.\n"
+           "The object type is object that you are reading. It\n"
+           "can be defined either as the object-type name string\n"
+           "as defined in the BACnet specification, or as the\n"
+           "integer value of the enumeration BACNET_OBJECT_TYPE\n"
+           "in bacenum.h. For example if you were reading Analog\n"
+           "Output 2, the object-type would be analog-output or 1.\n"
            "\nobject-instance:\n"
            "This is the object instance number of the object that\n"
            "you are reading.  For example, if you were reading\n"
            "Analog Output 2, the object-instance would be 2.\n"
            "\nproperty:\n"
-           "The property is an integer value of the enumeration\n"
-           "BACNET_PROPERTY_ID in bacenum.h.  It is the property\n"
-           "you are reading.  For example, if you were reading the\n"
-           "Present Value property, use 85 as the property.\n"
+           "The property of the object that you are reading. It\n"
+           "can be defined either as the property name string as\n"
+           "defined in the BACnet specification, or as an integer\n"
+           "value of the enumeration BACNET_PROPERTY_ID in\n"
+           "bacenum.h. For example, if you were reading the Present\n"
+           "Value property, use present-value or 85 as the property.\n"
            "\nindex:\n"
            "This integer parameter is the index number of an array.\n"
            "If the property is an array, individual elements can\n"
@@ -217,12 +221,16 @@ static void print_help(char *filename)
            "is an array, the entire array will be read.\n"
            "\nExample:\n"
            "If you want read the Present-Value of Analog Output 101\n"
-           "in Device 123, you could send the following command:\n"
+           "in Device 123, you could send either of the following\n"
+           "commands:\n"
+           "%s 123 analog-output 101 present-value\n"
            "%s 123 1 101 85\n"
            "If you want read the Priority-Array of Analog Output 101\n"
-           "in Device 123, you could send the following command:\n"
+           "in Device 123, you could send either of the following\n"
+           "commands:\n"
+           "%s 123 analog-output 101 priority-array\n"
            "%s 123 1 101 87\n",
-        filename, filename);
+        filename, filename, filename, filename);
 }
 
 int main(int argc, char *argv[])
@@ -285,13 +293,21 @@ int main(int argc, char *argv[])
                 Target_Device_Object_Instance = strtol(argv[argi], NULL, 0);
                 target_args++;
             } else if (target_args == 1) {
-                Target_Object_Type = strtol(argv[argi], NULL, 0);
+                if (bactext_object_type_strtol(
+                        argv[argi], &Target_Object_Type) == false) {
+                    fprintf(stderr, "object-type=%s invalid\n", argv[argi]);
+                    return 1;
+                }
                 target_args++;
             } else if (target_args == 2) {
                 Target_Object_Instance = strtol(argv[argi], NULL, 0);
                 target_args++;
             } else if (target_args == 3) {
-                Target_Object_Property = strtol(argv[argi], NULL, 0);
+                if (bactext_property_strtol(
+                        argv[argi], &Target_Object_Property) == false) {
+                    fprintf(stderr, "property=%s invalid\n", argv[argi]);
+                    return 1;
+                }
                 target_args++;
             } else if (target_args == 4) {
                 Target_Object_Index = strtol(argv[argi], NULL, 0);

--- a/apps/readpropm/main.c
+++ b/apps/readpropm/main.c
@@ -242,10 +242,12 @@ static void print_help(char *filename)
            "I-Am services.  For example, if you were reading\n"
            "Device Object 123, the device-instance would be 123.\n"
            "\nobject-type:\n"
-           "The object type is the integer value of the enumeration\n"
-           "BACNET_OBJECT_TYPE in bacenum.h.  It is the object\n"
-           "that you are reading.  For example if you were\n"
-           "reading Analog Output 2, the object-type would be 1.\n"
+           "The object type is object that you are reading. It\n"
+           "can be defined either as the object-type name string\n"
+           "as defined in the BACnet specification, or as the\n"
+           "integer value of the enumeration BACNET_OBJECT_TYPE\n"
+           "in bacenum.h. For example if you were reading Analog\n"
+           "Output 2, the object-type would be analog-output or 1.\n"
            "\nobject-instance:\n"
            "This is the object instance number of the object that\n"
            "you are reading.  For example, if you were reading\n"
@@ -263,22 +265,28 @@ static void print_help(char *filename)
            "\nExample:\n"
            "If you want read the PRESENT_VALUE property and various\n"
            "array elements of the PRIORITY_ARRAY in Device 123\n"
-           "Analog Output object 99, use the following command:\n"
+           "Analog Output object 99, use one of the following commands:\n"
+           "%s 123 analog-output 99 85,87[0],87\n"
            "%s 123 1 99 85,87[0],87\n"
            "If you want read the PRESENT_VALUE property in objects\n"
            "Analog Input 77 and Analog Input 78 in Device 123\n"
-           "use the following command:\n"
+           "use one of the following commands:\n"
+           "%s 123 analog-input 77 85 analog-input 78 85\n"
            "%s 123 0 77 85 0 78 85\n"
            "If you want read the ALL property in\n"
-           "Device object 123, you would use the following command:\n"
+           "Device object 123, you would use one of the following commands:\n"
+           "%s 123 device 123 8\n"
            "%s 123 8 123 8\n"
            "If you want read the OPTIONAL property in\n"
-           "Device object 123, you would use the following command:\n"
+           "Device object 123, you would use one of the following commands:\n"
+           "%s 123 device 123 80\n"
            "%s 123 8 123 80\n"
            "If you want read the REQUIRED property in\n"
-           "Device object 123, you would use the following command:\n"
+           "Device object 123, you would one of use the following commands:\n"
+           "%s 123 device 123 105\n"
            "%s 123 8 123 105\n",
-        filename, filename, filename, filename, filename);
+        filename, filename, filename, filename, filename, filename, filename,
+        filename, filename, filename);
 }
 
 int main(int argc, char *argv[])
@@ -338,7 +346,12 @@ int main(int argc, char *argv[])
     arg_sets = 0;
     while (rpm_object) {
         tag_value_arg = 2 + (arg_sets * 3);
-        rpm_object->object_type = strtol(argv[tag_value_arg], NULL, 0);
+        if (bactext_object_type_strtol(
+                argv[tag_value_arg], &rpm_object->object_type) == false) {
+            fprintf(
+                stderr, "Error: object-type=%s invalid\n", argv[tag_value_arg]);
+            return 1;
+        }
         tag_value_arg++;
         args_remaining--;
         if (args_remaining <= 0) {

--- a/apps/readrange/main.c
+++ b/apps/readrange/main.c
@@ -177,9 +177,11 @@ static void print_help(char *filename)
            "\nExample:\n"
            "If you want read the Log_Buffer of Trend Log 2\n"
            "in Device 123, from starting position 1 and read 10 entries,\n"
-           "you could send the following command:\n"
-           "%s 123 20 2 131 1 1 10\n",
-        filename);
+           "you could send the following commands:\n");
+    printf("%s 123 trend-log 2 log-buffer 1 1 10\n", filename);
+    printf("%s 123 trend-log 2 log-buffer 2 1 10\n", filename);
+    printf("%s 123 trend-log 2 log-buffer 3 1/1/2014 00:00:01 10\n", filename);
+    printf("%s 123 20 2 131 1 1 10\n", filename);
     printf("%s 123 20 2 131 2 1 10\n", filename);
     printf("%s 123 20 2 131 3 1/1/2014 00:00:01 10\n", filename);
 }
@@ -224,9 +226,15 @@ int main(int argc, char *argv[])
     }
     /* decode the command line parameters */
     Target_Device_Object_Instance = strtol(argv[1], NULL, 0);
-    Target_Object_Type = strtol(argv[2], NULL, 0);
+    if (bactext_object_type_strtol(argv[2], &Target_Object_Type) == false) {
+        fprintf(stderr, "object-type=%s invalid\n", argv[2]);
+        return 1;
+    }
     Target_Object_Instance = strtol(argv[3], NULL, 0);
-    Target_Object_Property = strtol(argv[4], NULL, 0);
+    if (bactext_property_strtol(argv[4], &Target_Object_Property) == false) {
+        fprintf(stderr, "property=%s invalid\n", argv[4]);
+        return 1;
+    }
     Target_Object_Range_Type = strtol(argv[5], NULL, 0);
     /* some bounds checking */
     if (Target_Device_Object_Instance > BACNET_MAX_INSTANCE) {

--- a/apps/scov/main.c
+++ b/apps/scov/main.c
@@ -193,6 +193,7 @@ int main(int argc, char *argv[])
     BACNET_SUBSCRIBE_COV_DATA *cov_data = NULL;
     int argi = 0;
     int arg_remaining = 0;
+    unsigned uint;
 
     if (argc < 6) {
         print_usage_terse = true;
@@ -216,10 +217,12 @@ int main(int argc, char *argv[])
                "The subscriber BACnet Device Object Instance number.\r\n"
                "\r\n"
                "object-type:\r\n"
-               "The monitored object type is the integer value of the\r\n"
-               "enumeration BACNET_OBJECT_TYPE in bacenum.h.  For example,\r\n"
-               "if you were monitoring Analog Output 2, the object-type\r\n"
-               "would be 1.\r\n"
+               "The object type is object that you are reading. It\r\n"
+               "can be defined either as the object-type name string\r\n"
+               "as defined in the BACnet specification, or as the\r\n"
+               "integer value of the enumeration BACNET_OBJECT_TYPE\r\n"
+               "in bacenum.h. For example if you were reading Analog\r\n"
+               "Output 2, the object-type would be analog-output or 1.\r\n"
                "\r\n"
                "object-instance:\r\n"
                "The monitored object instance number.\r\n"
@@ -264,7 +267,11 @@ int main(int argc, char *argv[])
     cov_data = COV_Subscribe_Data;
     argi = 2;
     while (cov_data) {
-        cov_data->monitoredObjectIdentifier.type = strtol(argv[argi], NULL, 0);
+        if (bactext_object_type_strtol(argv[argi], &uint) == false) {
+            fprintf(stderr, "Error: object-type=%s invalid\n", argv[argi]);
+            return 1;
+        }
+        cov_data->monitoredObjectIdentifier.type = (uint16_t)uint;
         if (cov_data->monitoredObjectIdentifier.type >=
             MAX_BACNET_OBJECT_TYPE) {
             fprintf(stderr, "object-type=%u - it must be less than %u\r\n",

--- a/apps/whohas/main.c
+++ b/apps/whohas/main.c
@@ -117,7 +117,7 @@ static void print_help(char *filename)
            "The device-instance-min or max can be 0 to %d.\r\n"
            "\r\n"
            "Use either:\r\n"
-           "The object-type can be 0 to %d.\r\n"
+           "The object-type can be 0 to %d, or a string e.g. analog-output.\r\n"
            "The object-instance can be 0 to %d.\r\n"
            "or:\r\n"
            "The object-name can be any string of characters.\r\n",
@@ -157,7 +157,10 @@ int main(int argc, char *argv[])
     } else if (argc < 4) {
         /* bacwh 8 1234 */
         Target_Object_Instance_Min = Target_Object_Instance_Max = -1;
-        Target_Object_Type = strtol(argv[1], NULL, 0);
+        if (bactext_object_type_strtol(argv[1], &Target_Object_Type) == false) {
+            fprintf(stderr, "object-type=%s invalid\n", argv[1]);
+            return 1;
+        }
         Target_Object_Instance = strtol(argv[2], NULL, 0);
     } else if (argc < 5) {
         /* bacwh 0 4194303 "name" */
@@ -169,7 +172,10 @@ int main(int argc, char *argv[])
         /* bacwh 0 4194303 8 1234 */
         Target_Object_Instance_Min = strtol(argv[1], NULL, 0);
         Target_Object_Instance_Max = strtol(argv[2], NULL, 0);
-        Target_Object_Type = strtol(argv[3], NULL, 0);
+        if (bactext_object_type_strtol(argv[3], &Target_Object_Type) == false) {
+            fprintf(stderr, "object-type=%s invalid\n", argv[3]);
+            return 1;
+        }
         Target_Object_Instance = strtol(argv[4], NULL, 0);
     } else {
         print_usage(filename_remove_path(argv[0]));

--- a/apps/writeprop/main.c
+++ b/apps/writeprop/main.c
@@ -165,10 +165,12 @@ static void print_help(char *filename)
         "writing to Device Object 123, the device-instance would be 123.\n"
         "\n"
         "object-type:\n"
-        "The object type is the integer value of the enumeration\n"
-        "BACNET_OBJECT_TYPE in bacenum.h.  It is the object that you are\n"
-        "writing to.  For example if you were writing to Analog Output 2, \n"
-        "the object-type would be 1.\n"
+        "The object type is object that you are reading. It\n"
+        "can be defined either as the object-type name string\n"
+        "as defined in the BACnet specification, or as the\n"
+        "integer value of the enumeration BACNET_OBJECT_TYPE\n"
+        "in bacenum.h. For example if you were reading Analog\n"
+        "Output 2, the object-type would be analog-output or 1.\n"
         "\n"
         "object-instance:\n"
         "This is the object instance number of the object that you are \n"
@@ -176,10 +178,12 @@ static void print_help(char *filename)
         "the object-instance would be 2.\n"
         "\n"
         "property:\n"
-        "The property is an integer value of the enumeration \n"
-        "BACNET_PROPERTY_ID in bacenum.h.  It is the property you are \n"
-        "writing to.  For example, if you were writing to the Present Value\n"
-        "property, you would use 85 as the property.\n"
+        "The property of the object that you are reading. It\n"
+        "can be defined either as the property name string as\n"
+        "defined in the BACnet specification, or as an integer\n"
+        "value of the enumeration BACNET_PROPERTY_ID in\n"
+        "bacenum.h. For example, if you were reading the Present\n"
+        "Value property, use present-value or 85 as the property.\n"
         "\n"
         "priority:\n"
         "This parameter is used for setting the priority of the\n"
@@ -221,11 +225,13 @@ static void print_help(char *filename)
         "\nExample:\n"
         "If you want send a value of 100 to the Present-Value in\n"
         "Analog Output 0 of Device 123 at priority 16,\n"
-        "send the following command:\n"
+        "send the one of following commands:\n"
+        "%s 123 analog-output 0 present-value 16 -1 4 100\n"
         "%s 123 1 0 85 16 -1 4 100\n"
         "To send a relinquish command to the same object:\n"
+        "%s 123 analog-output 0 present-value 16 -1 0 0\n"
         "%s 123 1 0 85 16 -1 0 0\n",
-        filename, filename);
+        filename, filename, filename, filename);
 }
 
 int main(int argc, char *argv[])
@@ -270,9 +276,15 @@ int main(int argc, char *argv[])
     }
     /* decode the command line parameters */
     Target_Device_Object_Instance = strtol(argv[1], NULL, 0);
-    Target_Object_Type = strtol(argv[2], NULL, 0);
+    if (bactext_object_type_strtol(argv[2], &Target_Object_Type) == false) {
+        fprintf(stderr, "object-type=%s invalid\n", argv[2]);
+        return 1;
+    }
     Target_Object_Instance = strtol(argv[3], NULL, 0);
-    Target_Object_Property = strtol(argv[4], NULL, 0);
+    if (bactext_property_strtol(argv[4], &Target_Object_Property) == false) {
+        fprintf(stderr, "property=%s invalid\n", argv[4]);
+        return 1;
+    }
     Target_Object_Property_Priority = (uint8_t)strtol(argv[5], NULL, 0);
     Target_Object_Property_Index = strtol(argv[6], NULL, 0);
     if (Target_Object_Property_Index == -1)

--- a/apps/writepropm/main.c
+++ b/apps/writepropm/main.c
@@ -184,10 +184,12 @@ static void print_help(char *filename)
         "I-Am services.  For example, if you were writing\n"
         "Device Object 123, the device-instance would be 123.\n"
         "\nobject-type:\n"
-        "The object type is the integer value of the enumeration\n"
-        "BACNET_OBJECT_TYPE in bacenum.h.  It is the object\n"
-        "that you are writing.  For example if you were\n"
-        "writing Analog Output 2, the object-type would be 1.\n"
+        "The object type is object that you are reading. It\n"
+        "can be defined either as the object-type name string\n"
+        "as defined in the BACnet specification, or as the\n"
+        "integer value of the enumeration BACNET_OBJECT_TYPE\n"
+        "in bacenum.h. For example if you were reading Analog\n"
+        "Output 2, the object-type would be analog-output or 1.\n"
         "\nobject-instance:\n"
         "This is the object instance number of the object that\n"
         "you are writing.  For example, if you were writing\n"
@@ -302,7 +304,12 @@ int main(int argc, char *argv[])
     arg_sets = 0;
     while (wpm_object) {
         tag_value_arg = 2 + (arg_sets * 6);
-        wpm_object->object_type = strtol(argv[tag_value_arg], NULL, 0);
+        if (bactext_object_type_strtol(
+                argv[tag_value_arg], &wpm_object->object_type) == false) {
+            fprintf(
+                stderr, "Error: object-type=%s invalid\n", argv[tag_value_arg]);
+            return 1;
+        }
         tag_value_arg++;
         args_remaining--;
         if (Verbose) {

--- a/src/bacnet/bactext.c
+++ b/src/bacnet/bactext.c
@@ -33,6 +33,7 @@
 ####COPYRIGHTEND####*/
 
 #include <stdio.h>
+#include <stdlib.h>
 #include "bacnet/indtext.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/bactext.h"
@@ -41,6 +42,30 @@
 
 static const char *ASHRAE_Reserved_String = "Reserved for Use by ASHRAE";
 static const char *Vendor_Proprietary_String = "Vendor Proprietary Value";
+
+/* Search for a text value first based on the corresponding text list, then by
+ * attempting to convert to an integer value. */
+static bool bactext_strtol_index(INDTEXT_DATA *istring, const char *search_name, unsigned *found_index)
+{
+    char *endptr;
+    long value;
+
+    if (indtext_by_istring(istring, search_name, found_index) == true) {
+        return true;
+    } else {
+        value = strtol(search_name, &endptr, 0);
+        if (endptr == search_name) {
+            /* No digits found */
+            return false;
+        } else if (*endptr != '\0') {
+            /* Extra text found */
+            return false;
+        } else {
+            *found_index = (unsigned)value;
+            return true;
+        }
+    }
+}
 
 INDTEXT_DATA bacnet_confirmed_service_names[] = {
     { SERVICE_CONFIRMED_ACKNOWLEDGE_ALARM, "Acknowledge-Alarm" },
@@ -203,6 +228,12 @@ const char *bactext_object_type_name(unsigned index)
 bool bactext_object_type_index(const char *search_name, unsigned *found_index)
 {
     return indtext_by_istring(
+        bacnet_object_type_names, search_name, found_index);
+}
+
+bool bactext_object_type_strtol(const char *search_name, unsigned *found_index)
+{
+    return bactext_strtol_index(
         bacnet_object_type_names, search_name, found_index);
 }
 
@@ -658,6 +689,12 @@ unsigned bactext_property_id(const char *name)
 bool bactext_property_index(const char *search_name, unsigned *found_index)
 {
     return indtext_by_istring(bacnet_property_names, search_name, found_index);
+}
+
+bool bactext_property_strtol(const char *search_name, unsigned *found_index)
+{
+    return bactext_strtol_index(
+        bacnet_property_names, search_name, found_index);
 }
 
 INDTEXT_DATA bacnet_engineering_unit_names[] = {

--- a/src/bacnet/bactext.h
+++ b/src/bacnet/bactext.h
@@ -55,6 +55,9 @@ extern "C" {
     bool bactext_object_type_index(
         const char *search_name,
         unsigned *found_index);
+    bool bactext_object_type_strtol(
+        const char *search_name,
+        unsigned *found_index);
     const char *bactext_notify_type_name(
         unsigned index);
     const char *bactext_event_type_name(
@@ -65,6 +68,9 @@ extern "C" {
         unsigned index,
         const char *default_string);
     bool bactext_property_index(
+        const char *search_name,
+        unsigned *found_index);
+    bool bactext_property_strtol(
         const char *search_name,
         unsigned *found_index);
     const char *bactext_engineering_unit_name(


### PR DESCRIPTION
I'm not proposing this as a patch to be merged straight away. This change is an example of what I'd like to do across a few of the demo apps. If you like the idea, do you want me to duplicate the StrToX functions across the different apps, or to put them in a common file - and if so, then where would you suggest?

The existing method of calling bacrp requires the user to know the
enumeration value for the object-type and property values. This patch
enhances to allow the object-type and property arguments to be specified
as strings, using the strings as defined in the spec. It does not remove
the old behaviour.

Current:
  bacrp 1234 3 1 85

New:
  bacrp 1234 binary-input 1 present-value