### PR TITLE
Fix typo in bvlc_debug_disable

### DIFF
--- a/src/bacnet/basic/bbmd/h_bbmd.c
+++ b/src/bacnet/basic/bbmd/h_bbmd.c
@@ -107,7 +107,7 @@ void bvlc_debug_enable(void)
  */
 void bvlc_debug_disable(void)
 {
-    BVLC_Debug = true;
+    BVLC_Debug = false;
 }
 
 /**


### PR DESCRIPTION
Every other `_disable_debug` function sets the associated debug flag to `false`. Looks like a simple copy-paste typo.