### PR TITLE
Uci fix

### DIFF
--- a/apps/Makefile
+++ b/apps/Makefile
@@ -64,7 +64,7 @@ BACNET_PORT ?= linux
 ifeq (${UCI},1)
 BACNET_DEFINES += -DBAC_UCI
 UCI_LIB_DIR ?= /usr/local/lib
-BACNET_LIB += -L$(UCI_LIB_DIR),-luci
+BACNET_LIB += -L$(UCI_LIB_DIR) -luci
 endif
 # OS specific builds
 ifeq (${BACNET_PORT},linux)

--- a/apps/server/Makefile
+++ b/apps/server/Makefile
@@ -40,6 +40,12 @@ SRC = main.c \
 BACNET_BASIC_SRC += \
 	$(wildcard $(BACNET_SRC_DIR)/bacnet/basic/service/*.c)
 
+# build in uci integration - use UCI=1 when invoking make
+ifeq (${UCI},1)
+BACNET_BASIC_SRC += \
+      $(wildcard $(BACNET_SRC_DIR)/bacnet/basic/ucix/*.c)
+endif
+
 # TARGET_EXT is defined in apps/Makefile as .exe or nothing
 TARGET_BIN = ${TARGET}$(TARGET_EXT)
 


### PR DESCRIPTION
This Patches fixes compile errors with uci https://openwrt.org/docs/guide-user/base-system/uci
Short test environment in my case macOS 12.1

```
git clone git://nbd.name/luci2/libubox.git
cd libubox/; cmake -D BUILD_LUA:BOOL=OFF .;make
sudo make install
cd ..
git clone git://nbd.name/uci.git
cd uci/; cmake -D BUILD_LUA:BOOL=OFF .;make
sudo make install
cd ..
git clone https://github.com/bacnet-stack/bacnet-stack.git
cd bacnet-stack
make clean;make UCI=1 bsd
echo "config dev '0'
	option name 'openwrt-router-bip'
	option Id 4711" > /etc/config/bacnet_dev

BACNET_IFACE=en0 UCI_SECTION=0 bin/bacserv
```

THX