### PR TITLE
Make "dlenv_network_port_init()" public (was static)

### DIFF
--- a/src/bacnet/datalink/dlenv.c
+++ b/src/bacnet/datalink/dlenv.c
@@ -250,7 +250,7 @@ int dlenv_register_as_foreign_device(void)
 /**
  * Datalink network port object settings
  */
-static void dlenv_network_port_init(void)
+void dlenv_network_port_init(void)
 {
     const uint32_t instance = 1;
     BACNET_IP_ADDRESS addr = { 0 };
@@ -288,7 +288,7 @@ static void dlenv_network_port_init(void)
 /**
  * Datalink network port object settings
  */
-static void dlenv_network_port_init(void)
+void dlenv_network_port_init(void)
 {
     uint32_t instance = 1;
     uint8_t mac[1] = { 0 };
@@ -315,7 +315,7 @@ static void dlenv_network_port_init(void)
 /**
  * Datalink network port object settings
  */
-static void dlenv_network_port_init(void)
+void dlenv_network_port_init(void)
 {
     uint32_t instance = 1;
     uint8_t prefix = 0;
@@ -348,7 +348,7 @@ static void dlenv_network_port_init(void)
 /**
  * Datalink network port object settings
  */
-static void dlenv_network_port_init(void)
+void dlenv_network_port_init(void)
 {
     /* do nothing */
 }

--- a/src/bacnet/datalink/dlenv.h
+++ b/src/bacnet/datalink/dlenv.h
@@ -44,6 +44,10 @@ extern "C" {
         void);
 
     BACNET_STACK_EXPORT
+    void dlenv_network_port_init(
+        void);
+
+    BACNET_STACK_EXPORT
     void dlenv_maintenance_timer(
         uint16_t elapsed_seconds);
 


### PR DESCRIPTION
This is needed when initing as a library, without calling "dlenv_init()". 

That's desirable if you don't want to use env variables and don't want to risk hitting exit() in the function (that should probably be removed).