### PR TITLE
Bug#74 Printing of the Read property acknowledgement

### DIFF
--- a/src/bacnet/basic/service/h_rp_a.c
+++ b/src/bacnet/basic/service/h_rp_a.c
@@ -65,7 +65,7 @@ void rp_ack_print_data(BACNET_READ_PROPERTY_DATA *data)
         /* value? need to loop until all of the len is gone... */
         for (;;) {
             len = bacapp_decode_application_data(
-                application_data, (uint8_t)application_data_len, &value);
+                application_data, (unsigned)application_data_len, &value);
             if (first_value && (len < application_data_len)) {
                 first_value = false;
 #if PRINT_ENABLED


### PR DESCRIPTION
[Bug#74](https://sourceforge.net/p/bacnet/bugs/74/) Printing of the Read property acknowledgement when APDU len is > 255 bytes.  Thank you [unnakb](https://sourceforge.net/u/unnakb/profile/)!