### PR TITLE
Fix error in datalink/bvlc.c

### DIFF
--- a/src/bacnet/datalink/bvlc.c
+++ b/src/bacnet/datalink/bvlc.c
@@ -2759,16 +2759,6 @@ int bvlc_foreign_device_bbmd_host_address_decode(uint8_t *apdu,
         }
         return BACNET_STATUS_REJECT;
     }
-    /* bbmd-address [0] BACnetHostNPort - closing */
-    if (!decode_is_closing_tag_number(&apdu[len++], 0)) {
-        if (error_code) {
-            *error_code = ERROR_CODE_REJECT_INVALID_TAG;
-        }
-        return BACNET_STATUS_REJECT;
-    }
-    if (len > apdu_len) {
-        return BACNET_STATUS_REJECT;
-    }
 
     return apdu_len;
 }

--- a/test/bacnet/datalink/bvlc/src/main.c
+++ b/test/bacnet/datalink/bvlc/src/main.c
@@ -820,7 +820,7 @@ static void test_BVLC_BBMD_Address(void)
 {
     uint8_t apdu[480] = { 0 };
     uint16_t apdu_len = 0;
-    uint16_t test_apdu_len = 0;
+    int16_t test_apdu_len = 0;
     uint16_t i = 0;
     BACNET_IP_ADDRESS bbmd_address;
     BACNET_IP_ADDRESS test_bbmd_address;


### PR DESCRIPTION
1 In bvlc_foreign_device_bbmd_host_address_decode() remove checking of close the common tag.
Reason - the bvlc_foreign_device_bbmd_host_address_encode() is not encode common tag for BACnetHostNPort and bvlc_foreign_device_bbmd_host_address_decode() is not check open tag.
Add and check tag for host only.
Test - test/bacnet/datalink/bvlc.