### PR TITLE
Reduce Tusage_timeout from 95ms to 30ms as per 136-2016bm.

### DIFF
--- a/src/bacnet/datalink/mstp.c
+++ b/src/bacnet/datalink/mstp.c
@@ -149,12 +149,12 @@ static inline void printf_master(const char *format, ...)
 #define Treply_timeout 295
 #endif
 
-/* The minimum time without a DataAvailable or ReceiveError event that a */
-/* node must wait for a remote node to begin using a token or replying to */
-/* a Poll For Master frame: 20 milliseconds. (Implementations may use */
-/* larger values for this timeout, not to exceed 100 milliseconds.) */
+/* The time without a DataAvailable or ReceiveError event that a node must */
+/* wait for a remote node to begin using a token or replying to a Poll For */
+/* Master frame: 20 milliseconds. (Implementations may use larger values for */
+/* this timeout, not to exceed 35 milliseconds.) */
 #ifndef Tusage_timeout
-#define Tusage_timeout 95
+#define Tusage_timeout 30
 #endif
 
 /* we need to be able to increment without rolling over */


### PR DESCRIPTION
Addendum 135-2016bm-1 reduces the allowed range for Tusage_timeout in an MS/TP master device from 20-100ms to 20-35ms. Since this addendum falls under protocol revision 20, this PR reduces the value for Tusage_timeout from 95ms to 30ms. The new value satisfies both the pre-addendum and post-addendum range.