### PR TITLE
Various minor fixes/improvements

### DIFF
--- a/apps/epics/main.c
+++ b/apps/epics/main.c
@@ -299,7 +299,8 @@ static void MyReadPropertyMultipleAckHandler(uint8_t *service_request,
         } else {
             if (len < 0) { /* Eg, failed due to no segmentation */
                 Error_Detected = true;
-}
+            }
+            rpm_data_free(rpm_data);
             free(rpm_data);
         }
     }

--- a/apps/readpropm/main.c
+++ b/apps/readpropm/main.c
@@ -142,21 +142,8 @@ static void My_Read_Property_Multiple_Ack_Handler(uint8_t *service_request,
         if (len > 0) {
             while (rpm_data) {
                 rpm_ack_print_data(rpm_data);
-                rpm_property = rpm_data->listOfProperties;
-                while (rpm_property) {
-                    value = rpm_property->value;
-                    while (value) {
-                        old_value = value;
-                        value = value->next;
-                        free(old_value);
-                    }
-                    old_rpm_property = rpm_property;
-                    rpm_property = rpm_property->next;
-                    free(old_rpm_property);
-                }
-                old_rpm_data = rpm_data;
-                rpm_data = rpm_data->next;
-                free(old_rpm_data);
+                rpm_data = rpm_data_free(rpm_data);
+                
             }
         } else {
             fprintf(stderr, "RPM Ack Malformed! Freeing memory...\n");

--- a/src/bacnet/basic/binding/address.c
+++ b/src/bacnet/basic/binding/address.c
@@ -521,7 +521,9 @@ bool address_get_by_device(
             if ((pMatch->Flags & BAC_ADDR_BIND_REQ) == 0) {
                 /* If bound then fetch data */
                 bacnet_address_copy(src, &pMatch->address);
-                *max_apdu = pMatch->max_apdu;
+                if (max_apdu) {
+                    *max_apdu = pMatch->max_apdu;
+                }
                 /* Prove we found it */
                 found = true;
             }

--- a/src/bacnet/basic/service/h_rpm_a.c
+++ b/src/bacnet/basic/service/h_rpm_a.c
@@ -293,7 +293,7 @@ void rpm_ack_print_data(BACNET_READ_ACCESS_DATA *rpm_data)
  * @param rpm_data - #BACNET_READ_ACCESS_DATA
  * @return RPM data from the next element in the linked list
  */
-static BACNET_READ_ACCESS_DATA *rpm_data_free(BACNET_READ_ACCESS_DATA *rpm_data)
+BACNET_READ_ACCESS_DATA *rpm_data_free(BACNET_READ_ACCESS_DATA *rpm_data)
 {
     BACNET_READ_ACCESS_DATA *old_rpm_data = NULL;
     BACNET_PROPERTY_REFERENCE *rpm_property = NULL;

--- a/src/bacnet/basic/service/h_rpm_a.h
+++ b/src/bacnet/basic/service/h_rpm_a.h
@@ -56,6 +56,9 @@ extern "C" {
     BACNET_STACK_EXPORT
     void rpm_ack_print_data(
         BACNET_READ_ACCESS_DATA * rpm_data);
+    BACNET_STACK_EXPORT
+    BACNET_READ_ACCESS_DATA *rpm_data_free(
+        BACNET_READ_ACCESS_DATA *rpm_data);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/s_cov.h
+++ b/src/bacnet/basic/service/s_cov.h
@@ -39,6 +39,7 @@
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/cov.h"
+#include "bacnet/npdu.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bacnet/cov.c
+++ b/src/bacnet/cov.c
@@ -768,7 +768,7 @@ void cov_data_value_list_link(
  * @param value_list - #BACNET_PROPERTY_VALUE with at least 2 entries
  * @param value - REAL present-value
  * @param in_alarm - value of in-alarm status-flags
- * @param fault - value of in-alarm status-flags
+ * @param fault - value of fault status-flags
  * @param overridden - value of overridden status-flags
  * @param out_of_service - value of out-of-service status-flags
  *


### PR DESCRIPTION
A collection of odds and ends changed/fixed while developing my application. This includes:
- Making "rpm_data_free" a public method and using it where appropriate
  - Includes fixing memory leak in epics demo application
    (note Valgrind indicates that there are more...)
- Fix typo in cov.c
- Allow NULL max_apdu parameter to address_get_by_device
- Add missing include to s_cov.h