### PR TITLE
Feature/MSTP promiscuous read

### DIFF
--- a/ports/stm32f4xx/dlmstp.c
+++ b/ports/stm32f4xx/dlmstp.c
@@ -176,10 +176,10 @@ static volatile struct dlmstp_packet PDU_Buffer[MSTP_PDU_PACKET_COUNT];
 static RING_BUFFER PDU_Queue;
 
 /* Callback function to be called every time we receive a preamble */
-static dlmstp_hook_frame_rx_start_cb PreamCallback = NULL;
+static dlmstp_hook_frame_rx_start_cb Preamble_Callback = NULL;
 
 /* Callback function to be called every time we receive a frame */
-static dlmstp_hook_frame_rx_complete_cb FrameRxCallback = NULL;
+static dlmstp_hook_frame_rx_complete_cb Frame_Rx_Callback = NULL;
 
 bool dlmstp_init(char *ifname)
 {
@@ -450,8 +450,8 @@ static void MSTP_Receive_Frame_FSM(void)
                     Receive_State = MSTP_RECEIVE_STATE_PREAMBLE;
 
                     /* if a frame-start callback was provided, call it */
-                    if (PreamCallback != NULL) {
-                      PreamCallback();
+                    if (Preamble_Callback != NULL) {
+                        Preamble_Callback();
                     }
                 }
             }
@@ -563,9 +563,12 @@ static void MSTP_Receive_Frame_FSM(void)
                                 /* NotForUs */
                                 MSTP_Flag.ReceivedValidFrameNotForUs = true;
                             }
-                            /* if a frame-receipt callback was provided, call it for this frame */
-                            if (FrameRxCallback != NULL) {
-                              FrameRxCallback(SourceAddress, DestinationAddress, FrameType, InputBuffer, DataLength);
+                            /* if a frame-receipt callback was provided, call */
+                            /* it for this frame */
+                            if (Frame_Rx_Callback != NULL) {
+                                Frame_Rx_Callback(SourceAddress,
+                                    DestinationAddress, FrameType, InputBuffer,
+                                    DataLength);
                             }
                             /* wait for the start of the next frame. */
                             Receive_State = MSTP_RECEIVE_STATE_IDLE;
@@ -645,9 +648,11 @@ static void MSTP_Receive_Frame_FSM(void)
                             /* NotForUs */
                             MSTP_Flag.ReceivedValidFrameNotForUs = true;
                         }
-                        /* if a frame-receipt callback was provided, call it for this frame */
-                        if (FrameRxCallback != NULL) {
-                          FrameRxCallback(SourceAddress, DestinationAddress, FrameType, InputBuffer, DataLength);
+                        /* if a frame-receipt callback was provided, call it */
+                        /* for this frame */
+                        if (Frame_Rx_Callback != NULL) {
+                            Frame_Rx_Callback(SourceAddress, DestinationAddress,
+                                FrameType, InputBuffer, DataLength);
                         }
 
                     } else {
@@ -1531,12 +1536,13 @@ uint8_t dlmstp_max_master_limit(void)
     return 127;
 }
 
-void dlmstp_set_frame_rx_complete_callback(dlmstp_hook_frame_rx_complete_cb cb_func)
+void dlmstp_set_frame_rx_complete_callback(
+    dlmstp_hook_frame_rx_complete_cb cb_func)
 {
-  FrameRxCallback = cb_func;
+    Frame_Rx_Callback = cb_func;
 }
 
 void dlmstp_set_frame_rx_start_callback(dlmstp_hook_frame_rx_start_cb cb_func)
 {
-  PreamCallback = cb_func;
+    Preamble_Callback = cb_func;
 }

--- a/ports/stm32f4xx/dlmstp.c
+++ b/ports/stm32f4xx/dlmstp.c
@@ -179,7 +179,7 @@ static RING_BUFFER PDU_Queue;
 static dlmstp_hook_frame_rx_start_cb PreamCallback = NULL;
 
 /* Callback function to be called every time we receive a frame */
-static dlmstp_hook_frame_rx_compl_cb FrameRxCallback = NULL;
+static dlmstp_hook_frame_rx_complete_cb FrameRxCallback = NULL;
 
 bool dlmstp_init(char *ifname)
 {
@@ -1531,7 +1531,7 @@ uint8_t dlmstp_max_master_limit(void)
     return 127;
 }
 
-void dlmstp_set_frame_rx_complete_callback(dlmstp_hook_frame_rx_compl_cb cb_func)
+void dlmstp_set_frame_rx_complete_callback(dlmstp_hook_frame_rx_complete_cb cb_func)
 {
   FrameRxCallback = cb_func;
 }

--- a/src/bacnet/datalink/dlmstp.h
+++ b/src/bacnet/datalink/dlmstp.h
@@ -44,6 +44,17 @@ typedef struct dlmstp_packet {
     uint8_t pdu[DLMSTP_MPDU_MAX];      /* packet */
 } DLMSTP_PACKET;
 
+/* callback to signify the receipt of a preamble */
+typedef void (*dlmstp_hook_frame_rx_start_cb)();
+
+/* callback on for receiving every valid frame */
+typedef void (*dlmstp_hook_frame_rx_compl_cb)(
+    uint8_t src,
+    uint8_t dest,
+    uint8_t mstp_msg_type,
+    uint8_t * pdu,
+    uint16_t pdu_len);
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
@@ -141,6 +152,23 @@ extern "C" {
     BACNET_STACK_EXPORT
     uint8_t dlmstp_max_master_limit(void);
 
+    /* Set the callback function to be called on every valid received frame */
+    /* This is not necessary for normal usage, but is helpful if the caller */
+    /* needs to monitor traffic on the MS/TP bus */
+    /* The specified callback function should execute quickly so as to avoid */
+    /* interfering with bus timing */
+    void dlmstp_set_frame_rx_complete_callback(
+        dlmstp_hook_frame_rx_compl_cb cb_func);
+
+    /* Set the callback function to be called on every time the start of a */
+    /* frame is detected.  This is not necessary for normal usage, but is */
+    /* helpful if the caller needs to know when a frame begins for timing */
+    /* (timing is heavily dependent upon baud rate and the period with */
+    /* which dlmstp_receive is called) */
+    /* The specified callback function should execute quickly so as to avoid */
+    /* interfering with bus timing */
+    void dlmstp_set_frame_rx_start_callback(
+        dlmstp_hook_frame_rx_start_cb cb_func);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/datalink/dlmstp.h
+++ b/src/bacnet/datalink/dlmstp.h
@@ -157,16 +157,18 @@ extern "C" {
     /* needs to monitor traffic on the MS/TP bus */
     /* The specified callback function should execute quickly so as to avoid */
     /* interfering with bus timing */
+    BACNET_STACK_EXPORT
     void dlmstp_set_frame_rx_complete_callback(
         dlmstp_hook_frame_rx_compl_cb cb_func);
 
-    /* Set the callback function to be called on every time the start of a */
+    /* Set the callback function to be called every time the start of a */
     /* frame is detected.  This is not necessary for normal usage, but is */
     /* helpful if the caller needs to know when a frame begins for timing */
     /* (timing is heavily dependent upon baud rate and the period with */
     /* which dlmstp_receive is called) */
     /* The specified callback function should execute quickly so as to avoid */
     /* interfering with bus timing */
+    BACNET_STACK_EXPORT
     void dlmstp_set_frame_rx_start_callback(
         dlmstp_hook_frame_rx_start_cb cb_func);
 

--- a/src/bacnet/datalink/dlmstp.h
+++ b/src/bacnet/datalink/dlmstp.h
@@ -48,7 +48,7 @@ typedef struct dlmstp_packet {
 typedef void (*dlmstp_hook_frame_rx_start_cb)();
 
 /* callback on for receiving every valid frame */
-typedef void (*dlmstp_hook_frame_rx_compl_cb)(
+typedef void (*dlmstp_hook_frame_rx_complete_cb)(
     uint8_t src,
     uint8_t dest,
     uint8_t mstp_msg_type,
@@ -159,7 +159,7 @@ extern "C" {
     /* interfering with bus timing */
     BACNET_STACK_EXPORT
     void dlmstp_set_frame_rx_complete_callback(
-        dlmstp_hook_frame_rx_compl_cb cb_func);
+        dlmstp_hook_frame_rx_complete_cb cb_func);
 
     /* Set the callback function to be called every time the start of a */
     /* frame is detected.  This is not necessary for normal usage, but is */


### PR DESCRIPTION
This adds two callback functions to dlmstp (implemented on the stm32f4xx port at this time) so that the caller may observe incoming frames on the MSTP bus, regardless of whether they are addressed to the local MSTP address.

The callback functions, if provided, are called from `MSTP_Receive_Frame_FSM()` instead of `dlmstp_receive()` in order to:

- catch the preamble for noting the start of a frame
- call the frame completion callback as soon as the frame is complete
- not care whether the frame is for us or "NotForUs"

Sample Usage:
```
uint32_t frame_start_time = 0;

void mstp_rx_frame_start() {
    frame_start_time = get_ticks();
}

void mstp_rx_promiscuous_callback(uint8_t src, uint8_t dest, uint8_t mstp_msg_type, uint8_t * pdu, uint16_t pdu_len) {
    if (FRAME_TYPE_TOKEN == mstp_msg_type) {
        printf("%u handed token to %u. token frame took %u ms\r\n", src, dest, get_ticks() - frame_start_time);
    }
}

void app_main(void) {
    /* Other initialization, declarations, etc. here */

    dlmstp_init(NULL);
    dlmstp_set_frame_rx_start_callback(mstp_rx_frame_start);
    dlmstp_set_frame_rx_complete_callback(mstp_rx_promiscuous_callback);

    while (true) {
        pdu_len = dlmstp_receive(&src_addr, mstp_rx_buffer, DLMSTP_MPDU_MAX, 0);
    }
}
```

Additionally: when testing these changes, it was noted that when the `MSTP_Flag.ReceivedValidFrame` flag is set, `ReceiveFrameCount` could be incremented multiple times for the same frame.   This happens because `dlmstp_receive()` may be called several times between the frame arriving and `rs485_turnaround_elapsed()` returning true.
To fix this, `ReceiveFrameCount++` for "our" frames was moved to after the `rs485_turnaround_elapsed()` test.