### PR TITLE
Set name after call to Init_Service_Handlers()

### DIFF
--- a/apps/server/main.c
+++ b/apps/server/main.c
@@ -235,9 +235,7 @@ int main(int argc, char *argv[])
         if (argc > 1) {
             Device_Set_Object_Instance_Number(strtol(argv[1], NULL, 0));
         }
-        if (argc > 2) {
-            Device_Object_Name_ANSI_Init(argv[2]);
-        }
+
 #if defined(BAC_UCI)
     }
     ucix_cleanup(ctx);
@@ -252,6 +250,9 @@ int main(int argc, char *argv[])
        in our device bindings list */
     address_init();
     Init_Service_Handlers();
+    if (argc > 2) {
+        Device_Object_Name_ANSI_Init(argv[2]);
+    }
     dlenv_init();
     atexit(datalink_cleanup);
     /* configure the timeout values */


### PR DESCRIPTION
Fixes issue #97. I'm not sure if this is the preferred fix, or to remove setting of device name from the default implementation in device.c.