### PR TITLE
fix: compiler warnings Wtautological-pointer-compare

### DIFF
--- a/src/bacnet/basic/object/av.c
+++ b/src/bacnet/basic/object/av.c
@@ -683,8 +683,7 @@ bool Analog_Value_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
     if (wp_data == NULL) {
         return false;
     }
-    if ((wp_data->application_data == NULL) ||
-        (wp_data->application_data_len == 0)) {
+    if (wp_data->application_data_len == 0) {
         return false;
     }
 

--- a/src/bacnet/basic/object/bv.c
+++ b/src/bacnet/basic/object/bv.c
@@ -422,8 +422,7 @@ bool Binary_Value_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
     if (wp_data == NULL) {
         return false;
     }
-    if ((wp_data->application_data == NULL) ||
-        (wp_data->application_data_len == 0)) {
+    if (wp_data->application_data_len == 0) {
         return false;
     }
 

--- a/src/bacnet/basic/object/csv.c
+++ b/src/bacnet/basic/object/csv.c
@@ -488,8 +488,7 @@ bool CharacterString_Value_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
     if (wp_data == NULL) {
         return false;
     }
-    if ((wp_data->application_data == NULL) ||
-        (wp_data->application_data_len == 0)) {
+    if (wp_data->application_data_len == 0) {
         return false;
     }
 


### PR DESCRIPTION
warning: comparison of array 'wp_data->application_data' equal to a null pointer is always false [-Wtautological-pointer-compare]