### PR TITLE
Fix valgrind warnings in trendlog functions

### DIFF
--- a/src/bacnet/basic/object/trendlog.c
+++ b/src/bacnet/basic/object/trendlog.c
@@ -147,7 +147,7 @@ void Trend_Log_Init(void)
     static bool initialized = false;
     int iLog;
     int iEntry;
-    struct tm TempTime;
+    struct tm TempTime = {0};
     time_t tClock;
 
     if (!initialized) {
@@ -924,7 +924,7 @@ bool TL_Is_Enabled(int iLog)
 
 time_t TL_BAC_Time_To_Local(BACNET_DATE_TIME *SourceTime)
 {
-    struct tm LocalTime;
+    struct tm LocalTime = {0};
     int iTemp;
 
     LocalTime.tm_year =


### PR DESCRIPTION
Valgrind reports some issues inside of Device_Init(), related to passing uninitialized `struct tm` variables into `mktime`:

mktime requires the structure passed must be fully initialised: https://en.cppreference.com/w/c/chrono/mktime#Notes

```
==16775== Conditional jump or move depends on uninitialised value(s)
==16775==    at 0x515D26B: __mktime_internal (in /usr/lib64/libc-2.17.so)
==16775==    by 0x42574F: Trend_Log_Init (trendlog.c:180)
==16775==    by 0x419793: Device_Init (device.c:1834)
==16775==    by 0x40397B: Init_Service_Handlers (main.c:1100)
==16775==    by 0x40397B: main (main.c:1222)
==16775== 
==16775== Conditional jump or move depends on uninitialised value(s)
==16775==    at 0x515D26B: __mktime_internal (in /usr/lib64/libc-2.17.so)
==16775==    by 0x426EEB: TL_BAC_Time_To_Local (trendlog.c:950)
==16775==    by 0x425B45: Trend_Log_Init (trendlog.c:221)
==16775==    by 0x419793: Device_Init (device.c:1834)
==16775==    by 0x40397B: Init_Service_Handlers (main.c:1100)
==16775==    by 0x40397B: main (main.c:1222)
==16775== 
==16775== Conditional jump or move depends on uninitialised value(s)
==16775==    at 0x515D27F: __mktime_internal (in /usr/lib64/libc-2.17.so)
==16775==    by 0x426EEB: TL_BAC_Time_To_Local (trendlog.c:950)
==16775==    by 0x425B45: Trend_Log_Init (trendlog.c:221)
==16775==    by 0x419793: Device_Init (device.c:1834)
==16775==    by 0x40397B: Init_Service_Handlers (main.c:1100)
==16775==    by 0x40397B: main (main.c:1222)
==16775== 
==16775== Conditional jump or move depends on uninitialised value(s)
==16775==    at 0x515D26B: __mktime_internal (in /usr/lib64/libc-2.17.so)
==16775==    by 0x426EEB: TL_BAC_Time_To_Local (trendlog.c:950)
==16775==    by 0x425BDC: Trend_Log_Init (trendlog.c:225)
==16775==    by 0x419793: Device_Init (device.c:1834)
==16775==    by 0x40397B: Init_Service_Handlers (main.c:1100)
==16775==    by 0x40397B: main (main.c:1222)
==16775== 
==16775== Conditional jump or move depends on uninitialised value(s)
==16775==    at 0x515D27F: __mktime_internal (in /usr/lib64/libc-2.17.so)
==16775==    by 0x426EEB: TL_BAC_Time_To_Local (trendlog.c:950)
==16775==    by 0x425BDC: Trend_Log_Init (trendlog.c:225)
==16775==    by 0x419793: Device_Init (device.c:1834)
==16775==    by 0x40397B: Init_Service_Handlers (main.c:1100)
==16775==    by 0x40397B: main (main.c:1222)
==16775== 
==16775== Conditional jump or move depends on uninitialised value(s)
==16775==    at 0x515D347: __mktime_internal (in /usr/lib64/libc-2.17.so)
==16775==    by 0x426EEB: TL_BAC_Time_To_Local (trendlog.c:950)
==16775==    by 0x425BDC: Trend_Log_Init (trendlog.c:225)
==16775==    by 0x419793: Device_Init (device.c:1834)
==16775==    by 0x40397B: Init_Service_Handlers (main.c:1100)
==16775==    by 0x40397B: main (main.c:1222)
==16775== 

```