### PR TITLE
Fix: Use memmove with overlapping data

### DIFF
--- a/apps/epics/main.c
+++ b/apps/epics/main.c
@@ -678,7 +678,7 @@ static void PrintReadPropertyData(BACNET_OBJECT_TYPE object_type,
                         int iLast15idx =
                             value->type.Character_String.length - 15;
                         value->type.Character_String.value[15] = '-';
-                        memcpy(&value->type.Character_String.value[16],
+                        memmove(&value->type.Character_String.value[16],
                             &value->type.Character_String.value[iLast15idx],
                             15);
                         value->type.Character_String.value[31] = 0;


### PR DESCRIPTION
We should use memmove instead of memcpy when things can overlap.
I was looking little bit whole repo and this got my eye.