### PR TITLE
refactor: use const char * instead of char * for inputs

### DIFF
--- a/src/bacnet/basic/binding/address.c
+++ b/src/bacnet/basic/binding/address.c
@@ -284,7 +284,7 @@ void address_mac_init(BACNET_MAC_ADDRESS *mac, uint8_t *adr, uint8_t len)
  *
  * @return true if the address was parsed
  */
-bool address_mac_from_ascii(BACNET_MAC_ADDRESS *mac, char *arg)
+bool address_mac_from_ascii(BACNET_MAC_ADDRESS *mac, const char *arg)
 {
     unsigned a[6] = { 0 }, p = 0;
     uint16_t port = 0;

--- a/src/bacnet/basic/binding/address.h
+++ b/src/bacnet/basic/binding/address.h
@@ -136,7 +136,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool address_mac_from_ascii(
         BACNET_MAC_ADDRESS *mac,
-        char *arg);
+        const char *arg);
 
     BACNET_STACK_EXPORT
     void address_protected_entry_index_set(uint32_t top_protected_entry_index);


### PR DESCRIPTION
fixes: "ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]"