### PR TITLE
Fixed bsd compile error ld: unknown option: --gc-sections

### DIFF
--- a/apps/Makefile
+++ b/apps/Makefile
@@ -119,7 +119,11 @@ LFLAGS += -Wl,$(BACNET_LIB)
 endif
 # GCC dead code removal
 CFLAGS += -ffunction-sections -fdata-sections
+ifeq ($(shell uname -s),Darwin)
+LFLAGS += -Wl,-dead_strip
+else
 LFLAGS += -Wl,--gc-sections
+endif
 
 PORT_ARCNET_SRC = \
 	$(BACNET_PORT_DIR)/arcnet.c


### PR DESCRIPTION
add linker options for stripping dead code. Linux uses GNU ld, while macOS uses lld.

Signed-off-by: Patrick Grimm <patrick@lunatiki.de>