### PR TITLE
Oscbs 23 scalable ba cnet object arrays - variant 2

### DIFF
--- a/ports/bsd/bacport.h
+++ b/ports/bsd/bacport.h
@@ -95,5 +95,11 @@
 extern int bip_get_local_netmask(
     struct in_addr *netmask);
 
+#define BACNET_OBJECT_TABLE(table_name, _type, _init, _count,               \
+                            _index_to_instance, _valid_instance, _object_name, \
+                            _read_property, _write_property, _RPM_list,     \
+                            _RR_info, _iterator, _value_list, _COV,         \
+                            _COV_clear, _intrinsic_reporting)               \
+    /*TODO Add compile error "Unsupported BACNET_OBJECT_TABLE for this platform."  */
 
 #endif

--- a/ports/bsd/bacport.h
+++ b/ports/bsd/bacport.h
@@ -100,6 +100,6 @@ extern int bip_get_local_netmask(
                             _read_property, _write_property, _RPM_list,     \
                             _RR_info, _iterator, _value_list, _COV,         \
                             _COV_clear, _intrinsic_reporting)               \
-    /*TODO Add compile error "Unsupported BACNET_OBJECT_TABLE for this platform."  */
+    static_assert(false, "Unsupported BACNET_OBJECT_TABLE for this platform")
 
 #endif

--- a/ports/linux/bacport.h
+++ b/ports/linux/bacport.h
@@ -106,8 +106,7 @@
                             _read_property, _write_property, _RPM_list,     \
                             _RR_info, _iterator, _value_list, _COV,         \
                             _COV_clear, _intrinsic_reporting)               \
-/*TODO Add compile error "Unsupported BACNET_OBJECT_TABLE for this platform."  */
-
+    static_assert(false, "Unsupported BACNET_OBJECT_TABLE for this platform")
 
 /** @file linux/bacport.h  Includes Linux network headers. */
 

--- a/ports/linux/bacport.h
+++ b/ports/linux/bacport.h
@@ -101,6 +101,14 @@
 #include <netdb.h>
 #include "bacnet/bacnet_stack_exports.h"
 
+#define BACNET_OBJECT_TABLE(table_name, _type, _init, _count,               \
+                            _index_to_instance, _valid_instance, _object_name, \
+                            _read_property, _write_property, _RPM_list,     \
+                            _RR_info, _iterator, _value_list, _COV,         \
+                            _COV_clear, _intrinsic_reporting)               \
+/*TODO Add compile error "Unsupported BACNET_OBJECT_TABLE for this platform."  */
+
+
 /** @file linux/bacport.h  Includes Linux network headers. */
 
 /* Local helper functions for this port */

--- a/ports/lwip/bacport.h
+++ b/ports/lwip/bacport.h
@@ -41,6 +41,6 @@
                             _read_property, _write_property, _RPM_list,     \
                             _RR_info, _iterator, _value_list, _COV,         \
                             _COV_clear, _intrinsic_reporting)               \
-    /*TODO Add compile error "Unsupported BACNET_OBJECT_TABLE for this platform."  */
+    static_assert(false, "Unsupported BACNET_OBJECT_TABLE for this platform")
 
 #endif

--- a/ports/win32/bacport.h
+++ b/ports/win32/bacport.h
@@ -70,12 +70,6 @@ and globals in favor of more secure versions.  */
 #endif
 #include <sys/timeb.h>
 
-#if defined(__BORLANDC__) || defined(_WIN32)
-/* seems to not be defined in time.h as specified by The Open Group */
-/* difference from UTC and local standard time  */
-long int timezone;
-#endif
-
 #ifdef _MSC_VER
 #define inline __inline
 #endif
@@ -93,7 +87,6 @@ long int timezone;
                             _read_property, _write_property, _RPM_list,     \
                             _RR_info, _iterator, _value_list, _COV,         \
                             _COV_clear, _intrinsic_reporting)               \
-/*TODO Add compile error "Unsupported BACNET_OBJECT_TABLE for this platform."  */
-
+    static_assert(false, "Unsupported BACNET_OBJECT_TABLE for this platform")
 
 #endif

--- a/ports/win32/bacport.h
+++ b/ports/win32/bacport.h
@@ -70,6 +70,12 @@ and globals in favor of more secure versions.  */
 #endif
 #include <sys/timeb.h>
 
+#if defined(__BORLANDC__) || defined(_WIN32)
+/* seems to not be defined in time.h as specified by The Open Group */
+/* difference from UTC and local standard time  */
+long int timezone;
+#endif
+
 #ifdef _MSC_VER
 #define inline __inline
 #endif
@@ -81,5 +87,13 @@ and globals in favor of more secure versions.  */
 #define strncasecmp(x, y, z) _strnicmp(x, y, z)
 #define snprintf _snprintf
 #endif
+
+#define BACNET_OBJECT_TABLE(table_name, _type, _init, _count,               \
+                            _index_to_instance, _valid_instance, _object_name, \
+                            _read_property, _write_property, _RPM_list,     \
+                            _RR_info, _iterator, _value_list, _COV,         \
+                            _COV_clear, _intrinsic_reporting)               \
+/*TODO Add compile error "Unsupported BACNET_OBJECT_TABLE for this platform."  */
+
 
 #endif

--- a/ports/zephyr/bacport.h
+++ b/ports/zephyr/bacport.h
@@ -39,6 +39,8 @@ static inline char *inet_ntoa(struct in_addr in) {
 extern int bip_get_local_netmask(
     struct in_addr *netmask);
 
+#ifdef CONFIG_BACNET_USE_SECTION_ITERABLE_OBJECT_TABLE
+
 #define BACNET_OBJECT_TABLE(table_name, _type, _init, _count, \
                             _index_to_instance, _valid_instance, _object_name, \
                             _read_property, _write_property, _RPM_list, \
@@ -61,5 +63,16 @@ STRUCT_SECTION_ITERABLE(object_functions, table_name) = {   \
     .Object_COV_Clear = _COV_clear,                         \
     .Object_Intrinsic_Reporting = _intrinsic_reporting      \
 }
+
+#else
+
+#define BACNET_OBJECT_TABLE(table_name, _type, _init, _count, \
+                            _index_to_instance, _valid_instance, _object_name, \
+                            _read_property, _write_property, _RPM_list, \
+                            _RR_info, _iterator, _value_list, _COV, \
+                            _COV_clear, _intrinsic_reporting) \
+    /* empty define */
+
+#endif
 
 #endif

--- a/ports/zephyr/bacport.h
+++ b/ports/zephyr/bacport.h
@@ -29,7 +29,7 @@
 #include <net/net_ip.h>
 #include <net/socket.h>
 #include <zephyr.h>
-#include "bacnet/basic/object/device.h"
+#include <bacnet/basic/object/device.h>
 
 static inline char *inet_ntoa(struct in_addr in) {
     return "(inet_ntoa() to be implemented)";
@@ -71,7 +71,7 @@ STRUCT_SECTION_ITERABLE(object_functions, table_name) = {   \
                             _read_property, _write_property, _RPM_list, \
                             _RR_info, _iterator, _value_list, _COV, \
                             _COV_clear, _intrinsic_reporting) \
-    /* empty define */
+    while{}(0)
 
 #endif
 

--- a/ports/zephyr/bacport.h
+++ b/ports/zephyr/bacport.h
@@ -28,6 +28,8 @@
 
 #include <net/net_ip.h>
 #include <net/socket.h>
+#include <zephyr.h>
+#include "bacnet/basic/object/device.h"
 
 static inline char *inet_ntoa(struct in_addr in) {
     return "(inet_ntoa() to be implemented)";
@@ -37,5 +39,27 @@ static inline char *inet_ntoa(struct in_addr in) {
 extern int bip_get_local_netmask(
     struct in_addr *netmask);
 
+#define BACNET_OBJECT_TABLE(table_name, _type, _init, _count, \
+                            _index_to_instance, _valid_instance, _object_name, \
+                            _read_property, _write_property, _RPM_list, \
+                            _RR_info, _iterator, _value_list, _COV, \
+                            _COV_clear, _intrinsic_reporting) \
+STRUCT_SECTION_ITERABLE(object_functions, table_name) = {   \
+    .Object_Type = _type,                                   \
+    .Object_Init = _init,                                   \
+    .Object_Count = _count,                                 \
+    .Object_Index_To_Instance = _index_to_instance,         \
+    .Object_Valid_Instance = _valid_instance,               \
+    .Object_Name = _object_name,                            \
+    .Object_Read_Property = _read_property,                 \
+    .Object_Write_Property = _write_property,               \
+    .Object_RPM_List = _RPM_list,                           \
+    .Object_RR_Info = _RR_info,                             \
+    .Object_Iterator = _iterator,                           \
+    .Object_Value_List = _value_list,                       \
+    .Object_COV = _COV,                                     \
+    .Object_COV_Clear = _COV_clear,                         \
+    .Object_Intrinsic_Reporting = _intrinsic_reporting      \
+}
 
 #endif

--- a/test/bacnet/include/bacport.h
+++ b/test/bacnet/include/bacport.h
@@ -1,6 +1,6 @@
 /**************************************************************************
 *
-* Copyright (C) 2020 Steve Karg <skarg@users.sourceforge.net>
+* Copyright (c) 2022 Legrand North America, LLC.
 *
 * Permission is hereby granted, free of charge, to any person obtaining
 * a copy of this software and associated documentation files (the
@@ -23,24 +23,16 @@
 *
 *********************************************************************/
 
+/* ztest mock file */
+
 #ifndef BACPORT_H
 #define BACPORT_H
-
-#include <stdint.h>
-#include <stdbool.h>
-#include <string.h>
-#include "lwip/def.h"
-#include "lwip/udp.h"
-#include "lwip/memp.h"
-#include "netif/etharp.h"
-#include "lwip/dhcp.h"
-#include "lwip/inet.h"
 
 #define BACNET_OBJECT_TABLE(table_name, _type, _init, _count,               \
                             _index_to_instance, _valid_instance, _object_name, \
                             _read_property, _write_property, _RPM_list,     \
                             _RR_info, _iterator, _value_list, _COV,         \
                             _COV_clear, _intrinsic_reporting)               \
-    /*TODO Add compile error "Unsupported BACNET_OBJECT_TABLE for this platform."  */
+    /* Empty define */
 
 #endif

--- a/test/bacnet/include/bacport.h
+++ b/test/bacnet/include/bacport.h
@@ -33,6 +33,6 @@
                             _read_property, _write_property, _RPM_list,     \
                             _RR_info, _iterator, _value_list, _COV,         \
                             _COV_clear, _intrinsic_reporting)               \
-    /* Empty define */
+    while{}(0)
 
 #endif

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -339,7 +339,7 @@ set(BACNETSTACK_BASIC_SRCS
     ${BACNETSTACK_SRC}/bacnet/basic/object/mso.c
     ${BACNETSTACK_SRC}/bacnet/basic/object/msv.c
     ${BACNETSTACK_SRC}/bacnet/basic/object/nc.c
-    ${BACNETSTACK_SRC}/bacnet/basic/object/netport.c
+    $<$<BOOL:${CONFIG_BACDL_BIP}>:${BACNETSTACK_SRC}/bacnet/basic/object/netport.c>
     ${BACNETSTACK_SRC}/bacnet/basic/object/objects.c
     ${BACNETSTACK_SRC}/bacnet/basic/object/osv.c
     ${BACNETSTACK_SRC}/bacnet/basic/object/piv.c

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -106,6 +106,12 @@ config BACNET_ADDRESS_CACHE_FILE
 	help
 		BACnet Address Cache file functionality
 
+config BACNET_USE_SECTION_ITERABLE_OBJECT_TABLE
+	bool "Use the Section Iterable for the Object Table"
+	default true
+	help
+		Use the Section Iterable for the Object Table
+
 rsource "subsys/Kconfig"
 
 endif # BACNETSTACK

--- a/zephyr/subsys/CMakeLists.txt
+++ b/zephyr/subsys/CMakeLists.txt
@@ -2,3 +2,4 @@
 # SPDX-License-Identifier: MIT
 
 add_subdirectory_ifdef(CONFIG_BACNETSTACK_BACNET_SERVER server)
+add_subdirectory(object)

--- a/zephyr/subsys/Kconfig
+++ b/zephyr/subsys/Kconfig
@@ -5,4 +5,5 @@
 
 comment "BACnet Subsystems"
 
+rsource "object/Kconfig"
 rsource "server/Kconfig"

--- a/zephyr/subsys/object/CMakeLists.txt
+++ b/zephyr/subsys/object/CMakeLists.txt
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2022 Legrand North America, LLC.
+#
+# SPDX-License-Identifier: MIT
+#
+
+zephyr_sources(device.c)
+
+if(CONFIG_BACNET_USE_DYNAMIC_DESCRIPTION)
+  zephyr_sources(
+    acc.c
+    access_credential.c
+    access_door.c
+    access_point.c
+    access_rights.c
+    access_user.c
+    access_zone.c
+    ai.c
+    ao.c
+    av.c
+    bacfile.c
+    bi.c
+    bo.c
+    bv.c
+    channel.c
+    command.c
+    credential_data_input.c
+    csv.c
+    iv.c
+    lc.c
+    lo.c
+    lsp.c
+    ms-input.c
+    mso.c
+    msv.c
+    nc.c
+    osv.c
+    piv.c
+    schedule.c
+    trendlog.c
+    )
+
+  zephyr_sources_ifdef(CONFIG_BACDL_BIP netport.c)
+
+  zephyr_linker_sources(DATA_SECTIONS objects.ld)
+
+endif()

--- a/zephyr/subsys/object/Kconfig
+++ b/zephyr/subsys/object/Kconfig
@@ -1,0 +1,14 @@
+# Feature configuration options for BACnet-Stack
+
+# Copyright (c) 2022 Legrand North America, LLC.
+# SPDX-License-Identifier: MIT
+
+if BACNETSTACK
+
+config BACNET_USE_DYNAMIC_DESCRIPTION
+	bool "Use dynalic allocate for objects descriptions"
+	default false
+	help
+		Use dynalic allocate for objects descriptions
+
+endif # BACNETSTACK

--- a/zephyr/subsys/object/acc.c
+++ b/zephyr/subsys/object/acc.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* BACnet accumulator Objects used to represent meter registers */
+
+#include "object.h"
+#include "bacnet/basic/object/acc.h"
+
+OBJECT_FUNCTIONS(Accumulator, ACCUMULATOR_DESCR);

--- a/zephyr/subsys/object/access_credential.c
+++ b/zephyr/subsys/object/access_credential.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Access Credential Objects - customize for your use */
+
+#include "object.h"
+#include "bacnet/basic/object/access_credential.h"
+
+OBJECT_FUNCTIONS(Access_Credential, ACCESS_CREDENTIAL_DESCR);

--- a/zephyr/subsys/object/access_door.c
+++ b/zephyr/subsys/object/access_door.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Access Door Objects - customize for your use */
+
+#include "object.h"
+#include "bacnet/basic/object/access_door.h"
+
+OBJECT_FUNCTIONS(Access_Door, ACCESS_DOOR_DESCR);

--- a/zephyr/subsys/object/access_point.c
+++ b/zephyr/subsys/object/access_point.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Access Point Objects - customize for your use */
+
+#include "object.h"
+#include "bacnet/basic/object/access_point.h"
+
+OBJECT_FUNCTIONS(Access_Point, ACCESS_POINT_DESCR);

--- a/zephyr/subsys/object/access_rights.c
+++ b/zephyr/subsys/object/access_rights.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Access Rights Objects - customize for your use */
+
+#include "object.h"
+#include "bacnet/basic/object/access_rights.h"
+
+OBJECT_FUNCTIONS(Access_Rights, ACCESS_RIGHTS_DESCR);

--- a/zephyr/subsys/object/access_user.c
+++ b/zephyr/subsys/object/access_user.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Access User Objects - customize for your use */
+
+#include "object.h"
+#include "bacnet/basic/object/access_user.h"
+
+OBJECT_FUNCTIONS(Access_User, ACCESS_USER_DESCR);

--- a/zephyr/subsys/object/access_zone.c
+++ b/zephyr/subsys/object/access_zone.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Access Zone Objects - customize for your use */
+
+#include "object.h"
+#include "bacnet/basic/object/access_zone.h"
+
+OBJECT_FUNCTIONS(Access_Zone, ACCESS_ZONE_DESCR);

--- a/zephyr/subsys/object/ai.c
+++ b/zephyr/subsys/object/ai.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Analog Input Objects - Zephyr specific part */
+
+#include "object.h"
+#include "bacnet/basic/object/ai.h"
+
+OBJECT_FUNCTIONS_WITHOUT_INIT(Analog_Input, ANALOG_INPUT_DESCR);
+
+void Analog_Input_Init(void)
+{
+    if (!Object_List) {
+        Object_List = Keylist_Create();
+ 
+#if defined(INTRINSIC_REPORTING)
+        /* Set handler for GetEventInformation function */
+        handler_get_event_information_set(
+            OBJECT_ANALOG_INPUT, Analog_Input_Event_Information);
+        /* Set handler for AcknowledgeAlarm function */
+        handler_alarm_ack_set(OBJECT_ANALOG_INPUT, Analog_Input_Alarm_Ack);
+        /* Set handler for GetAlarmSummary Service */
+        handler_get_alarm_summary_set(
+            OBJECT_ANALOG_INPUT, Analog_Input_Alarm_Summary);
+#endif
+    }
+}

--- a/zephyr/subsys/object/ao.c
+++ b/zephyr/subsys/object/ao.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Analog Output Objects - customize for your use */
+
+#include "object.h"
+#include "bacnet/basic/object/ao.h"
+
+OBJECT_FUNCTIONS(Analog_Output, ANALOG_OUTPUT_DESCR);

--- a/zephyr/subsys/object/av.c
+++ b/zephyr/subsys/object/av.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Analog Value Objects - customize for your use */
+
+#include "object.h"
+#include "bacnet/basic/object/av.h"
+
+OBJECT_FUNCTIONS_WITHOUT_INIT(Analog_Value, ANALOG_VALUE_DESCR);
+
+void Analog_Value_Init(void)
+{
+    if (!Object_List) {
+        Object_List = Keylist_Create();
+ 
+#if defined(INTRINSIC_REPORTING)
+        /* Set handler for GetEventInformation function */
+        handler_get_event_information_set(
+            OBJECT_ANALOG_VALUE, Analog_Value_Event_Information);
+        /* Set handler for AcknowledgeAlarm function */
+        handler_alarm_ack_set(OBJECT_ANALOG_VALUE, Analog_Value_Alarm_Ack);
+        /* Set handler for GetAlarmSummary Service */
+        handler_get_alarm_summary_set(
+            OBJECT_ANALOG_VALUE, Analog_Value_Alarm_Summary);
+#endif
+    }
+}

--- a/zephyr/subsys/object/bacfile.c
+++ b/zephyr/subsys/object/bacfile.c
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "object.h"
+#include "bacnet/basic/object/bacfile.h"
+
+OBJECT_FUNCTIONS(Bacfile, BACNET_FILE_LISTING);
+

--- a/zephyr/subsys/object/bi.c
+++ b/zephyr/subsys/object/bi.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Binary Input Objects customize for your use */
+
+#include "object.h"
+#include "bacnet/basic/object/bi.h"
+
+OBJECT_FUNCTIONS(Binary_Input, BINARY_INPUT_DESCR);

--- a/zephyr/subsys/object/bo.c
+++ b/zephyr/subsys/object/bo.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Binary Output Objects - customize for your use */
+
+#include "object.h"
+#include "bacnet/basic/object/bo.h"
+
+OBJECT_FUNCTIONS(Binary_Output, BINARY_OUTPUT_DESCR);

--- a/zephyr/subsys/object/bv.c
+++ b/zephyr/subsys/object/bv.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Binary Value Objects - customize for your use */
+
+#include "object.h"
+#include "bacnet/basic/object/bv.h"
+
+OBJECT_FUNCTIONS(Binary_Value, BINARY_VALUE_DESCR);

--- a/zephyr/subsys/object/channel.c
+++ b/zephyr/subsys/object/channel.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "object.h"
+#include "bacnet/basic/object/channel.h"
+
+OBJECT_FUNCTIONS(Channel, CHANNEL_OBJECT);

--- a/zephyr/subsys/object/command.c
+++ b/zephyr/subsys/object/command.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "object.h"
+#include "bacnet/basic/object/command.h"
+
+OBJECT_FUNCTIONS(Command, COMMAND_DESCR);

--- a/zephyr/subsys/object/credential_data_input.c
+++ b/zephyr/subsys/object/credential_data_input.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Credential Data Input Objects - customize for your use */
+
+#include "object.h"
+#include "bacnet/basic/object/credential_data_input.h"
+
+OBJECT_FUNCTIONS(Credential_Data_Input, CREDENTIAL_DATA_INPUT_DESCR);

--- a/zephyr/subsys/object/csv.c
+++ b/zephyr/subsys/object/csv.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* CharacterString Value Objects */
+
+#include "object.h"
+#include "bacnet/basic/object/csv.h"
+
+OBJECT_FUNCTIONS(CharacterString_Value, CHARACTERSTRING_DESCR);

--- a/zephyr/subsys/object/device.c
+++ b/zephyr/subsys/object/device.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/** @file device.c Zephyr specific part of the Base "class". */
+
+#ifdef CONFIG_BACNET_USE_SECTION_ITERABLE_OBJECT_TABLE
+#include <zephyr.h>
+#endif
+#include "bacnet/basic/object/device.h"
+#include "object.h"
+
+#ifdef CONFIG_BACNET_USE_SECTION_ITERABLE_OBJECT_TABLE
+  extern struct object_functions _object_functions_list_end[];
+#endif
+
+#if BAC_ROUTING
+static object_functions Routing_object = {
+    .Object_Type = OBJECT_DEVICE,
+    .Object_Init = NULL,
+    .Object_Count = Device_Count,
+    .Object_Index_To_Instance = Routed_Device_Index_To_Instance,
+    .Object_Valid_Instance = Routed_Device_Valid_Object_Instance_Number,
+    .Object_Name = Routed_Device_Name,
+    .Object_Read_Property = Routed_Device_Read_Property_Local,
+    .Object_Write_Property = Routed_Device_Write_Property_Local,
+    .Object_RPM_List = Device_Property_Lists,
+    .Object_RR_Info = DeviceGetRRInfo
+    .Object_Iterator =  NULL,
+    .Object_Value_List =  NULL,
+    .Object_COV =  NULL,
+    .Object_COV_Clear =  NULL,
+    .Object_Intrinsic_Reporting =  NULL,
+};
+static bool routing_Device = false;
+
+/* In Zephyr port the object_functions table is saved in ROM and 
+   can't change fields value.
+   Instead this Device_Objects_Get_First(Next)_Object() returns the "Routing"
+   object when asked "Device" object, see static filter functions. */
+void Routing_Device_Init(uint32_t first_object_instance)
+{
+    /* Initialize with our preset strings */
+    Add_Routed_Device(first_object_instance, &My_Object_Name, Description);
+
+    routing_Device = true;
+}
+
+#endif /* BAC_ROUTING */
+
+#ifdef CONFIG_BACNET_USE_SECTION_ITERABLE_OBJECT_TABLE
+static struct object_functions *Device_Object_Filter_Out(
+    struct object_functions *pObject)
+{
+#if BAC_ROUTING
+    if (routing_Device && pObject == &Device_object)
+        return &Routing_object;
+    else
+#endif
+    return pObject;
+}
+
+static struct object_functions *Device_Object_Filter_In(
+    struct object_functions *pObject)
+{
+#if BAC_ROUTING
+    if (routing_Device && pObject == &Routing_object)
+        return &Device_object;
+    else
+#endif
+    return pObject;
+}
+
+struct object_functions *Device_Objects_Get_First_Object(void)
+{
+    STRUCT_SECTION_FOREACH(object_functions, pObject) {
+        return Device_Object_Filter_Out(pObject);
+    }
+    return NULL;
+}
+
+struct object_functions *Device_Objects_Get_Next_Object(
+    struct object_functions *object)
+{
+    if (object == NULL)
+        return NULL;
+    
+    object = Device_Object_Filter_In(object);
+    ++object;
+
+    if (object < _object_functions_list_end) {
+        return Device_Object_Filter_Out(object);
+    }
+    return NULL;
+}
+#endif /* CONFIG_BACNET_USE_SECTION_ITERABLE_OBJECT_TABLE */
+
+/**
+ * Allocate a Bacnet object
+ */
+void* Bacnet_Object_Allocate(size_t size)
+{
+    return k_malloc(size);
+}
+
+/**
+ * Free a Bacnet object
+ */
+void Bacnet_Object_Free(void *descr)
+{
+    k_free(descr);
+}

--- a/zephyr/subsys/object/iv.c
+++ b/zephyr/subsys/object/iv.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "object.h"
+#include "bacnet/basic/object/iv.h"
+
+OBJECT_FUNCTIONS(Integer_Value, struct integer_object);

--- a/zephyr/subsys/object/lc.c
+++ b/zephyr/subsys/object/lc.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Load Control Objects - customize for your use */
+/* from 135-2004-Addendum e */
+
+#include "object.h"
+#include "bacnet/basic/object/lc.h"
+
+OBJECT_FUNCTIONS(Load_Control, struct Load_Control);

--- a/zephyr/subsys/object/lo.c
+++ b/zephyr/subsys/object/lo.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "object.h"
+#include "bacnet/basic/object/lo.h"
+
+OBJECT_FUNCTIONS(Lighting_Output, struct lighting_output_object);

--- a/zephyr/subsys/object/lsp.c
+++ b/zephyr/subsys/object/lsp.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Life Safety Point Objects - customize for your use */
+
+#include "object.h"
+#include "bacnet/basic/object/lsp.h"
+
+OBJECT_FUNCTIONS(Life_Safety_Point, struct life_safety_point_object);

--- a/zephyr/subsys/object/ms-input.c
+++ b/zephyr/subsys/object/ms-input.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Multi-state Input Objects */
+
+#include "object.h"
+#include "bacnet/basic/object/ms-input.h"
+
+OBJECT_FUNCTIONS(Multistate_Input, MULTISTATE_INPUT_DESCR);

--- a/zephyr/subsys/object/mso.c
+++ b/zephyr/subsys/object/mso.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Multi-state Output Objects - customize for your use */
+
+#include "object.h"
+#include "bacnet/basic/object/mso.h"
+
+OBJECT_FUNCTIONS(Multistate_Output, MULTISTATE_OUTPUT_DESCR);
+

--- a/zephyr/subsys/object/msv.c
+++ b/zephyr/subsys/object/msv.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Multi-state Value Objects */
+
+#include "object.h"
+#include "bacnet/basic/object/msv.h"
+
+OBJECT_FUNCTIONS(Multistate_Value, MULTISTATE_VALUE_DESCR);

--- a/zephyr/subsys/object/nc.c
+++ b/zephyr/subsys/object/nc.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "object.h"
+#include "bacnet/basic/object/nc.h"
+
+#if defined(INTRINSIC_REPORTING)
+    OBJECT_FUNCTIONS(Notification_Class, NOTIFICATION_CLASS_INFO);
+#endif

--- a/zephyr/subsys/object/netport.c
+++ b/zephyr/subsys/object/netport.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "object.h"
+#include "bacnet/readrange.h"
+#include "bacnet/basic/object/netport.h"
+
+OBJECT_FUNCTIONS(Network_Port, struct netport_object_data);
+
+bool Network_Port_Object_Instance_Number_Set(
+    unsigned index, uint32_t object_instance)
+{
+    struct netport_object_data *descr;
+
+    uint32_t old_inst = Network_Port_Index_To_Instance(index);
+    descr = Keylist_Data_Delete(Object_List, old_inst);
+    if (descr == NULL) {
+        return false;
+    }
+
+    descr->Instance_Number = object_instance;
+    return Keylist_Data_Add(Object_List, object_instance, descr) >= 0;
+}

--- a/zephyr/subsys/object/object.h
+++ b/zephyr/subsys/object/object.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef ZTEST_UNITTEST
+  #include <zephyr.h>
+#else
+  #include "stdlib.h"
+  #define k_malloc(a) malloc(a)
+  #define k_free(a) free(a)
+
+  #define _DO_CONCAT(x, y) x ## y
+  #define _CONCAT(x, y) _DO_CONCAT(x, y)
+
+#endif
+#include "bacnet/basic/sys/keylist.h"
+
+
+#define OBJECT_ENUM_FUNCTIONS(object_name, descr_type)                      \
+    descr_type *_CONCAT(object_name, _Find_Description)(uint32_t instance)  \
+        { return Keylist_Data(Object_List, instance); }                     \
+    unsigned _CONCAT(object_name, _Count)(void)                             \
+        { return Keylist_Count(Object_List); }                              \
+    uint32_t _CONCAT(object_name, _Index_To_Instance)(unsigned index)       \
+        { return Keylist_Key(Object_List, index); }                         \
+    unsigned _CONCAT(object_name, _Instance_To_Index)(uint32_t instance)    \
+        { return (unsigned)Keylist_Index(Object_List, instance); }
+
+
+#define OBJECT_MEMORY_FUNCTIONS(object_name, descr_type)                    \
+    bool _CONCAT(object_name, _Create)(uint32_t instance)                   \
+    {                                                                       \
+        descr_type *descr = Keylist_Data(Object_List, instance);            \
+        if (!descr) {                                                       \
+            descr = k_malloc(sizeof(descr_type));                           \
+            if (descr) {                                                    \
+                _CONCAT(object_name, _Init_Description)(descr, instance);   \
+                return Keylist_Data_Add(Object_List, instance, descr) >= 0; \
+            }                                                               \
+        }                                                                   \
+        return false;                                                       \
+    }                                                                       \
+    void _CONCAT(object_name, _Cleanup)(void)                               \
+    {                                                                       \
+        descr_type *descr;                                                  \
+        if (Object_List) {                                                  \
+            do {                                                            \
+                descr = Keylist_Data_Pop(Object_List);                      \
+                if (descr) {                                                \
+                    k_free(descr);                                          \
+                }                                                           \
+            } while (descr);                                                \
+            Keylist_Delete(Object_List);                                    \
+            Object_List = NULL;                                             \
+        }                                                                   \
+    }                                                                       \
+    bool _CONCAT(object_name, _Delete)(uint32_t instance)                   \
+    {                                                                       \
+        bool status = false;                                                \
+        descr_type *descr = Keylist_Data_Delete(Object_List, instance);     \
+        if (descr) {                                                        \
+            k_free(descr);                                                  \
+            status = true;                                                  \
+        }                                                                   \
+        return status;                                                      \
+    }
+
+#define OBJECT_FUNCTIONS_WITHOUT_INIT(object_name, descr_type)  \
+    static OS_Keylist Object_List = NULL;                       \
+    OBJECT_ENUM_FUNCTIONS(object_name, descr_type)              \
+    OBJECT_MEMORY_FUNCTIONS(object_name, descr_type)
+
+#define OBJECT_FUNCTIONS(object_name, descr_type)               \
+    OBJECT_FUNCTIONS_WITHOUT_INIT(object_name, descr_type)      \
+    void _CONCAT(object_name, _Init)(void){                     \
+        if (!Object_List) {                                     \
+            Object_List = Keylist_Create();                     \
+        }                                                       \
+    }

--- a/zephyr/subsys/object/objects.ld
+++ b/zephyr/subsys/object/objects.ld
@@ -1,0 +1,1 @@
+ITERABLE_SECTION_ROM(object_functions, 4)

--- a/zephyr/subsys/object/osv.c
+++ b/zephyr/subsys/object/osv.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "object.h"
+#include "bacnet/basic/object/osv.h"
+
+OBJECT_FUNCTIONS(OctetString_Value, OCTETSTRING_VALUE_DESCR);

--- a/zephyr/subsys/object/piv.c
+++ b/zephyr/subsys/object/piv.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Positiveinteger Value Objects - customize for your use */
+
+#include "object.h"
+#include "bacnet/basic/object/piv.h"
+
+OBJECT_FUNCTIONS(PositiveInteger_Value, POSITIVEINTEGER_VALUE_DESCR);

--- a/zephyr/subsys/object/schedule.c
+++ b/zephyr/subsys/object/schedule.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "object.h"
+#include "bacnet/basic/object/schedule.h"
+
+OBJECT_FUNCTIONS(Schedule, SCHEDULE_DESCR);

--- a/zephyr/subsys/object/trendlog.c
+++ b/zephyr/subsys/object/trendlog.c
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "object.h"
+#include "bacnet/readrange.h"
+#include "bacnet/basic/object/trendlog.h"
+
+OBJECT_FUNCTIONS(Trend_Log, TL_DESCR);


### PR DESCRIPTION
The proposal for the implementation of the OSBCS-23 ticket is shown on the example of the Analog Input object.
Pay attention on changes 'bacnet/basic/object/ai.c'  and 'ports/zeptyr/ai.c' 

The object descriptor provider (Analog_Input_Create(), Analog_Input_Delete(), getting an object by instance, etc.) is in 'ports/zeptyr'.
The code 'bacnet/basic/object/ai.c' calls Analog_Input_Find_Description() when working with the descriptor.
The default descriptor provider is temporarily left in the file "bacnet/basic/object/ai.c" and marked as "USE_DEFAULT_DESCRIPT_PROVIDER".