### PR TITLE
basic/object/iv: Name it "INTEGER VALUE", not "ANALOG VALUE"

### DIFF
--- a/src/bacnet/basic/object/iv.c
+++ b/src/bacnet/basic/object/iv.c
@@ -228,7 +228,7 @@ bool Integer_Value_Object_Name(
     index = Integer_Value_Instance_To_Index(object_instance);
     if (index < MAX_INTEGER_VALUES) {
         sprintf(
-            text_string, "ANALOG VALUE %lu", (unsigned long)object_instance);
+            text_string, "INTEGER VALUE %lu", (unsigned long)object_instance);
         status = characterstring_init_ansi(object_name, text_string);
     }
 


### PR DESCRIPTION
Running the sample BACnet demo server, we noticed that the names of
integer-value types were all "ANALOG VALUE <n>" for some number n which
creates multiple objects with the same object-name.

Signed-off-by: Thomas Jespersen <tj@omnio.net>

---
Thanks for a great library btw, with well-working demos to build off of!