### PR TITLE
Fix BACnet/SC tests

### DIFF
--- a/src/bacnet/basic/object/bacfile.c
+++ b/src/bacnet/basic/object/bacfile.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 #include "bacnet/config.h"
 #include "bacnet/basic/binding/address.h"
 #include "bacnet/bacdef.h"
@@ -108,6 +109,7 @@ const char *bacfile_pathname(uint32_t object_instance)
     struct object_data *pObject;
     const char *pathname = NULL;
 
+    assert(Object_List);
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         pathname = pObject->Pathname;
@@ -125,6 +127,7 @@ void bacfile_pathname_set(uint32_t object_instance, const char *pathname)
 {
     struct object_data *pObject;
 
+    assert(Object_List);
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if (pObject->Pathname) {
@@ -147,6 +150,7 @@ uint32_t bacfile_pathname_instance(
     int count = 0;
     int index = 0;
 
+    assert(Object_List);
     count = Keylist_Count(Object_List);
     while (count) {
         pObject = Keylist_Data_Index(Object_List, index);
@@ -177,6 +181,7 @@ bool bacfile_object_name(
     struct object_data *pObject;
     char name_text[32];
 
+    assert(Object_List);
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if (pObject->Object_Name) {
@@ -209,6 +214,7 @@ bool bacfile_object_name_set(uint32_t object_instance, char *new_name)
     uint32_t found_instance = 0;
     struct object_data *pObject;
 
+    assert(Object_List);
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject && new_name) {
         /* All the object names in a device must be unique */
@@ -242,6 +248,7 @@ bool bacfile_valid_instance(uint32_t object_instance)
 {
     struct object_data *pObject;
 
+    assert(Object_List);
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         return true;
@@ -389,6 +396,7 @@ bool bacfile_file_size_set(
     bool status = false;
     struct object_data *pObject;
 
+    assert(Object_List);
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if (pObject->File_Access_Stream) {
@@ -412,6 +420,7 @@ const char * bacfile_file_type(
     struct object_data *pObject;
     const char * mime_type = "application/octet-stream";
 
+    assert(Object_List);
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if (pObject->File_Type) {
@@ -433,6 +442,7 @@ void bacfile_file_type_set(
 {
     struct object_data *pObject;
 
+    assert(Object_List);
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if (pObject->File_Type) {
@@ -463,6 +473,7 @@ bool bacfile_archive(
     bool status = false;
     struct object_data *pObject;
 
+    assert(Object_List);
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         status = pObject->Archive;
@@ -488,6 +499,7 @@ bool bacfile_archive_set(
     bool status = false;
     struct object_data *pObject;
 
+    assert(Object_List);
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         pObject->Archive = archive;
@@ -508,6 +520,7 @@ bool bacfile_read_only(
     bool status = false;
     struct object_data *pObject;
 
+    assert(Object_List);
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         status = pObject->Read_Only;
@@ -529,6 +542,7 @@ bool bacfile_read_only_set(
     bool status = false;
     struct object_data *pObject;
 
+    assert(Object_List);
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         pObject->Read_Only = read_only;
@@ -548,6 +562,7 @@ void bacfile_modification_date(
 {
     struct object_data *pObject;
 
+    assert(Object_List);
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         datetime_copy(bdatetime, &pObject->Modification_Date);
@@ -565,6 +580,7 @@ bool bacfile_file_access_stream(
     bool status = false;
     struct object_data *pObject;
 
+    assert(Object_List);
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         status = pObject->File_Access_Stream;
@@ -586,6 +602,7 @@ bool bacfile_file_access_stream_set(
     bool status = false;
     struct object_data *pObject;
 
+    assert(Object_List);
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         pObject->File_Access_Stream = access;
@@ -1002,6 +1019,7 @@ bool bacfile_create(uint32_t object_instance)
     struct object_data *pObject = NULL;
     int index = 0;
 
+    assert(Object_List);
     pObject = Keylist_Data(Object_List, object_instance);
     if (!pObject) {
         pObject = calloc(1, sizeof(struct object_data));
@@ -1036,6 +1054,7 @@ bool bacfile_delete(uint32_t object_instance)
     bool status = false;
     struct object_data *pObject = NULL;
 
+    assert(Object_List);
     pObject = Keylist_Data_Delete(Object_List, object_instance);
     if (pObject) {
         free(pObject);

--- a/src/bacnet/datalink/bsc/bsc-util.c
+++ b/src/bacnet/datalink/bsc/bsc-util.c
@@ -117,6 +117,7 @@ void bsc_node_conf_fill_from_netport(BSC_NODE_CONF *bsc_conf,
     file_length = bacfile_read(file_instance,
         bsc_conf->key, bsc_conf->key_size);
     (void)file_length;
+
 #ifdef BACDL_BSC
     bsc_conf->local_uuid =
         (BACNET_SC_UUID*)Network_Port_SC_Local_UUID(instance);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -124,12 +124,12 @@ list(APPEND testdirs
   bacnet/datalink/crc
   bacnet/datalink/bvlc
   bacnet/datalink/bvlc-sc
-  #bacnet/datalink/runloop
-  #bacnet/datalink/websockets
-  #bacnet/datalink/bsc-socket
-  #bacnet/datalink/hub-sc
-  #bacnet/datalink/bsc-node
-  #bacnet/datalink/bsc-datalink
+  bacnet/datalink/runloop
+  bacnet/datalink/websockets
+  bacnet/datalink/bsc-socket
+  bacnet/datalink/hub-sc
+  bacnet/datalink/bsc-node
+  bacnet/datalink/bsc-datalink
   )
 
 enable_testing()

--- a/test/bacnet/datalink/bsc-datalink/src/main.c
+++ b/test/bacnet/datalink/bsc-datalink/src/main.c
@@ -1305,6 +1305,7 @@ static void test_sc_parameters(void)
         BACNET_WEBSOCKET_SERVER_PORT2);
 
     // prepare
+    bacfile_init();
     netport_object_init(SC_DATALINK_INSTANCE, ca_cert, sizeof(ca_cert),
         server_cert, sizeof(server_cert), server_key, sizeof(server_key), iface,
         &hubf_uuid, &hubf_vmac, primary_url, secondary_url,
@@ -1316,16 +1317,15 @@ static void test_sc_parameters(void)
     bsc_node_conf_fill_from_netport(&bsc_conf, &node_event);
 
     // check
-    zassert_equal(bsc_conf.ca_cert_chain, ca_cert, NULL);
     zassert_equal(bsc_conf.ca_cert_chain_size, sizeof(ca_cert), NULL);
-    zassert_equal(bsc_conf.cert_chain, server_cert, NULL);
+    zassert_mem_equal(bsc_conf.ca_cert_chain, ca_cert, sizeof(ca_cert), NULL);
     zassert_equal(bsc_conf.cert_chain_size, sizeof(server_cert), NULL);
-    zassert_equal(bsc_conf.key, server_key, NULL);
+    zassert_mem_equal(
+        bsc_conf.cert_chain, server_cert, sizeof(server_cert), NULL);
     zassert_equal(bsc_conf.key_size, sizeof(server_key), NULL);
-    zassert_equal(
-        memcmp(bsc_conf.local_uuid, &hubf_uuid, sizeof(hubf_uuid)), 0, NULL);
-    zassert_equal(
-        memcmp(bsc_conf.local_vmac, &hubf_vmac, sizeof(hubf_vmac)), 0, NULL);
+    zassert_mem_equal(bsc_conf.key, server_key, sizeof(server_key), NULL);
+    zassert_mem_equal(bsc_conf.local_uuid, &hubf_uuid, sizeof(hubf_uuid), NULL);
+    zassert_mem_equal(bsc_conf.local_vmac, &hubf_vmac, sizeof(hubf_vmac), NULL);
     zassert_equal(bsc_conf.max_local_bvlc_len, SC_NETPORT_BVLC_MAX, NULL);
     zassert_equal(bsc_conf.max_local_npdu_len, SC_NETPORT_NPDU_MAX, NULL);
     zassert_equal(bsc_conf.connect_timeout_s, SC_NETPORT_CONNECT_TIMEOUT, NULL);
@@ -1356,10 +1356,9 @@ static void test_sc_parameters(void)
     zassert_equal(bsc_conf.direct_connect_accept_enable,
         SC_NETPORT_DIRECT_CONNECT_ACCERT, NULL);
 
-    zassert_equal(memcmp(bsc_conf.direct_connection_accept_uris,
+    zassert_mem_equal(bsc_conf.direct_connection_accept_uris,
                       SC_NETPORT_DIRECT_CONNECT_ACCERT_URIS,
-                      strlen(SC_NETPORT_DIRECT_CONNECT_ACCERT_URIS)),
-        0, NULL);
+                      strlen(SC_NETPORT_DIRECT_CONNECT_ACCERT_URIS), NULL);
     zassert_equal(bsc_conf.direct_connection_accept_uris_len,
         strlen(SC_NETPORT_DIRECT_CONNECT_ACCERT_URIS), NULL);
 #endif
@@ -1419,6 +1418,7 @@ static void test_sc_datalink(void)
     sprintf(secondary_url1, "wss://%s:%d", BACNET_LOCALHOST, BACNET_HUB_PORT);
     sprintf(direct_url, "wss://%s:%d", BACNET_LOCALHOST, SC_NETPORT_DIRECT_SERVER_PORT);
 
+    bacfile_init();
     netport_object_init(SC_DATALINK_INSTANCE, ca_cert, sizeof(ca_cert),
         server_cert, sizeof(server_cert), server_key, sizeof(server_key), NULL,
         &uuid1, &vmac1, primary_url1, secondary_url1, true, false, false, 0,


### PR DESCRIPTION
Recent changes to the bacfile object require the presence of a file system.
But the BacNET/SC connection can be used on a device without a file system.
In this case, the use of the bacfile object is not possible.

If there is no file system, the certificates will be present as static arrays in the HW.
The user can set certificates by calling the bsc_node_conf_set_certs() function.
This variant is shown in the test_sc_parameters_static_certs() from test tests/datalink/bsc-datalink.