### PR TITLE
RPM should return UNKNOWN_OBJECT for non-existent objects

### DIFF
--- a/src/bacnet/basic/service/h_rpm.c
+++ b/src/bacnet/basic/service/h_rpm.c
@@ -236,6 +236,17 @@ void handler_read_property_multiple(uint8_t *service_request,
                     berror = true;
                     break;
                 }
+                
+                /* Test for invalid object before proceeding */
+                if (!Device_Valid_Object_Id(rpmdata.object_type, rpmdata.object_instance)) {
+                    rpmdata.error_class = ERROR_CLASS_OBJECT;
+                    rpmdata.error_code =
+                        ERROR_CODE_UNKNOWN_OBJECT;
+                    error = BACNET_STATUS_ERROR;
+                    berror = true;
+                    break; /* The berror flag ensures that both loops will */
+                           /* be broken! */
+                }
 
                 /* Test for case of indefinite Device object instance */
                 if ((rpmdata.object_type == OBJECT_DEVICE) &&

--- a/src/bacnet/basic/service/h_rpm.c
+++ b/src/bacnet/basic/service/h_rpm.c
@@ -130,7 +130,16 @@ static int RPM_Encode_Property(
     rpdata.array_index = rpmdata->array_index;
     rpdata.application_data = &Temp_Buf[0];
     rpdata.application_data_len = sizeof(Temp_Buf);
-    len = Device_Read_Property(&rpdata);
+
+    if ((rpmdata->object_property == PROP_ALL) ||
+        (rpmdata->object_property == PROP_REQUIRED) ||
+        (rpmdata->object_property == PROP_OPTIONAL)) {
+        /* special properties only get ERROR encoding */
+        len = BACNET_STATUS_ERROR;
+    } else {
+        len = Device_Read_Property(&rpdata);
+    }
+
     if (len < 0) {
         if ((len == BACNET_STATUS_ABORT) || (len == BACNET_STATUS_REJECT)) {
             rpmdata->error_code = rpdata.error_code;
@@ -301,7 +310,26 @@ void handler_read_property_multiple(uint8_t *service_request,
                         unsigned index = 0;
                         BACNET_PROPERTY_ID special_object_property;
 
-                        if (rpmdata.array_index != BACNET_ARRAY_ALL) {
+                        if (!Device_Valid_Object_Id(rpmdata.object_type,
+                                                    rpmdata.object_instance)) {
+                            len = RPM_Encode_Property(
+                                &Handler_Transmit_Buffer[npdu_len],
+                                (uint16_t)apdu_len, MAX_APDU, &rpmdata);
+                            if (len > 0) {
+                                apdu_len += len;
+                            } else {
+#if PRINT_ENABLED
+                                fprintf(stderr,
+                                        "RPM: Too full for property!\r\n");
+#endif
+                                error = len;
+                                /* The berror flag ensures that
+                                   both loops will be broken! */
+                                berror = true;
+                                break;
+                            }
+                        } else if (rpmdata.array_index != BACNET_ARRAY_ALL) {
+
                             /* No array index options for this special property.
                                Encode error for this object property response */
                             len = rpm_ack_encode_apdu_object_property(


### PR DESCRIPTION
Right now, the stack is returning empty values/lists, which I understand is not in accordance with the spec.