### PR TITLE
Reduce Tusage_timeout for all ports.

### DIFF
--- a/apps/router/mstpmodule.c
+++ b/apps/router/mstpmodule.c
@@ -51,7 +51,7 @@ void *dl_mstp_thread(void *pArgs)
 
     shared_port_data.Treply_timeout = 260;
     shared_port_data.MSTP_Packets = 0;
-    shared_port_data.Tusage_timeout = 50;
+    shared_port_data.Tusage_timeout = 30;
     shared_port_data.RS485_Handle = -1;
     shared_port_data.RS485_Baud = B38400;
     shared_port_data.RS485MOD = 0;

--- a/ports/at91sam7s/dlmstp.c
+++ b/ports/at91sam7s/dlmstp.c
@@ -129,11 +129,11 @@ static uint8_t Nmax_master = 127;
 /* larger values for this timeout, not to exceed 300 milliseconds.) */
 #define Treply_timeout 260
 
-/* The minimum time without a DataAvailable or ReceiveError event that a */
-/* node must wait for a remote node to begin using a token or replying to */
-/* a Poll For Master frame: 20 milliseconds. (Implementations may use */
-/* larger values for this timeout, not to exceed 100 milliseconds.) */
-#define Tusage_timeout 60
+/* The time without a DataAvailable or ReceiveError event that a node must */
+/* wait for a remote node to begin using a token or replying to a Poll For */
+/* Master frame: 20 milliseconds. (Implementations may use larger values for */
+/* this timeout, not to exceed 35 milliseconds.) */
+#define Tusage_timeout 30
 
 /* The number of tokens received or used before a Poll For Master cycle */
 /* is executed: 50. */

--- a/ports/atmega168/dlmstp.c
+++ b/ports/atmega168/dlmstp.c
@@ -141,11 +141,11 @@ static uint8_t TransmitPacketDest;
 /* larger values for this timeout, not to exceed 300 milliseconds.) */
 #define Treply_timeout 295
 
-/* The minimum time without a DataAvailable or ReceiveError event that a */
-/* node must wait for a remote node to begin using a token or replying to */
-/* a Poll For Master frame: 20 milliseconds. (Implementations may use */
-/* larger values for this timeout, not to exceed 100 milliseconds.) */
-#define Tusage_timeout 95
+/* The time without a DataAvailable or ReceiveError event that a node must */
+/* wait for a remote node to begin using a token or replying to a Poll For */
+/* Master frame: 20 milliseconds. (Implementations may use larger values for */
+/* this timeout, not to exceed 35 milliseconds.) */
+#define Tusage_timeout 30
 
 /* The minimum number of DataAvailable or ReceiveError events that must be */
 /* seen by a receiving node in order to declare the line "active": 4. */

--- a/ports/bdk-atxx4-mstp/dlmstp.c
+++ b/ports/bdk-atxx4-mstp/dlmstp.c
@@ -133,11 +133,11 @@ static uint8_t Nmax_master = 127;
 /* larger values for this timeout, not to exceed 300 milliseconds.) */
 #define Treply_timeout 260
 
-/* The minimum time without a DataAvailable or ReceiveError event that a */
-/* node must wait for a remote node to begin using a token or replying to */
-/* a Poll For Master frame: 20 milliseconds. (Implementations may use */
-/* larger values for this timeout, not to exceed 100 milliseconds.) */
-#define Tusage_timeout 60
+/* The time without a DataAvailable or ReceiveError event that a node must */
+/* wait for a remote node to begin using a token or replying to a Poll For */
+/* Master frame: 20 milliseconds. (Implementations may use larger values for */
+/* this timeout, not to exceed 35 milliseconds.) */
+#define Tusage_timeout 30
 
 /* The number of tokens received or used before a Poll For Master cycle */
 /* is executed: 50. */

--- a/ports/linux/dlmstp.c
+++ b/ports/linux/dlmstp.c
@@ -91,11 +91,11 @@ static RING_BUFFER PDU_Queue;
 /* confirmed request: 255 milliseconds. (Implementations may use */
 /* larger values for this timeout, not to exceed 300 milliseconds.) */
 static uint16_t Treply_timeout = 300;
-/* The minimum time without a DataAvailable or ReceiveError event that a */
-/* node must wait for a remote node to begin using a token or replying to */
-/* a Poll For Master frame: 20 milliseconds. (Implementations may use */
-/* larger values for this timeout, not to exceed 100 milliseconds.) */
-static uint8_t Tusage_timeout = 100;
+/* The time without a DataAvailable or ReceiveError event that a node must */
+/* wait for a remote node to begin using a token or replying to a Poll For */
+/* Master frame: 20 milliseconds. (Implementations may use larger values for */
+/* this timeout, not to exceed 35 milliseconds.) */
+static uint8_t Tusage_timeout = 30;
 /* Timer that indicates line silence - and functions */
 
 static struct timespec start;

--- a/ports/stm32f10x/dlmstp.c
+++ b/ports/stm32f10x/dlmstp.c
@@ -120,11 +120,11 @@ static uint8_t Nmax_master = 127;
 /* larger values for this timeout, not to exceed 300 milliseconds.) */
 #define Treply_timeout 260
 
-/* The minimum time without a DataAvailable or ReceiveError event that a */
-/* node must wait for a remote node to begin using a token or replying to */
-/* a Poll For Master frame: 20 milliseconds. (Implementations may use */
-/* larger values for this timeout, not to exceed 100 milliseconds.) */
-#define Tusage_timeout 60
+/* The time without a DataAvailable or ReceiveError event that a node must */
+/* wait for a remote node to begin using a token or replying to a Poll For */
+/* Master frame: 20 milliseconds. (Implementations may use larger values for */
+/* this timeout, not to exceed 35 milliseconds.) */
+#define Tusage_timeout 30
 
 /* The minimum number of DataAvailable or ReceiveError events that must be */
 /* seen by a receiving node in order to declare the line "active": 4. */

--- a/ports/win32/dlmstp.c
+++ b/ports/win32/dlmstp.c
@@ -60,11 +60,11 @@ static uint8_t RxBuffer[MAX_MPDU];
 /* confirmed request: 255 milliseconds. (Implementations may use */
 /* larger values for this timeout, not to exceed 300 milliseconds.) */
 static uint16_t Treply_timeout = 260;
-/* The minimum time without a DataAvailable or ReceiveError event that a */
-/* node must wait for a remote node to begin using a token or replying to */
-/* a Poll For Master frame: 20 milliseconds. (Implementations may use */
-/* larger values for this timeout, not to exceed 100 milliseconds.) */
-static uint8_t Tusage_timeout = 50;
+/* The time without a DataAvailable or ReceiveError event that a node must */
+/* wait for a remote node to begin using a token or replying to a Poll For */
+/* Master frame: 20 milliseconds. (Implementations may use larger values for */
+/* this timeout, not to exceed 35 milliseconds.) */
+static uint8_t Tusage_timeout = 30;
 /* local timer for tracking silence on the wire */
 static struct mstimer Silence_Timer;
 

--- a/ports/xplained/dlmstp.c
+++ b/ports/xplained/dlmstp.c
@@ -133,11 +133,11 @@ static volatile uint8_t Nmax_master = 127;
 /* larger values for this timeout, not to exceed 300 milliseconds.) */
 #define Treply_timeout 260
 
-/* The minimum time without a DataAvailable or ReceiveError event that a */
-/* node must wait for a remote node to begin using a token or replying to */
-/* a Poll For Master frame: 20 milliseconds. (Implementations may use */
-/* larger values for this timeout, not to exceed 100 milliseconds.) */
-#define Tusage_timeout 60
+/* The time without a DataAvailable or ReceiveError event that a node must */
+/* wait for a remote node to begin using a token or replying to a Poll For */
+/* Master frame: 20 milliseconds. (Implementations may use larger values for */
+/* this timeout, not to exceed 35 milliseconds.) */
+#define Tusage_timeout 30
 
 /* The minimum number of DataAvailable or ReceiveError events that must be */
 /* seen by a receiving node in order to declare the line "active": 4. */


### PR DESCRIPTION
Same as #33 but now applied to the customized datalink layers for each of the ports as well. Any that were higher than 35, I've just set to 30.