### PR TITLE
Replace "bits/pthreadtypes.h" include with <sys/types.h> in /ports/li…

### DIFF
--- a/ports/linux/dlmstp_linux.h
+++ b/ports/linux/dlmstp_linux.h
@@ -26,7 +26,7 @@
 
 #include "bacnet/datalink/mstp.h"
 /*#include "bacnet/datalink/dlmstp.h" */
-#include "bits/pthreadtypes.h"
+#include <sys/types.h>
 #include <semaphore.h>
 
 #include <stdbool.h>


### PR DESCRIPTION
…nux/dlmstp_linux.h

This resolves #129 by making this file able to be built on Alpine Linux