### PR TITLE
Avoid redefining MSTP timeouts

### DIFF
--- a/ports/at91sam7s/dlmstp.c
+++ b/ports/at91sam7s/dlmstp.c
@@ -119,12 +119,6 @@ static uint8_t Nmax_info_frames = 1;
 /* its value shall be 127. */
 static uint8_t Nmax_master = 127;
 
-/* The time without a DataAvailable or ReceiveError event before declaration */
-/* of loss of token: 500 milliseconds. */
-#ifndef Tno_token
-#define Tno_token 500
-#endif
-
 /* The minimum time without a DataAvailable or ReceiveError event */
 /* that a node must wait for a station to begin replying to a */
 /* confirmed request: 255 milliseconds. (Implementations may use */
@@ -160,31 +154,11 @@ static uint8_t Nmax_master = 127;
 /* const uint16_t Tframe_abort = 1 + ((1000 * 60) / 9600); */
 #define Tframe_abort 30
 
-/* The maximum idle time a sending node may allow to elapse between octets */
-/* of a frame the node is transmitting: 20 bit times. */
-#define Tframe_gap 20
-
-/* The maximum time after the end of the stop bit of the final */
-/* octet of a transmitted frame before a node must disable its */
-/* EIA-485 driver: 15 bit times. */
-#define Tpostdrive 15
-
 /* The maximum time a node may wait after reception of a frame that expects */
 /* a reply before sending the first octet of a reply or Reply Postponed */
 /* frame: 250 milliseconds. */
 #ifndef Treply_delay
 #define Treply_delay 250
-#endif
-
-/* The width of the time slot within which a node may generate a token: */
-/* 10 milliseconds. */
-#define Tslot 10
-
-/* The maximum time a node may wait after reception of the token or */
-/* a Poll For Master frame before sending the first octet of a frame: */
-/* 15 milliseconds. */
-#ifndef Tusage_delay
-#define Tusage_delay 15
 #endif
 
 /* we need to be able to increment without rolling over */

--- a/ports/at91sam7s/dlmstp.c
+++ b/ports/at91sam7s/dlmstp.c
@@ -121,19 +121,25 @@ static uint8_t Nmax_master = 127;
 
 /* The time without a DataAvailable or ReceiveError event before declaration */
 /* of loss of token: 500 milliseconds. */
+#ifndef Tno_token
 #define Tno_token 500
+#endif
 
 /* The minimum time without a DataAvailable or ReceiveError event */
 /* that a node must wait for a station to begin replying to a */
 /* confirmed request: 255 milliseconds. (Implementations may use */
 /* larger values for this timeout, not to exceed 300 milliseconds.) */
+#ifndef Treply_timeout
 #define Treply_timeout 260
+#endif
 
 /* The time without a DataAvailable or ReceiveError event that a node must */
 /* wait for a remote node to begin using a token or replying to a Poll For */
 /* Master frame: 20 milliseconds. (Implementations may use larger values for */
 /* this timeout, not to exceed 35 milliseconds.) */
+#ifndef Tusage_timeout
 #define Tusage_timeout 30
+#endif
 
 /* The number of tokens received or used before a Poll For Master cycle */
 /* is executed: 50. */
@@ -166,7 +172,9 @@ static uint8_t Nmax_master = 127;
 /* The maximum time a node may wait after reception of a frame that expects */
 /* a reply before sending the first octet of a reply or Reply Postponed */
 /* frame: 250 milliseconds. */
+#ifndef Treply_delay
 #define Treply_delay 250
+#endif
 
 /* The width of the time slot within which a node may generate a token: */
 /* 10 milliseconds. */
@@ -175,7 +183,9 @@ static uint8_t Nmax_master = 127;
 /* The maximum time a node may wait after reception of the token or */
 /* a Poll For Master frame before sending the first octet of a frame: */
 /* 15 milliseconds. */
+#ifndef Tusage_delay
 #define Tusage_delay 15
+#endif
 
 /* we need to be able to increment without rolling over */
 #define INCREMENT_AND_LIMIT_UINT8(x) \

--- a/ports/atmega168/dlmstp.c
+++ b/ports/atmega168/dlmstp.c
@@ -139,13 +139,17 @@ static uint8_t TransmitPacketDest;
 /* that a node must wait for a station to begin replying to a */
 /* confirmed request: 255 milliseconds. (Implementations may use */
 /* larger values for this timeout, not to exceed 300 milliseconds.) */
+#ifndef Treply_timeout
 #define Treply_timeout 295
+#endif
 
 /* The time without a DataAvailable or ReceiveError event that a node must */
 /* wait for a remote node to begin using a token or replying to a Poll For */
 /* Master frame: 20 milliseconds. (Implementations may use larger values for */
 /* this timeout, not to exceed 35 milliseconds.) */
+#ifndef Tusage_timeout
 #define Tusage_timeout 30
+#endif
 
 /* The minimum number of DataAvailable or ReceiveError events that must be */
 /* seen by a receiving node in order to declare the line "active": 4. */
@@ -157,12 +161,16 @@ static uint8_t TransmitPacketDest;
 /* not to exceed 100 milliseconds.) */
 /* At 9600 baud, 60 bit times would be about 6.25 milliseconds */
 /* const uint16_t Tframe_abort = 1 + ((1000 * 60) / 9600); */
+#ifndef Tframe_abort
 #define Tframe_abort 30
+#endif
 
 /* The maximum time a node may wait after reception of a frame that expects */
 /* a reply before sending the first octet of a reply or Reply Postponed */
 /* frame: 250 milliseconds. */
+#ifndef Treply_delay
 #define Treply_delay 250
+#endif
 
 /* we need to be able to increment without rolling over */
 #define INCREMENT_AND_LIMIT_UINT8(x) \

--- a/ports/bdk-atxx4-mstp/dlmstp.c
+++ b/ports/bdk-atxx4-mstp/dlmstp.c
@@ -125,19 +125,25 @@ static uint8_t Nmax_master = 127;
 
 /* The time without a DataAvailable or ReceiveError event before declaration */
 /* of loss of token: 500 milliseconds. */
+#ifndef Tno_token
 #define Tno_token 500
+#endif
 
 /* The minimum time without a DataAvailable or ReceiveError event */
 /* that a node must wait for a station to begin replying to a */
 /* confirmed request: 255 milliseconds. (Implementations may use */
 /* larger values for this timeout, not to exceed 300 milliseconds.) */
+#ifndef Treply_timeout
 #define Treply_timeout 260
+#endif
 
 /* The time without a DataAvailable or ReceiveError event that a node must */
 /* wait for a remote node to begin using a token or replying to a Poll For */
 /* Master frame: 20 milliseconds. (Implementations may use larger values for */
 /* this timeout, not to exceed 35 milliseconds.) */
+#ifndef Tusage_timeout
 #define Tusage_timeout 30
+#endif
 
 /* The number of tokens received or used before a Poll For Master cycle */
 /* is executed: 50. */
@@ -156,30 +162,42 @@ static uint8_t Nmax_master = 127;
 /* not to exceed 100 milliseconds.) */
 /* At 9600 baud, 60 bit times would be about 6.25 milliseconds */
 /* const uint16_t Tframe_abort = 1 + ((1000 * 60) / 9600); */
+#ifndef Tframe_abort
 #define Tframe_abort 30
+#endif
 
 /* The maximum idle time a sending node may allow to elapse between octets */
 /* of a frame the node is transmitting: 20 bit times. */
+#ifndef Tframe_gap
 #define Tframe_gap 20
+#endif
 
 /* The maximum time after the end of the stop bit of the final */
 /* octet of a transmitted frame before a node must disable its */
 /* EIA-485 driver: 15 bit times. */
+#ifndef Tpostdrive
 #define Tpostdrive 15
+#endif
 
 /* The maximum time a node may wait after reception of a frame that expects */
 /* a reply before sending the first octet of a reply or Reply Postponed */
 /* frame: 250 milliseconds. */
+#ifndef Treply_delay
 #define Treply_delay 250
+#endif
 
 /* The width of the time slot within which a node may generate a token: */
 /* 10 milliseconds. */
+#ifndef Tslot
 #define Tslot 10
+#endif
 
 /* The maximum time a node may wait after reception of the token or */
 /* a Poll For Master frame before sending the first octet of a frame: */
 /* 15 milliseconds. */
+#ifndef Tusage_delay
 #define Tusage_delay 15
+#endif
 
 /* we need to be able to increment without rolling over */
 #define INCREMENT_AND_LIMIT_UINT8(x) \

--- a/ports/bdk-atxx4-mstp/dlmstp.c
+++ b/ports/bdk-atxx4-mstp/dlmstp.c
@@ -123,12 +123,6 @@ static uint8_t Nmax_info_frames = MSTP_PDU_PACKET_COUNT;
 /* its value shall be 127. */
 static uint8_t Nmax_master = 127;
 
-/* The time without a DataAvailable or ReceiveError event before declaration */
-/* of loss of token: 500 milliseconds. */
-#ifndef Tno_token
-#define Tno_token 500
-#endif
-
 /* The minimum time without a DataAvailable or ReceiveError event */
 /* that a node must wait for a station to begin replying to a */
 /* confirmed request: 255 milliseconds. (Implementations may use */
@@ -166,37 +160,11 @@ static uint8_t Nmax_master = 127;
 #define Tframe_abort 30
 #endif
 
-/* The maximum idle time a sending node may allow to elapse between octets */
-/* of a frame the node is transmitting: 20 bit times. */
-#ifndef Tframe_gap
-#define Tframe_gap 20
-#endif
-
-/* The maximum time after the end of the stop bit of the final */
-/* octet of a transmitted frame before a node must disable its */
-/* EIA-485 driver: 15 bit times. */
-#ifndef Tpostdrive
-#define Tpostdrive 15
-#endif
-
 /* The maximum time a node may wait after reception of a frame that expects */
 /* a reply before sending the first octet of a reply or Reply Postponed */
 /* frame: 250 milliseconds. */
 #ifndef Treply_delay
 #define Treply_delay 250
-#endif
-
-/* The width of the time slot within which a node may generate a token: */
-/* 10 milliseconds. */
-#ifndef Tslot
-#define Tslot 10
-#endif
-
-/* The maximum time a node may wait after reception of the token or */
-/* a Poll For Master frame before sending the first octet of a frame: */
-/* 15 milliseconds. */
-#ifndef Tusage_delay
-#define Tusage_delay 15
 #endif
 
 /* we need to be able to increment without rolling over */

--- a/ports/pic18f6720/mstp.c
+++ b/ports/pic18f6720/mstp.c
@@ -101,53 +101,73 @@
 /* not to exceed 100 milliseconds.) */
 /* At 9600 baud, 60 bit times would be about 6.25 milliseconds */
 /* const uint16_t Tframe_abort = 1 + ((1000 * 60) / 9600); */
+#ifndef Tframe_abort
 #define Tframe_abort 30
+#endif
 
 /* The maximum idle time a sending node may allow to elapse between octets */
 /* of a frame the node is transmitting: 20 bit times. */
+#ifndef Tframe_gap
 #define Tframe_gap 20
+#endif
 
 /* The time without a DataAvailable or ReceiveError event before declaration */
 /* of loss of token: 500 milliseconds. */
+#ifndef Tno_token
 #define Tno_token 500
+#endif
 
 /* The maximum time after the end of the stop bit of the final */
 /* octet of a transmitted frame before a node must disable its */
 /* EIA-485 driver: 15 bit times. */
+#ifndef Tpostdrive
 #define Tpostdrive 15
+#endif
 
 /* The maximum time a node may wait after reception of a frame that expects */
 /* a reply before sending the first octet of a reply or Reply Postponed */
 /* frame: 250 milliseconds. */
 /* note: we always send a reply postponed since a message other than
    the reply may be in the transmit queue */
+#ifndef Treply_delay
 #define Treply_delay 10
+#endif
 
 /* The minimum time without a DataAvailable or ReceiveError event */
 /* that a node must wait for a station to begin replying to a */
 /* confirmed request: 255 milliseconds. (Implementations may use */
 /* larger values for this timeout, not to exceed 300 milliseconds.) */
+#ifndef Treply_timeout
 #define Treply_timeout 255
+#endif
 
 /* Repeater turnoff delay. The duration of a continuous logical one state */
 /* at the active input port of an MS/TP repeater after which the repeater */
 /* will enter the IDLE state: 29 bit times < Troff < 40 bit times. */
+#ifndef Troff
 #define Troff 30
+#endif
 
 /* The width of the time slot within which a node may generate a token: */
 /* 10 milliseconds. */
+#ifndef Tslot
 #define Tslot 10
+#endif
 
 /* The maximum time a node may wait after reception of the token or */
 /* a Poll For Master frame before sending the first octet of a frame: */
 /* 15 milliseconds. */
+#ifndef Tusage_delay
 #define Tusage_delay 15
+#endif
 
 /* The minimum time without a DataAvailable or ReceiveError event that a */
 /* node must wait for a remote node to begin using a token or replying to */
 /* a Poll For Master frame: 20 milliseconds. (Implementations may use */
 /* larger values for this timeout, not to exceed 100 milliseconds.) */
+#ifndef Tusage_timeout
 #define Tusage_timeout 20
+#endif
 
 /* we need to be able to increment without rolling over */
 #define INCREMENT_AND_LIMIT_UINT8(x) \

--- a/ports/pic18f6720/mstp.c
+++ b/ports/pic18f6720/mstp.c
@@ -105,25 +105,6 @@
 #define Tframe_abort 30
 #endif
 
-/* The maximum idle time a sending node may allow to elapse between octets */
-/* of a frame the node is transmitting: 20 bit times. */
-#ifndef Tframe_gap
-#define Tframe_gap 20
-#endif
-
-/* The time without a DataAvailable or ReceiveError event before declaration */
-/* of loss of token: 500 milliseconds. */
-#ifndef Tno_token
-#define Tno_token 500
-#endif
-
-/* The maximum time after the end of the stop bit of the final */
-/* octet of a transmitted frame before a node must disable its */
-/* EIA-485 driver: 15 bit times. */
-#ifndef Tpostdrive
-#define Tpostdrive 15
-#endif
-
 /* The maximum time a node may wait after reception of a frame that expects */
 /* a reply before sending the first octet of a reply or Reply Postponed */
 /* frame: 250 milliseconds. */
@@ -146,19 +127,6 @@
 /* will enter the IDLE state: 29 bit times < Troff < 40 bit times. */
 #ifndef Troff
 #define Troff 30
-#endif
-
-/* The width of the time slot within which a node may generate a token: */
-/* 10 milliseconds. */
-#ifndef Tslot
-#define Tslot 10
-#endif
-
-/* The maximum time a node may wait after reception of the token or */
-/* a Poll For Master frame before sending the first octet of a frame: */
-/* 15 milliseconds. */
-#ifndef Tusage_delay
-#define Tusage_delay 15
 #endif
 
 /* The minimum time without a DataAvailable or ReceiveError event that a */

--- a/ports/pic18f97j60/mstp.c
+++ b/ports/pic18f97j60/mstp.c
@@ -101,53 +101,73 @@
 /* not to exceed 100 milliseconds.) */
 /* At 9600 baud, 60 bit times would be about 6.25 milliseconds */
 /* const uint16_t Tframe_abort = 1 + ((1000 * 60) / 9600); */
+#ifndef Tframe_abort
 #define Tframe_abort 30
+#endif
 
 /* The maximum idle time a sending node may allow to elapse between octets */
 /* of a frame the node is transmitting: 20 bit times. */
+#ifndef Tframe_gap
 #define Tframe_gap 20
+#endif
 
 /* The time without a DataAvailable or ReceiveError event before declaration */
 /* of loss of token: 500 milliseconds. */
+#ifndef Tno_token
 #define Tno_token 500
+#endif
 
 /* The maximum time after the end of the stop bit of the final */
 /* octet of a transmitted frame before a node must disable its */
 /* EIA-485 driver: 15 bit times. */
+#ifndef Tpostdrive
 #define Tpostdrive 15
+#endif
 
 /* The maximum time a node may wait after reception of a frame that expects */
 /* a reply before sending the first octet of a reply or Reply Postponed */
 /* frame: 250 milliseconds. */
 /* note: we always send a reply postponed since a message other than
    the reply may be in the transmit queue */
+#ifndef Treply_delay
 #define Treply_delay 10
+#endif
 
 /* The minimum time without a DataAvailable or ReceiveError event */
 /* that a node must wait for a station to begin replying to a */
 /* confirmed request: 255 milliseconds. (Implementations may use */
 /* larger values for this timeout, not to exceed 300 milliseconds.) */
+#ifndef Treply_timeout
 #define Treply_timeout 255
+#endif
 
 /* Repeater turnoff delay. The duration of a continuous logical one state */
 /* at the active input port of an MS/TP repeater after which the repeater */
 /* will enter the IDLE state: 29 bit times < Troff < 40 bit times. */
+#ifndef Troff
 #define Troff 30
+#endif
 
 /* The width of the time slot within which a node may generate a token: */
 /* 10 milliseconds. */
+#ifndef Tslot
 #define Tslot 10
+#endif
 
 /* The maximum time a node may wait after reception of the token or */
 /* a Poll For Master frame before sending the first octet of a frame: */
 /* 15 milliseconds. */
+#ifndef Tusage_delay
 #define Tusage_delay 15
+#endif
 
 /* The minimum time without a DataAvailable or ReceiveError event that a */
 /* node must wait for a remote node to begin using a token or replying to */
 /* a Poll For Master frame: 20 milliseconds. (Implementations may use */
 /* larger values for this timeout, not to exceed 100 milliseconds.) */
+#ifndef Tusage_timeout
 #define Tusage_timeout 20
+#endif
 
 /* we need to be able to increment without rolling over */
 #define INCREMENT_AND_LIMIT_UINT8(x) \

--- a/ports/pic18f97j60/mstp.c
+++ b/ports/pic18f97j60/mstp.c
@@ -105,25 +105,6 @@
 #define Tframe_abort 30
 #endif
 
-/* The maximum idle time a sending node may allow to elapse between octets */
-/* of a frame the node is transmitting: 20 bit times. */
-#ifndef Tframe_gap
-#define Tframe_gap 20
-#endif
-
-/* The time without a DataAvailable or ReceiveError event before declaration */
-/* of loss of token: 500 milliseconds. */
-#ifndef Tno_token
-#define Tno_token 500
-#endif
-
-/* The maximum time after the end of the stop bit of the final */
-/* octet of a transmitted frame before a node must disable its */
-/* EIA-485 driver: 15 bit times. */
-#ifndef Tpostdrive
-#define Tpostdrive 15
-#endif
-
 /* The maximum time a node may wait after reception of a frame that expects */
 /* a reply before sending the first octet of a reply or Reply Postponed */
 /* frame: 250 milliseconds. */
@@ -146,19 +127,6 @@
 /* will enter the IDLE state: 29 bit times < Troff < 40 bit times. */
 #ifndef Troff
 #define Troff 30
-#endif
-
-/* The width of the time slot within which a node may generate a token: */
-/* 10 milliseconds. */
-#ifndef Tslot
-#define Tslot 10
-#endif
-
-/* The maximum time a node may wait after reception of the token or */
-/* a Poll For Master frame before sending the first octet of a frame: */
-/* 15 milliseconds. */
-#ifndef Tusage_delay
-#define Tusage_delay 15
 #endif
 
 /* The minimum time without a DataAvailable or ReceiveError event that a */

--- a/ports/stm32f10x/dlmstp.c
+++ b/ports/stm32f10x/dlmstp.c
@@ -112,19 +112,25 @@ static uint8_t Nmax_master = 127;
 
 /* The time without a DataAvailable or ReceiveError event before declaration */
 /* of loss of token: 500 milliseconds. */
+#ifndef Tno_token
 #define Tno_token 500
+#endif
 
 /* The minimum time without a DataAvailable or ReceiveError event */
 /* that a node must wait for a station to begin replying to a */
 /* confirmed request: 255 milliseconds. (Implementations may use */
 /* larger values for this timeout, not to exceed 300 milliseconds.) */
+#ifndef Treply_timeout
 #define Treply_timeout 260
+#endif
 
 /* The time without a DataAvailable or ReceiveError event that a node must */
 /* wait for a remote node to begin using a token or replying to a Poll For */
 /* Master frame: 20 milliseconds. (Implementations may use larger values for */
 /* this timeout, not to exceed 35 milliseconds.) */
+#ifndef Tusage_timeout
 #define Tusage_timeout 30
+#endif
 
 /* The minimum number of DataAvailable or ReceiveError events that must be */
 /* seen by a receiving node in order to declare the line "active": 4. */
@@ -138,21 +144,29 @@ static uint8_t Nmax_master = 127;
 /* const uint16_t Tframe_abort = 1 + ((1000 * 60) / 9600); */
 /* At 115200 baud, 60 bit times would be about 0.5 milliseconds */
 /* const uint16_t Tframe_abort = 1 + ((1000 * 60) / 115200); */
+#ifndef Tframe_abort
 #define Tframe_abort 30
+#endif
 
 /* The maximum time a node may wait after reception of a frame that expects */
 /* a reply before sending the first octet of a reply or Reply Postponed */
 /* frame: 250 milliseconds. */
+#ifndef Treply_delay
 #define Treply_delay (250 - 50)
+#endif
 
 /* The width of the time slot within which a node may generate a token: */
 /* 10 milliseconds. */
+#ifndef Tslot
 #define Tslot 10
+#endif
 
 /* The maximum time a node may wait after reception of the token or */
 /* a Poll For Master frame before sending the first octet of a frame: */
 /* 15 milliseconds. */
+#ifndef Tusage_delay
 #define Tusage_delay 15
+#endif
 
 /* we need to be able to increment without rolling over */
 #define INCREMENT_AND_LIMIT_UINT8(x) \

--- a/ports/stm32f10x/dlmstp.c
+++ b/ports/stm32f10x/dlmstp.c
@@ -110,12 +110,6 @@ static uint8_t This_Station = 255;
 /* its value shall be 127. */
 static uint8_t Nmax_master = 127;
 
-/* The time without a DataAvailable or ReceiveError event before declaration */
-/* of loss of token: 500 milliseconds. */
-#ifndef Tno_token
-#define Tno_token 500
-#endif
-
 /* The minimum time without a DataAvailable or ReceiveError event */
 /* that a node must wait for a station to begin replying to a */
 /* confirmed request: 255 milliseconds. (Implementations may use */
@@ -153,19 +147,6 @@ static uint8_t Nmax_master = 127;
 /* frame: 250 milliseconds. */
 #ifndef Treply_delay
 #define Treply_delay (250 - 50)
-#endif
-
-/* The width of the time slot within which a node may generate a token: */
-/* 10 milliseconds. */
-#ifndef Tslot
-#define Tslot 10
-#endif
-
-/* The maximum time a node may wait after reception of the token or */
-/* a Poll For Master frame before sending the first octet of a frame: */
-/* 15 milliseconds. */
-#ifndef Tusage_delay
-#define Tusage_delay 15
 #endif
 
 /* we need to be able to increment without rolling over */

--- a/ports/stm32f4xx/dlmstp.c
+++ b/ports/stm32f4xx/dlmstp.c
@@ -127,13 +127,17 @@ static volatile uint8_t Nmax_master = 127;
 /* that a node must wait for a station to begin replying to a */
 /* confirmed request: 255 milliseconds. (Implementations may use */
 /* larger values for this timeout, not to exceed 300 milliseconds.) */
+#ifndef Treply_timeout
 #define Treply_timeout 260
+#endif
 
 /* The time without a DataAvailable or ReceiveError event that a node must */
 /* wait for a remote node to begin using a token or replying to a Poll For */
 /* Master frame: 20 milliseconds. (Implementations may use larger values for */
 /* this timeout, not to exceed 35 milliseconds.) */
+#ifndef Tusage_timeout
 #define Tusage_timeout 30
+#endif
 
 /* The minimum number of DataAvailable or ReceiveError events that must be */
 /* seen by a receiving node in order to declare the line "active": 4. */
@@ -145,12 +149,16 @@ static volatile uint8_t Nmax_master = 127;
 /* not to exceed 100 milliseconds.) */
 /* At 9600 baud, 60 bit times would be about 6.25 milliseconds */
 /* const uint16_t Tframe_abort = 1 + ((1000 * 60) / 9600); */
+#ifndef Tframe_abort
 #define Tframe_abort 30
+#endif
 
 /* The maximum time a node may wait after reception of a frame that expects */
 /* a reply before sending the first octet of a reply or Reply Postponed */
 /* frame: 250 milliseconds. */
+#ifndef Treply_delay
 #define Treply_delay (250 - 50)
+#endif
 
 /* An array of octets, used to store octets for transmitting */
 /* OutputBuffer is indexed from 0 to OutputBufferSize-1. */

--- a/ports/xplained/dlmstp.c
+++ b/ports/xplained/dlmstp.c
@@ -123,12 +123,6 @@ static volatile uint8_t Nmax_info_frames = MSTP_PDU_PACKET_COUNT;
 /* its value shall be 127. */
 static volatile uint8_t Nmax_master = 127;
 
-/* The time without a DataAvailable or ReceiveError event before declaration */
-/* of loss of token: 500 milliseconds. */
-#ifndef Tno_token
-#define Tno_token 500
-#endif
-
 /* The minimum time without a DataAvailable or ReceiveError event */
 /* that a node must wait for a station to begin replying to a */
 /* confirmed request: 255 milliseconds. (Implementations may use */
@@ -164,19 +158,6 @@ static volatile uint8_t Nmax_master = 127;
 /* frame: 250 milliseconds. */
 #ifndef Treply_delay
 #define Treply_delay (250 - 50)
-#endif
-
-/* The width of the time slot within which a node may generate a token: */
-/* 10 milliseconds. */
-#ifndef Tslot
-#define Tslot 10
-#endif
-
-/* The maximum time a node may wait after reception of the token or */
-/* a Poll For Master frame before sending the first octet of a frame: */
-/* 15 milliseconds. */
-#ifndef Tusage_delay
-#define Tusage_delay 15
 #endif
 
 /* we need to be able to increment without rolling over */

--- a/ports/xplained/dlmstp.c
+++ b/ports/xplained/dlmstp.c
@@ -125,19 +125,25 @@ static volatile uint8_t Nmax_master = 127;
 
 /* The time without a DataAvailable or ReceiveError event before declaration */
 /* of loss of token: 500 milliseconds. */
+#ifndef Tno_token
 #define Tno_token 500
+#endif
 
 /* The minimum time without a DataAvailable or ReceiveError event */
 /* that a node must wait for a station to begin replying to a */
 /* confirmed request: 255 milliseconds. (Implementations may use */
 /* larger values for this timeout, not to exceed 300 milliseconds.) */
+#ifndef Treply_timeout
 #define Treply_timeout 260
+#endif
 
 /* The time without a DataAvailable or ReceiveError event that a node must */
 /* wait for a remote node to begin using a token or replying to a Poll For */
 /* Master frame: 20 milliseconds. (Implementations may use larger values for */
 /* this timeout, not to exceed 35 milliseconds.) */
+#ifndef Tusage_timeout
 #define Tusage_timeout 30
+#endif
 
 /* The minimum number of DataAvailable or ReceiveError events that must be */
 /* seen by a receiving node in order to declare the line "active": 4. */
@@ -149,21 +155,29 @@ static volatile uint8_t Nmax_master = 127;
 /* not to exceed 100 milliseconds.) */
 /* At 9600 baud, 60 bit times would be about 6.25 milliseconds */
 /* const uint16_t Tframe_abort = 1 + ((1000 * 60) / 9600); */
+#ifndef Tframe_abort
 #define Tframe_abort 30
+#endif
 
 /* The maximum time a node may wait after reception of a frame that expects */
 /* a reply before sending the first octet of a reply or Reply Postponed */
 /* frame: 250 milliseconds. */
+#ifndef Treply_delay
 #define Treply_delay (250 - 50)
+#endif
 
 /* The width of the time slot within which a node may generate a token: */
 /* 10 milliseconds. */
+#ifndef Tslot
 #define Tslot 10
+#endif
 
 /* The maximum time a node may wait after reception of the token or */
 /* a Poll For Master frame before sending the first octet of a frame: */
 /* 15 milliseconds. */
+#ifndef Tusage_delay
 #define Tusage_delay 15
+#endif
 
 /* we need to be able to increment without rolling over */
 #define INCREMENT_AND_LIMIT_UINT8(x) \

--- a/src/bacnet/datalink/mstp.c
+++ b/src/bacnet/datalink/mstp.c
@@ -134,12 +134,16 @@ static inline void printf_master(const char *format, ...)
 /* The maximum time a node may wait after reception of a frame that expects */
 /* a reply before sending the first octet of a reply or Reply Postponed */
 /* frame: 250 milliseconds. */
+#ifndef Treply_delay
 #define Treply_delay 250
+#endif
 
 /* Repeater turnoff delay. The duration of a continuous logical one state */
 /* at the active input port of an MS/TP repeater after which the repeater */
 /* will enter the IDLE state: 29 bit times < Troff < 40 bit times. */
+#ifndef Troff
 #define Troff 30
+#endif
 
 /* The minimum time without a DataAvailable or ReceiveError event */
 /* that a node must wait for a station to begin replying to a */


### PR DESCRIPTION
There was a precedent in src/bacnet/datalink/mstp.c to check whether timeouts were already defined before defining them.
Example:
```
#ifndef Treply_timeout
#define Treply_timeout 295
#endif
```

This change extends those `#ifndef` checks to the various ports so that timeouts may be overridden by defining them in bacnet-config.h (assuming `BACNET_CONFIG_H` is defined to cause bacnet-config.h to be included)