### PR TITLE
CI: use cmake --build command to build a project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
     - stage: demos-build-cmake
       os: linux
       compiler: gcc
-      script: mkdir build && cd build && cmake .. && make clean all
+      script: mkdir build && cd build && cmake .. && cmake --build . --clean-first
     - stage: gateway-build
       os: linux
       compiler: gcc


### PR DESCRIPTION
This way we hide the real build system and thus, can replace Makefiles
with Ninja and we won't have to change the build command.

--clean-first parameter will invoke clean target before building.