### PR TITLE
Fix min data len for UNCONFIRMED_SERVICE_REQUEST from 3 to 2

### DIFF
--- a/src/bacnet/basic/service/h_apdu.c
+++ b/src/bacnet/basic/service/h_apdu.c
@@ -585,7 +585,7 @@ void apdu_handler(BACNET_ADDRESS *src,
                 }
                 break;
             case PDU_TYPE_UNCONFIRMED_SERVICE_REQUEST:
-                if (apdu_len < 3) {
+                if (apdu_len < 2) {
                     break;
                 }
                 service_choice = apdu[1];


### PR DESCRIPTION
This is tested with Yabe on win32 and bin/bacserv on mac os x.
