### PR TITLE
Custom datalink support

### DIFF
--- a/src/bacnet/config.h
+++ b/src/bacnet/config.h
@@ -37,7 +37,8 @@
    see datalink.h for possible defines. */
 #if !(defined(BACDL_ETHERNET) || defined(BACDL_ARCNET) || \
     defined(BACDL_MSTP) || defined(BACDL_BIP) || defined(BACDL_BIP6) || \
-    defined(BACDL_TEST) || defined(BACDL_ALL) || defined(BACDL_NONE))
+    defined(BACDL_TEST) || defined(BACDL_ALL) || defined(BACDL_NONE) || \
+    defined(BACDL_CUSTOM))
 #define BACDL_BIP
 #endif
 

--- a/src/bacnet/datalink/datalink.h
+++ b/src/bacnet/datalink/datalink.h
@@ -99,7 +99,7 @@ void routed_get_my_address(
 #define datalink_get_my_address bip6_get_my_address
 #define datalink_maintenance_timer(s) bvlc6_maintenance_timer(s)
 
-#elif defined(BACDL_ALL) || defined(BACDL_NONE)
+#elif defined(BACDL_ALL) || defined(BACDL_NONE) || defined(BACDL_CUSTOM)
 #include "bacnet/npdu.h"
 
 #define MAX_HEADER (8)
@@ -174,6 +174,7 @@ extern "C" {
  * - BACDL_ALL      -- Unspecified for the build, so the transport can be
  *                     chosen at runtime from among these choices.
  * - BACDL_NONE      -- Unspecified for the build for unit testing
+ * - BACDL_CUSTOM    -- For externally linked datalink_xxx functions
  * - Clause 10 POINT-TO-POINT (PTP) and Clause 11 EIA/CEA-709.1 ("LonTalk") LAN
  *   are not currently supported by this project.
                                                                                                                                                                                               *//** @defgroup DLTemplates DataLink Template Functions


### PR DESCRIPTION
PR introduces a define `BACDL_CUSTOM` which allows stack users to externally define functions like `datalink_send_pdu` while playing nicely with the rest of the stack. `datalink.h` ends up defining the prototypes for these functions which are to be externally linked. 