### PR TITLE
Fix UNKNOWN_PROPERTY on Mac_Address of Network Port demo object.

### DIFF
--- a/src/bacnet/basic/object/netport.c
+++ b/src/bacnet/basic/object/netport.c
@@ -1852,28 +1852,19 @@ int Network_Port_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata)
     BACNET_OCTET_STRING octet_string;
     BACNET_CHARACTER_STRING char_string;
     uint8_t *apdu = NULL;
+    const int *pRequired = NULL;
+    const int *pOptional = NULL;
+    const int *pProprietary = NULL;
 
     if ((rpdata == NULL) || (rpdata->application_data == NULL) ||
         (rpdata->application_data_len == 0)) {
         return 0;
     }
-    if ((Network_Port_Type(rpdata->object_instance) != PORT_TYPE_MSTP) &&
-        property_list_member(
-            MSTP_Port_Properties_Optional, rpdata->object_property)) {
-        rpdata->error_class = ERROR_CLASS_PROPERTY;
-        rpdata->error_code = ERROR_CODE_UNKNOWN_PROPERTY;
-        return BACNET_STATUS_ERROR;
-    }
-    if ((Network_Port_Type(rpdata->object_instance) != PORT_TYPE_BIP) &&
-        property_list_member(
-            BIP_Port_Properties_Optional, rpdata->object_property)) {
-        rpdata->error_class = ERROR_CLASS_PROPERTY;
-        rpdata->error_code = ERROR_CODE_UNKNOWN_PROPERTY;
-        return BACNET_STATUS_ERROR;
-    }
-    if ((Network_Port_Type(rpdata->object_instance) != PORT_TYPE_BIP6) &&
-        property_list_member(
-            BIP6_Port_Properties_Optional, rpdata->object_property)) {
+    Network_Port_Property_List(rpdata->object_instance,
+        &pRequired, &pOptional, &pProprietary);
+    if ((!property_list_member(pRequired, rpdata->object_property)) &&
+        (!property_list_member(pOptional, rpdata->object_property)) &&
+        (!property_list_member(pProprietary, rpdata->object_property))) {
         rpdata->error_class = ERROR_CLASS_PROPERTY;
         rpdata->error_code = ERROR_CODE_UNKNOWN_PROPERTY;
         return BACNET_STATUS_ERROR;


### PR DESCRIPTION
In the Network Port demo object, Mac_Address appears in all three of `MSTP_Port_Properties_Optional`, `BIP_Port_Properties_Optional` and `BIP6_Port_Properties_Optional`. As a result, due to how the optional properties list is checked in relation to the Network Port's port type, the check for Mac_Address always fails and returns UNKNOWN_PROPERTY.

This PR fixes the problem by getting the appropriate optional properties list for the Network Port object instance and checking all three of required, optional and proprietary properties before returning UNKNOWN_PROPERTY.

Alternatively, a check could be added for Mac_Address specifically, but this would be less maintainable should more common optional properties be added to the Network Port object in later BACnet revisions.

Note that this error also applies to the Max_APDU_Length_Accepted property of the Network Port demo object, but this property should be removed anyway--see #23.