### PR TITLE
Test shared libraries on travis-ci + add appveyor script

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,10 @@
+configuration: Release
+
+image:
+  - Visual Studio 2019
+  - Ubuntu
+  - macOS
+
+build_script:
+  - cmake . -DBUILD_SHARED_LIBS=ON
+  - cmake --build . --config %CONFIGURATION%

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
     - stage: demos-build-cmake
       os: linux
       compiler: gcc
-      script: mkdir build && cd build && cmake .. && cmake --build . --clean-first
+      script: mkdir build && cd build && cmake .. -DBUILD_SHARED_LIBS=ON && cmake --build . --clean-first
     - stage: gateway-build
       os: linux
       compiler: gcc

--- a/ports/bsd/mstimer-init.c
+++ b/ports/bsd/mstimer-init.c
@@ -22,11 +22,12 @@
 * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 *
 *********************************************************************/
+#include <limits.h>
 #include <stdio.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <time.h>
-#include "mstimer.h"
+#include "bacnet/basic/sys/mstimer.h"
 #include <mach/clock.h>
 #include <mach/mach.h>
 


### PR DESCRIPTION
This should help #49 and avoid regressions in the future.

appveyor output: https://ci.appveyor.com/project/madebr/bacnet-stack/builds/30891966
travis output: https://travis-ci.com/madebr/bacnet-stack/builds/149527509

To enable appveyor: somebody should create a organization account there and enable builds for this repo. Optionally, you can then also add a badge to the readme.

Building on macos also uncovers a new error:
```
/Users/appveyor/projects/bacnet-stack/ports/bsd/mstimer-init.c:29:10: fatal error: 'mstimer.h' file not found
#include "mstimer.h"
         ^~~~~~~~~~~
1 error generated.
make[2]: *** [CMakeFiles/bacnet-stack.dir/ports/bsd/mstimer-init.c.o] Error 1

```

I see that macos is not officially supported, as written in the first line of the README, but I added it for reference. Packagers, such as conan, will also try to build macos libraries.