### PR TITLE
Add bip_get_socket

### DIFF
--- a/ports/bsd/bip-init.c
+++ b/ports/bsd/bip-init.c
@@ -81,6 +81,15 @@ static void debug_print_ipv4(const char *str,
 }
 
 /**
+ * @brief Return the active BIP socket.
+ * @return The active BIP socket, or -1 if uninitialized.
+ */
+int bip_get_socket(void)
+{
+    return BIP_Socket;
+}
+
+/**
  * @brief Enabled debug printing of BACnet/IPv4
  */
 void bip_debug_enable(void)

--- a/ports/linux/bip-init.c
+++ b/ports/linux/bip-init.c
@@ -92,6 +92,17 @@ static void debug_print_ipv4(const char *str,
     }
 }
 
+
+/**
+ * @brief Return the active BIP socket
+ * @note DLS addition
+ */
+int bip_get_socket(void)
+{
+    return BIP_Socket;
+}
+
+
 /**
  * @brief Enabled debug printing of BACnet/IPv4
  */

--- a/ports/linux/bip-init.c
+++ b/ports/linux/bip-init.c
@@ -94,8 +94,8 @@ static void debug_print_ipv4(const char *str,
 
 
 /**
- * @brief Return the active BIP socket
- * @note DLS addition
+ * @brief Return the active BIP socket.
+ * @return The active BIP socket, or -1 if uninitialized.
  */
 int bip_get_socket(void)
 {

--- a/ports/win32/bip-init.c
+++ b/ports/win32/bip-init.c
@@ -88,6 +88,17 @@ static void debug_print_ipv4(const char *str,
 }
 
 /**
+ * @brief Return the active BIP socket.
+ * @return The active BIP socket, or INVALID_SOCKET if uninitialized.
+ * @note Strictly, the return type should be SOCKET, however in practice 
+ *  Windows never returns values large enough that truncation is an issue.
+ */
+int bip_get_socket(void)
+{
+    return (int)BIP_Socket;
+}
+
+/**
  * @brief Enabled debug printing of BACnet/IPv4
  */
 void bip_debug_enable(void)

--- a/src/bacnet/datalink/bip.h
+++ b/src/bacnet/datalink/bip.h
@@ -115,6 +115,10 @@ extern "C" {
     BACNET_STACK_EXPORT
     void bip_debug_enable(void);
 
+    /* DLS addition */
+    BACNET_STACK_EXPORT
+    int bip_get_socket(void);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/src/bacnet/datalink/bip.h
+++ b/src/bacnet/datalink/bip.h
@@ -115,7 +115,6 @@ extern "C" {
     BACNET_STACK_EXPORT
     void bip_debug_enable(void);
 
-    /* DLS addition */
     BACNET_STACK_EXPORT
     int bip_get_socket(void);
 


### PR DESCRIPTION
Adds a function to return the currently active BIP port.

This is useful for applications that have many of their own sockets and want to maintain a single `select()` call to manage all of them (In my case I want to also run an HTTP server and several other things). This does mean that `select` is called in my application code, and then again in `bip_receive()`, but as far as I'm aware it's safe to call it twice on the same socket.

There's a slight headache in dealing with Windows, as it uses the SOCKET type which can _technically_ be 64 bit and therefore not fit into an `int`, however there seems to be an assumption going back at least 12 years that `int == SOCKET`, and as such it's highly unlikely that Windows will ever change that. This is baked into many applications, most notable OpenSSL. See links for further reading:
https://stackoverflow.com/questions/1953639/is-it-safe-to-cast-socket-to-int-under-win64
https://github.com/openssl/openssl/issues/7282#issuecomment-430633656
https://github.com/openssl/openssl/issues/8169#issuecomment-461171391
