### PR TITLE
Lower minimal cmake version requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 project(
   bacnet-stack


### PR DESCRIPTION
It builds fine with 3.5 too. We had a problem on some old debian with this.