### PR TITLE
Fixes Issue #157 (Router segfaults)

### DIFF
--- a/apps/router/Makefile
+++ b/apps/router/Makefile
@@ -13,7 +13,7 @@ ifeq (${BACNET_PORT},linux)
 #PFLAGS =
 # -pthread
 TARGET_EXT =
-LIBS = -lpthread -lconfig
+LIBS = -lpthread -lconfig -lm
 LFLAGS += $(LIBS)
 endif
 

--- a/apps/router/main.c
+++ b/apps/router/main.c
@@ -83,8 +83,6 @@ inline bool is_network_msg(BACMSG *msg);
 
 int main(int argc, char *argv[])
 {
-    printf("I am router\n");
-
     ROUTER_PORT *port;
     BACMSG msg_storage, *bacmsg = NULL;
     MSG_DATA *msg_data = NULL;
@@ -115,7 +113,8 @@ int main(int argc, char *argv[])
             }
         }
 
-        bacmsg = recv_from_msgbox(head->main_id, &msg_storage);
+        // blocking dequeue here
+        bacmsg = recv_from_msgbox(head->main_id, &msg_storage, 0);
         if (bacmsg) {
             switch (bacmsg->type) {
                 case DATA: {
@@ -128,7 +127,7 @@ int main(int argc, char *argv[])
                         break;
                     }
 
-                    print_msg(bacmsg);
+                    // print_msg(bacmsg);
 
                     if (is_network_msg(bacmsg)) {
                         buff_len =
@@ -154,7 +153,7 @@ int main(int argc, char *argv[])
                         msg_storage.type = DATA;
                         msg_storage.data = msg_data;
 
-                        print_msg(bacmsg);
+                        // print_msg(bacmsg);
 
                         if (is_network_msg(bacmsg)) {
                             msg_data->ref_count = 1;
@@ -253,13 +252,13 @@ bool read_config(char *filepath)
 
             /* create new list node to store port information */
             if (head == NULL) {
-                head = (ROUTER_PORT *)malloc(sizeof(ROUTER_PORT));
+                head = (ROUTER_PORT *)calloc(sizeof(ROUTER_PORT), 1);
                 head->next = NULL;
                 current = head;
             } else {
                 ROUTER_PORT *tmp = current;
                 current = current->next;
-                current = (ROUTER_PORT *)malloc(sizeof(ROUTER_PORT));
+                current = (ROUTER_PORT *)calloc(sizeof(ROUTER_PORT), 1);
                 current->next = NULL;
                 tmp->next = current;
             }
@@ -273,7 +272,7 @@ bool read_config(char *filepath)
                 result = config_setting_lookup_string(port, "device", &iface);
                 if (result) {
                     current->iface =
-                        (char *)malloc((strlen(iface) + 1) * sizeof(char));
+                      (char *)calloc(sizeof(char), strlen(iface) + 1);
                     strcpy(current->iface, iface);
 
                     /* check if interface is valid */
@@ -315,7 +314,7 @@ bool read_config(char *filepath)
                 result = config_setting_lookup_string(port, "device", &iface);
                 if (result) {
                     current->iface =
-                        (char *)malloc((strlen(iface) + 1) * sizeof(char));
+                      (char *)calloc(sizeof(char), strlen(iface) + 1);
                     strcpy(current->iface, iface);
 
                     /* check if interface is valid */
@@ -455,13 +454,13 @@ bool parse_cmd(int argc, char *argv[])
 
                 /* create new list node to store port information */
                 if (head == NULL) {
-                    head = (ROUTER_PORT *)malloc(sizeof(ROUTER_PORT));
+                    head = (ROUTER_PORT *)calloc(sizeof(ROUTER_PORT), 1);
                     head->next = NULL;
                     current = head;
                 } else {
                     ROUTER_PORT *tmp = current;
                     current = current->next;
-                    current = (ROUTER_PORT *)malloc(sizeof(ROUTER_PORT));
+                    current = (ROUTER_PORT *)calloc(sizeof(ROUTER_PORT), 1);
                     current->next = NULL;
                     tmp->next = current;
                 }

--- a/apps/router/msgqueue.c
+++ b/apps/router/msgqueue.c
@@ -58,12 +58,12 @@ bool send_to_msgbox(MSGBOX_ID dest, BACMSG *msg)
     return true;
 }
 
-BACMSG *recv_from_msgbox(MSGBOX_ID src, BACMSG *msg)
+BACMSG *recv_from_msgbox(MSGBOX_ID src, BACMSG *msg, int flags)
 {
     int recv_bytes;
 
     recv_bytes =
-        msgrcv(src, msg, sizeof(BACMSG) - sizeof(MSGTYPE), 0, IPC_NOWAIT);
+        msgrcv(src, msg, sizeof(BACMSG) - sizeof(MSGTYPE), 0, flags);
     if (recv_bytes > 0) {
         return msg;
     } else {

--- a/apps/router/msgqueue.h
+++ b/apps/router/msgqueue.h
@@ -82,7 +82,8 @@ bool send_to_msgbox(
 /* returns received message */
 BACMSG *recv_from_msgbox(
     MSGBOX_ID src,
-    BACMSG * msg);
+    BACMSG * msg,
+    int flags);
 
 void del_msgbox(
     MSGBOX_ID msgboxid);

--- a/apps/router/mstpmodule.c
+++ b/apps/router/mstpmodule.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/ipc.h>
 #include "mstpmodule.h"
 #include "bacnet/bacint.h"
 #include "dlmstp_linux.h"
@@ -106,7 +107,7 @@ void *dl_mstp_thread(void *pArgs)
         BACMSG msg_storage, *bacmsg;
         MSG_DATA *msg_data;
 
-        bacmsg = recv_from_msgbox(port->port_id, &msg_storage);
+        bacmsg = recv_from_msgbox(port->port_id, &msg_storage, IPC_NOWAIT);
 
         if (bacmsg) {
             switch (bacmsg->type) {


### PR DESCRIPTION
Found a number of problems with the router when compiling on linux

* Expected malloc()'ed memory to be zeroed resulting in segfault when attempting to traverse uninitialized dnet list.
* IPC_NOWAIT in main loop means the router sits at 100% cpu utilization polling the main message queue.  fixed by using a blocking wait in that loop and polling in the iplayer threads.
* When configured with two BIP interfaces, broadcast loops ensue because the broadcast traffic is not correctly filtered.  I think the safest thing to do here is to use the SO_BINDTODEVICE setsockopt.