### PR TITLE
Add option to subscribe to single property COV

### DIFF
--- a/src/bacnet/basic/service/s_cov.c
+++ b/src/bacnet/basic/service/s_cov.c
@@ -142,8 +142,15 @@ uint8_t Send_COV_Subscribe(
         pdu_len = npdu_encode_pdu(
             &Handler_Transmit_Buffer[0], &dest, &my_address, &npdu_data);
         /* encode the APDU portion of the packet */
-        len = cov_subscribe_encode_apdu(&Handler_Transmit_Buffer[pdu_len],
-            sizeof(Handler_Transmit_Buffer) - pdu_len, invoke_id, cov_data);
+        if (cov_data->covSubscribeToProperty) {
+            // subscribe to 1 property
+            len = cov_subscribe_property_encode_apdu(&Handler_Transmit_Buffer[pdu_len],
+                sizeof(Handler_Transmit_Buffer) - pdu_len, invoke_id, cov_data);
+        } else {
+            // subscribe to object
+            len = cov_subscribe_encode_apdu(&Handler_Transmit_Buffer[pdu_len],
+                sizeof(Handler_Transmit_Buffer) - pdu_len, invoke_id, cov_data);
+        }
         pdu_len += len;
         /* will it fit in the sender?
            note: if there is a bottleneck router in between

--- a/src/bacnet/cov.h
+++ b/src/bacnet/cov.h
@@ -45,6 +45,7 @@ typedef struct BACnet_Subscribe_COV_Data {
     bool cancellationRequest;   /* true if this is a cancellation request */
     bool issueConfirmedNotifications;   /* optional */
     uint32_t lifetime;  /* seconds, optional */
+    bool covSubscribeToProperty;  /* true to use per-property subscription */
     BACNET_PROPERTY_REFERENCE monitoredProperty;
     bool covIncrementPresent;   /* true if present */
     float covIncrement; /* optional */


### PR DESCRIPTION
This is experimental.

I wanted to receive just property 85 COV, but the server sends COV also for other properties of the object.

This was an attempt to send a more selective COV subscription. It did not work in my case, I still receive other properties.

Would be interesting to verify the function against some other bacnet server.