### PR TITLE
Feature/bacnet bacerror unit tests

### DIFF
--- a/src/bacnet/bacerror.c
+++ b/src/bacnet/bacerror.c
@@ -73,7 +73,7 @@ int bacerror_decode_error_class_and_code(uint8_t *apdu,
     uint32_t len_value_type = 0;
     uint32_t decoded_value = 0;
 
-    if (apdu_len) {
+    if (apdu && apdu_len) {
         /* error class */
         len += decode_tag_number_and_value(
             &apdu[len], &tag_number, &len_value_type);
@@ -109,15 +109,17 @@ int bacerror_decode_service_request(uint8_t *apdu,
 {
     int len = 0;
 
-    if (apdu_len > 2) {
+    if (apdu && apdu_len > 2) {
         if (invoke_id) {
             *invoke_id = apdu[0];
         }
         if (service) {
             *service = (BACNET_CONFIRMED_SERVICE)apdu[1];
         }
+	len += 2;
+
         /* decode the application class and code */
-        len = bacerror_decode_error_class_and_code(
+        len += bacerror_decode_error_class_and_code(
             &apdu[2], apdu_len - 2, error_class, error_code);
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,6 +33,7 @@ add_custom_command(TARGET lcov
 #
 
 list(APPEND testdirs
+  unit/bacnet/bacerror
   unit/bacnet/bits
   )
 

--- a/test/unit/bacnet/bacerror/CMakeLists.txt
+++ b/test/unit/bacnet/bacerror/CMakeLists.txt
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MIT
+
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+
+get_filename_component(basename ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(unittest_${basename}
+	VERSION 1.0.0
+	LANGUAGES C)
+
+
+string(REGEX REPLACE
+    "/test/unit/bacnet/[a-zA-Z_/-]*$"
+    "/src"
+    SRC_DIR
+    ${CMAKE_CURRENT_SOURCE_DIR})
+string(REGEX REPLACE
+    "/test/unit/bacnet/[a-zA-Z_/-]*$"
+    "/test"
+    TST_DIR
+    ${CMAKE_CURRENT_SOURCE_DIR})
+set(ZTST_DIR "${TST_DIR}/ztest/src")
+
+add_compile_definitions(
+	BIG_ENDIAN=0
+	CONFIG_ZTEST=1
+	)
+
+include_directories(
+	./src
+	${SRC_DIR}
+	${TST_DIR}/ztest/include
+	)
+
+add_executable(${PROJECT_NAME}
+    # File(s) under test
+    	${SRC_DIR}/bacnet/bacerror.c
+    # Support files and stubs (pathname alphabetical)
+    # Test and test library files
+	./src/main.c
+	./src/fakes/bacdcode.c
+	${ZTST_DIR}/ztest_mock.c
+	${ZTST_DIR}/ztest.c
+	)

--- a/test/unit/bacnet/bacerror/src/fakes/bacdcode.c
+++ b/test/unit/bacnet/bacerror/src/fakes/bacdcode.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2023 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/fff.h>
+
+#include "fakes/bacdcode.h"
+
+#if 0
+DEFINE_FAKE_VALUE_FUNC(int, encode_tag, uint8_t *, uint8_t, bool, uint32_t);
+DEFINE_FAKE_VALUE_FUNC(int, encode_opening_tag, uint8_t *, uint8_t);
+DEFINE_FAKE_VALUE_FUNC(int, encode_closing_tag, uint8_t *, uint8_t);
+DEFINE_FAKE_VALUE_FUNC(int, decode_tag_number, uint8_t *, uint8_t *);
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_tag_number_decode, uint8_t *, uint32_t, uint8_t *);
+#endif
+DEFINE_FAKE_VALUE_FUNC(
+    int, decode_tag_number_and_value, uint8_t *, uint8_t *, uint32_t *);
+#if 0
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_tag_number_and_value_decode, uint8_t *, uint32_t, uint8_t *, uint32_t *);
+DEFINE_FAKE_VALUE_FUNC(bool, decode_is_opening_tag_number, uint8_t *, uint8_t);
+DEFINE_FAKE_VALUE_FUNC(bool, decode_is_closing_tag_number, uint8_t *, uint8_t);
+DEFINE_FAKE_VALUE_FUNC(bool, decode_is_context_tag, uint8_t *, uint8_t);
+DEFINE_FAKE_VALUE_FUNC(bool, decode_is_context_tag_with_length, uint8_t *, uint8_t, int *);
+DEFINE_FAKE_VALUE_FUNC(bool, decode_is_opening_tag, uint8_t *);
+DEFINE_FAKE_VALUE_FUNC(bool, decode_is_closing_tag, uint8_t *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_application_null, uint8_t *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_context_null, uint8_t *, uint8_t);
+DEFINE_FAKE_VALUE_FUNC(int, encode_application_boolean, uint8_t *, bool);
+DEFINE_FAKE_VALUE_FUNC(bool, decode_boolean, uint32_t);
+DEFINE_FAKE_VALUE_FUNC(int, encode_context_boolean, uint8_t *, uint8_t, bool);
+DEFINE_FAKE_VALUE_FUNC(bool, decode_context_boolean, uint8_t *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_context_boolean2, uint8_t *, uint8_t, bool *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_bitstring, uint8_t *, uint32_t, BACNET_BIT_STRING *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_context_bitstring, uint8_t *, uint8_t, BACNET_BIT_STRING *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_bitstring, uint8_t *, BACNET_BIT_STRING *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_application_bitstring, uint8_t *, BACNET_BIT_STRING *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_context_bitstring, uint8_t *, uint8_t, BACNET_BIT_STRING *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_application_real, uint8_t *, float);
+DEFINE_FAKE_VALUE_FUNC(int, encode_context_real, uint8_t *, uint8_t, float);
+DEFINE_FAKE_VALUE_FUNC(int, decode_context_real, uint8_t *, uint8_t, float *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_application_double, uint8_t *, double);
+DEFINE_FAKE_VALUE_FUNC(int, encode_context_double, uint8_t *, uint8_t, double);
+DEFINE_FAKE_VALUE_FUNC(int, decode_context_double, uint8_t *, uint8_t, double *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_object_id, uint8_t *, BACNET_OBJECT_TYPE *, uint32_t *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_object_id_safe, uint8_t *, uint32_t, BACNET_OBJECT_TYPE *, uint32_t *);
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_object_id_decode, uint8_t *, uint16_t, uint32_t, BACNET_OBJECT_TYPE *, uint32_t *);
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_object_id_application_decode, uint8_t *, uint16_t, BACNET_OBJECT_TYPE *, uint32_t *);
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_object_id_context_decode, uint8_t *, uint16_t, uint8_t, BACNET_OBJECT_TYPE *, uint32_t *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_context_object_id, uint8_t *, uint8_t, BACNET_OBJECT_TYPE *, uint32_t *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_bacnet_object_id, uint8_t *, BACNET_OBJECT_TYPE, uint32_t);
+DEFINE_FAKE_VALUE_FUNC(int, encode_context_object_id, uint8_t *, uint8_t, BACNET_OBJECT_TYPE, uint32_t);
+DEFINE_FAKE_VALUE_FUNC(int, encode_application_object_id, uint8_t *, BACNET_OBJECT_TYPE, uint32_t);
+DEFINE_FAKE_VALUE_FUNC(int, encode_octet_string, uint8_t *, BACNET_OCTET_STRING *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_application_octet_string, uint8_t *, BACNET_OCTET_STRING *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_context_octet_string, uint8_t *, uint8_t, BACNET_OCTET_STRING *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_octet_string, uint8_t *, uint32_t, BACNET_OCTET_STRING *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_context_octet_string, uint8_t *, uint8_t, BACNET_OCTET_STRING *);
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_octet_string_decode, uint8_t *, uint16_t, uint32_t, BACNET_OCTET_STRING *);
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_octet_string_application_decode, uint8_t *, uint16_t, BACNET_OCTET_STRING *);
+DEFINE_FAKE_VALUE_FUNC(uint32_t, encode_bacnet_character_string_safe, uint8_t *apdu, uint32_t, uint8_t, char *, uint32_t);
+DEFINE_FAKE_VALUE_FUNC(int, encode_bacnet_character_string, uint8_t *, BACNET_CHARACTER_STRING *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_application_character_string, uint8_t *, BACNET_CHARACTER_STRING *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_context_character_string, uint8_t *, uint8_t, BACNET_CHARACTER_STRING *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_character_string, uint8_t *, uint32_t, BACNET_CHARACTER_STRING *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_context_character_string, uint8_t *, uint8_t, BACNET_CHARACTER_STRING *);
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_character_string_decode, uint8_t *, uint16_t, uint32_t, BACNET_CHARACTER_STRING *);
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_character_string_context_decode, uint8_t *, uint16_t, uint8_t, BACNET_CHARACTER_STRING *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_bacnet_unsigned, uint8_t *, BACNET_UNSIGNED_INTEGER);
+DEFINE_FAKE_VALUE_FUNC(int, encode_context_unsigned, uint8_t *, uint8_t, BACNET_UNSIGNED_INTEGER);
+DEFINE_FAKE_VALUE_FUNC(int, encode_application_unsigned, uint8_t *, BACNET_UNSIGNED_INTEGER);
+DEFINE_FAKE_VALUE_FUNC(int, decode_unsigned, uint8_t *, uint32_t, BACNET_UNSIGNED_INTEGER *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_context_unsigned, uint8_t *, uint8_t, BACNET_UNSIGNED_INTEGER *);
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_unsigned_decode, uint8_t *, uint16_t, uint32_t, BACNET_UNSIGNED_INTEGER *);
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_unsigned_application_decode, uint8_t *, uint16_t, BACNET_UNSIGNED_INTEGER *);
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_unsigned_context_decode, uint8_t *, uint16_t, uint8_t, BACNET_UNSIGNED_INTEGER *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_bacnet_signed, uint8_t *, int32_t);
+DEFINE_FAKE_VALUE_FUNC(int, encode_application_signed, uint8_t *, int32_t);
+DEFINE_FAKE_VALUE_FUNC(int, encode_context_signed, uint8_t *, uint8_t, int32_t);
+DEFINE_FAKE_VALUE_FUNC(int, decode_signed, uint8_t *, uint32_t, int32_t *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_context_signed, uint8_t *, uint8_t, int32_t *);
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_signed_decode, uint8_t *, uint16_t, uint32_t, int32_t *);
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_signed_context_decode, uint8_t *, uint16_t, uint8_t, int32_t *);
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_signed_application_decode, uint8_t *, uint16_t, int32_t *);
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_enumerated_decode, uint8_t *, uint16_t, uint32_t, uint32_t *);
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_enumerated_context_decode, uint8_t *, uint16_t, uint8_t, uint32_t *);
+#endif
+DEFINE_FAKE_VALUE_FUNC(int, decode_enumerated, uint8_t *, uint32_t, uint32_t *);
+#if 0
+DEFINE_FAKE_VALUE_FUNC(int, decode_context_enumerated, uint8_t *, uint8_t, uint32_t *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_bacnet_enumerated, uint8_t *, uint32_t);
+#endif
+DEFINE_FAKE_VALUE_FUNC(int, encode_application_enumerated, uint8_t *, uint32_t);
+#if 0
+DEFINE_FAKE_VALUE_FUNC(int, encode_context_enumerated, uint8_t *, uint8_t, uint32_t);
+DEFINE_FAKE_VALUE_FUNC(int, encode_bacnet_time, uint8_t *, BACNET_TIME *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_application_time, uint8_t *, BACNET_TIME *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_bacnet_time, uint8_t *, BACNET_TIME *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_bacnet_time_safe, uint8_t *, uint32_t, BACNET_TIME *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_context_time, uint8_t *, uint8_t, BACNET_TIME *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_application_time, uint8_t *, BACNET_TIME *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_context_bacnet_time, uint8_t *, uint8_t, BACNET_TIME *);
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_time_decode, uint8_t *, uint16_t, uint32_t, BACNET_TIME *);
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_time_context_decode, uint8_t *, uint16_t, uint8_t, BACNET_TIME *);
+DEFINE_FAKE_VALUE_FUNC(int, bacnet_time_application_decode, uint8_t *, uint16_t, BACNET_TIME *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_bacnet_date, uint8_t *, BACNET_DATE *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_application_date, uint8_t *, BACNET_DATE *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_context_date, uint8_t *, uint8_t, BACNET_DATE *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_date, uint8_t *, BACNET_DATE *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_date_safe, uint8_t *, uint32_t, BACNET_DATE *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_application_date, uint8_t *, BACNET_DATE *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_context_date, uint8_t *, uint8_t, BACNET_DATE *);
+DEFINE_FAKE_VALUE_FUNC(uint8_t, encode_max_segs_max_apdu, int, int);
+DEFINE_FAKE_VALUE_FUNC(int, decode_max_segs, uint8_t);
+DEFINE_FAKE_VALUE_FUNC(int, decode_max_apdu, uint8_t);
+DEFINE_FAKE_VALUE_FUNC(int, encode_simple_ack, uint8_t *, uint8_t, uint8_t);
+DEFINE_FAKE_VALUE_FUNC(int, encode_bacnet_address, uint8_t *, BACNET_ADDRESS *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_bacnet_address, uint8_t *, BACNET_ADDRESS *);
+DEFINE_FAKE_VALUE_FUNC(int, encode_context_bacnet_address, uint8_t *, uint8_t, BACNET_ADDRESS *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_context_bacnet_address, uint8_t *, uint8_t, BACNET_ADDRESS *);
+#endif

--- a/test/unit/bacnet/bacerror/src/fakes/bacdcode.h
+++ b/test/unit/bacnet/bacerror/src/fakes/bacdcode.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2023 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef BACNET_STACK_TEST_UNIT_BACNET_BACERROR_FAKES_BACDCODE_H_
+#define BACNET_STACK_TEST_UNIT_BACNET_BACERROR_FAKES_BACDCODE_H_
+
+#include <bacnet/bacdcode.h>
+#include <stdint.h>
+
+#include <zephyr/fff.h>
+
+#define BACNET_STACK_TEST_BACNET_BACDCODE_FFF_FAKES_LIST(FAKE) \
+    FAKE(decode_tag_number_and_value)                          \
+    FAKE(decode_enumerated)                                    \
+    FAKE(encode_application_enumerated)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if 0
+DECLARE_FAKE_VALUE_FUNC(int, encode_tag, uint8_t *, uint8_t, bool, uint32_t);
+DECLARE_FAKE_VALUE_FUNC(int, encode_opening_tag, uint8_t *, uint8_t);
+DECLARE_FAKE_VALUE_FUNC(int, encode_closing_tag, uint8_t *, uint8_t);
+DECLARE_FAKE_VALUE_FUNC(int, decode_tag_number, uint8_t *, uint8_t *);
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_tag_number_decode, uint8_t *, uint32_t, uint8_t *);
+#endif
+DECLARE_FAKE_VALUE_FUNC(
+    int, decode_tag_number_and_value, uint8_t *, uint8_t *, uint32_t *);
+#if 0
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_tag_number_and_value_decode, uint8_t *, uint32_t, uint8_t *, uint32_t *);
+DECLARE_FAKE_VALUE_FUNC(bool, decode_is_opening_tag_number, uint8_t *, uint8_t);
+DECLARE_FAKE_VALUE_FUNC(bool, decode_is_closing_tag_number, uint8_t *, uint8_t);
+DECLARE_FAKE_VALUE_FUNC(bool, decode_is_context_tag, uint8_t *, uint8_t);
+DECLARE_FAKE_VALUE_FUNC(bool, decode_is_context_tag_with_length, uint8_t *, uint8_t, int *);
+DECLARE_FAKE_VALUE_FUNC(bool, decode_is_opening_tag, uint8_t *);
+DECLARE_FAKE_VALUE_FUNC(bool, decode_is_closing_tag, uint8_t *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_application_null, uint8_t *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_context_null, uint8_t *, uint8_t);
+DECLARE_FAKE_VALUE_FUNC(int, encode_application_boolean, uint8_t *, bool);
+DECLARE_FAKE_VALUE_FUNC(bool, decode_boolean, uint32_t);
+DECLARE_FAKE_VALUE_FUNC(int, encode_context_boolean, uint8_t *, uint8_t, bool);
+DECLARE_FAKE_VALUE_FUNC(bool, decode_context_boolean, uint8_t *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_context_boolean2, uint8_t *, uint8_t, bool *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_bitstring, uint8_t *, uint32_t, BACNET_BIT_STRING *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_context_bitstring, uint8_t *, uint8_t, BACNET_BIT_STRING *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_bitstring, uint8_t *, BACNET_BIT_STRING *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_application_bitstring, uint8_t *, BACNET_BIT_STRING *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_context_bitstring, uint8_t *, uint8_t, BACNET_BIT_STRING *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_application_real, uint8_t *, float);
+DECLARE_FAKE_VALUE_FUNC(int, encode_context_real, uint8_t *, uint8_t, float);
+DECLARE_FAKE_VALUE_FUNC(int, decode_context_real, uint8_t *, uint8_t, float *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_application_double, uint8_t *, double);
+DECLARE_FAKE_VALUE_FUNC(int, encode_context_double, uint8_t *, uint8_t, double);
+DECLARE_FAKE_VALUE_FUNC(int, decode_context_double, uint8_t *, uint8_t, double *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_object_id, uint8_t *, BACNET_OBJECT_TYPE *, uint32_t *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_object_id_safe, uint8_t *, uint32_t, BACNET_OBJECT_TYPE *, uint32_t *);
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_object_id_decode, uint8_t *, uint16_t, uint32_t, BACNET_OBJECT_TYPE *, uint32_t *);
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_object_id_application_decode, uint8_t *, uint16_t, BACNET_OBJECT_TYPE *, uint32_t *);
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_object_id_context_decode, uint8_t *, uint16_t, uint8_t, BACNET_OBJECT_TYPE *, uint32_t *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_context_object_id, uint8_t *, uint8_t, BACNET_OBJECT_TYPE *, uint32_t *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_bacnet_object_id, uint8_t *, BACNET_OBJECT_TYPE, uint32_t);
+DECLARE_FAKE_VALUE_FUNC(int, encode_context_object_id, uint8_t *, uint8_t, BACNET_OBJECT_TYPE, uint32_t);
+DECLARE_FAKE_VALUE_FUNC(int, encode_application_object_id, uint8_t *, BACNET_OBJECT_TYPE, uint32_t);
+DECLARE_FAKE_VALUE_FUNC(int, encode_octet_string, uint8_t *, BACNET_OCTET_STRING *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_application_octet_string, uint8_t *, BACNET_OCTET_STRING *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_context_octet_string, uint8_t *, uint8_t, BACNET_OCTET_STRING *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_octet_string, uint8_t *, uint32_t, BACNET_OCTET_STRING *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_context_octet_string, uint8_t *, uint8_t, BACNET_OCTET_STRING *);
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_octet_string_decode, uint8_t *, uint16_t, uint32_t, BACNET_OCTET_STRING *);
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_octet_string_application_decode, uint8_t *, uint16_t, BACNET_OCTET_STRING *);
+DECLARE_FAKE_VALUE_FUNC(uint32_t, encode_bacnet_character_string_safe, uint8_t *apdu, uint32_t, uint8_t, char *, uint32_t);
+DECLARE_FAKE_VALUE_FUNC(int, encode_bacnet_character_string, uint8_t *, BACNET_CHARACTER_STRING *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_application_character_string, uint8_t *, BACNET_CHARACTER_STRING *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_context_character_string, uint8_t *, uint8_t, BACNET_CHARACTER_STRING *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_character_string, uint8_t *, uint32_t, BACNET_CHARACTER_STRING *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_context_character_string, uint8_t *, uint8_t, BACNET_CHARACTER_STRING *);
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_character_string_decode, uint8_t *, uint16_t, uint32_t, BACNET_CHARACTER_STRING *);
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_character_string_context_decode, uint8_t *, uint16_t, uint8_t, BACNET_CHARACTER_STRING *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_bacnet_unsigned, uint8_t *, BACNET_UNSIGNED_INTEGER);
+DECLARE_FAKE_VALUE_FUNC(int, encode_context_unsigned, uint8_t *, uint8_t, BACNET_UNSIGNED_INTEGER);
+DECLARE_FAKE_VALUE_FUNC(int, encode_application_unsigned, uint8_t *, BACNET_UNSIGNED_INTEGER);
+DECLARE_FAKE_VALUE_FUNC(int, decode_unsigned, uint8_t *, uint32_t, BACNET_UNSIGNED_INTEGER *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_context_unsigned, uint8_t *, uint8_t, BACNET_UNSIGNED_INTEGER *);
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_unsigned_decode, uint8_t *, uint16_t, uint32_t, BACNET_UNSIGNED_INTEGER *);
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_unsigned_application_decode, uint8_t *, uint16_t, BACNET_UNSIGNED_INTEGER *);
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_unsigned_context_decode, uint8_t *, uint16_t, uint8_t, BACNET_UNSIGNED_INTEGER *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_bacnet_signed, uint8_t *, int32_t);
+DECLARE_FAKE_VALUE_FUNC(int, encode_application_signed, uint8_t *, int32_t);
+DECLARE_FAKE_VALUE_FUNC(int, encode_context_signed, uint8_t *, uint8_t, int32_t);
+DECLARE_FAKE_VALUE_FUNC(int, decode_signed, uint8_t *, uint32_t, int32_t *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_context_signed, uint8_t *, uint8_t, int32_t *);
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_signed_decode, uint8_t *, uint16_t, uint32_t, int32_t *);
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_signed_context_decode, uint8_t *, uint16_t, uint8_t, int32_t *);
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_signed_application_decode, uint8_t *, uint16_t, int32_t *);
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_enumerated_decode, uint8_t *, uint16_t, uint32_t, uint32_t *);
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_enumerated_context_decode, uint8_t *, uint16_t, uint8_t, uint32_t *);
+#endif
+DECLARE_FAKE_VALUE_FUNC(
+    int, decode_enumerated, uint8_t *, uint32_t, uint32_t *);
+#if 0
+DECLARE_FAKE_VALUE_FUNC(int, decode_context_enumerated, uint8_t *, uint8_t, uint32_t *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_bacnet_enumerated, uint8_t *, uint32_t);
+#endif
+DECLARE_FAKE_VALUE_FUNC(
+    int, encode_application_enumerated, uint8_t *, uint32_t);
+#if 0
+DECLARE_FAKE_VALUE_FUNC(int, encode_context_enumerated, uint8_t *, uint8_t, uint32_t);
+DECLARE_FAKE_VALUE_FUNC(int, encode_bacnet_time, uint8_t *, BACNET_TIME *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_application_time, uint8_t *, BACNET_TIME *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_bacnet_time, uint8_t *, BACNET_TIME *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_bacnet_time_safe, uint8_t *, uint32_t, BACNET_TIME *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_context_time, uint8_t *, uint8_t, BACNET_TIME *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_application_time, uint8_t *, BACNET_TIME *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_context_bacnet_time, uint8_t *, uint8_t, BACNET_TIME *);
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_time_decode, uint8_t *, uint16_t, uint32_t, BACNET_TIME *);
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_time_context_decode, uint8_t *, uint16_t, uint8_t, BACNET_TIME *);
+DECLARE_FAKE_VALUE_FUNC(int, bacnet_time_application_decode, uint8_t *, uint16_t, BACNET_TIME *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_bacnet_date, uint8_t *, BACNET_DATE *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_application_date, uint8_t *, BACNET_DATE *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_context_date, uint8_t *, uint8_t, BACNET_DATE *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_date, uint8_t *, BACNET_DATE *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_date_safe, uint8_t *, uint32_t, BACNET_DATE *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_application_date, uint8_t *, BACNET_DATE *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_context_date, uint8_t *, uint8_t, BACNET_DATE *);
+DECLARE_FAKE_VALUE_FUNC(uint8_t, encode_max_segs_max_apdu, int, int);
+DECLARE_FAKE_VALUE_FUNC(int, decode_max_segs, uint8_t);
+DECLARE_FAKE_VALUE_FUNC(int, decode_max_apdu, uint8_t);
+DECLARE_FAKE_VALUE_FUNC(int, encode_simple_ack, uint8_t *, uint8_t, uint8_t);
+DECLARE_FAKE_VALUE_FUNC(int, encode_bacnet_address, uint8_t *, BACNET_ADDRESS *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_bacnet_address, uint8_t *, BACNET_ADDRESS *);
+DECLARE_FAKE_VALUE_FUNC(int, encode_context_bacnet_address, uint8_t *, uint8_t, BACNET_ADDRESS *);
+DECLARE_FAKE_VALUE_FUNC(int, decode_context_bacnet_address, uint8_t *, uint8_t, BACNET_ADDRESS *);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BACNET_STACK_TEST_UNIT_BACNET_BACERROR_FAKES_BACDCODE_H_ */

--- a/test/unit/bacnet/bacerror/src/main.c
+++ b/test/unit/bacnet/bacerror/src/main.c
@@ -1,0 +1,1127 @@
+/*
+ * Copyright (c) 2023 Legrand North America, LLC.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bacnet/bacerror.h"
+
+#include <errno.h>
+#include <zephyr/fff.h>
+#include <zephyr/ztest.h>
+#include <zephyr/sys/util.h>
+
+#include "fakes/bacdcode.h"
+
+#if 0
+#include <zephyr/fff_extensions.h>
+#else
+
+/* The helpful macro below is from a Zephyr v3.3.0+ PR currently under review.
+ * Once it is in a Zephyr release, then it can be provided via #include
+ * rather than declared locally.
+ */
+#ifndef RETURN_HANDLED_CONTEXT
+#define RETURN_HANDLED_CONTEXT(                                        \
+    FUNCNAME, CONTEXTTYPE, RESULTFIELD, CONTEXTPTRNAME, HANDLERBODY)   \
+    if (FUNCNAME##_fake.return_val_seq_len) {                          \
+        CONTEXTTYPE *const contexts = CONTAINER_OF(                    \
+            FUNCNAME##_fake.return_val_seq, CONTEXTTYPE, RESULTFIELD); \
+        size_t const seq_idx = (FUNCNAME##_fake.return_val_seq_idx <   \
+                                   FUNCNAME##_fake.return_val_seq_len) \
+            ? FUNCNAME##_fake.return_val_seq_idx++                     \
+            : FUNCNAME##_fake.return_val_seq_idx - 1;                  \
+        CONTEXTTYPE *const CONTEXTPTRNAME = &contexts[seq_idx];        \
+        HANDLERBODY;                                                   \
+    }                                                                  \
+    return FUNCNAME##_fake.return_val
+#endif /* RETURN_HANDLED_CONTEXT */
+
+#endif
+
+#define RESET_HISTORY_AND_FAKES()                                \
+    BACNET_STACK_TEST_BACNET_BACDCODE_FFF_FAKES_LIST(RESET_FAKE) \
+    FFF_RESET_HISTORY()
+
+DEFINE_FFF_GLOBALS;
+
+/*
+ * Custom Fakes:
+ */
+struct encode_application_enumerated_custom_fake_context {
+    uint8_t *const apdu_expected;
+    uint32_t value_expected;
+
+    /* Written to client by custom fake */
+    const uint8_t *const encoded_enumerated;
+    int const encoded_enumerated_len;
+
+    int result;
+};
+
+static int encode_application_enumerated_custom_fake(
+    uint8_t *apdu, uint32_t enumerated)
+{
+    RETURN_HANDLED_CONTEXT(encode_application_enumerated,
+        struct encode_application_enumerated_custom_fake_context,
+        result, /* return field name in _fake_context struct */
+        context, /* Name of context ptr variable used below */
+        {
+            if (context != NULL) {
+                if (context->result == 0) {
+                    if (apdu != NULL) {
+                        memcpy(apdu, context->encoded_enumerated,
+                            context->encoded_enumerated_len);
+                    }
+                }
+
+                return context->result;
+            }
+
+            return encode_application_enumerated_fake.return_val;
+        });
+}
+
+struct decode_tag_number_and_value_custom_fake_context {
+    uint8_t *const apdu_expected;
+
+    /* Written to client by custom fake */
+    uint8_t const tag_number;
+    uint32_t const value;
+
+    int result;
+};
+
+static int decode_tag_number_and_value_custom_fake(
+    uint8_t *apdu, uint8_t *tag_number, uint32_t *value)
+{
+    RETURN_HANDLED_CONTEXT(decode_tag_number_and_value,
+        struct decode_tag_number_and_value_custom_fake_context,
+        result, /* return field name in _fake_context struct */
+        context, /* Name of context ptr variable used below */
+        {
+            if (context != NULL) {
+                if (context->result > 0) {
+                    if (tag_number != NULL)
+                        *tag_number = context->tag_number;
+                    if (value != NULL)
+                        *value = context->value;
+                }
+
+                return context->result;
+            }
+
+            return decode_tag_number_and_value_fake.return_val;
+        });
+}
+
+struct decode_enumerated_custom_fake_context {
+    uint8_t *const apdu_expected;
+
+    /* Written to client by custom fake */
+    uint32_t const value;
+
+    int result;
+};
+
+static int decode_enumerated_custom_fake(
+    uint8_t *apdu, uint32_t len_value, uint32_t *value)
+{
+    RETURN_HANDLED_CONTEXT(decode_enumerated,
+        struct decode_enumerated_custom_fake_context,
+        result, /* return field name in _fake_context struct */
+        context, /* Name of context ptr variable used below */
+        {
+            if (context != NULL) {
+                if (context->result > 0) {
+                    if (value != NULL)
+                        *value = context->value;
+                }
+
+                return context->result;
+            }
+
+            return decode_enumerated_fake.return_val;
+        });
+}
+
+/*
+ * Tests:
+ */
+
+static void test_bacerror_encode_apdu(void)
+{
+    uint8_t test_apdu[32] = { 0 };
+
+    struct test_case {
+        const char *description_oneliner;
+
+        uint8_t apdu_prefill;
+
+        uint8_t *apdu;
+        uint8_t invoke_id;
+        BACNET_CONFIRMED_SERVICE service;
+        BACNET_ERROR_CLASS error_class;
+        BACNET_ERROR_CODE error_code;
+
+        void **expected_call_history;
+
+        /* Last FFF sequence entry is reused for excess calls.
+         * Have an extra entry that returns a distinct failure (-E2BIG)
+         *
+         * Expect one less call than _len, or 0 if sequence ptr is NULL
+         *
+         * Configure to return -E2BIG if excess calls.
+         */
+        int encode_application_enumerated_custom_fake_contexts_len;
+        struct encode_application_enumerated_custom_fake_context
+            *encode_application_enumerated_custom_fake_contexts;
+
+        int result_expected;
+    } const test_cases[] = {
+        {
+            .description_oneliner = "Call with NULL apdu",
+
+            .apdu = NULL,
+
+            .expected_call_history =
+                (void *[]) {
+                    NULL, /* mark end of array */
+                },
+
+            .result_expected = 0, /* zero total length of APDU */
+        },
+        {
+            .description_oneliner =
+                "Call with valid apdu, return negative apdu_len",
+
+            .apdu_prefill = 0x55U, /* arbitrary */
+
+            .apdu = &test_apdu[0],
+            .invoke_id = 0xFEU,
+            .service = MAX_BACNET_CONFIRMED_SERVICE,
+            .error_class = ERROR_CLASS_PROPRIETARY_FIRST,
+            .error_code = ERROR_CODE_PROPRIETARY_LAST,
+
+            .expected_call_history =
+                (void *[]) {
+                    encode_application_enumerated,
+                    encode_application_enumerated, NULL, /* mark end of array */
+                },
+
+            .encode_application_enumerated_custom_fake_contexts_len = 3,
+            .encode_application_enumerated_custom_fake_contexts =
+                (struct encode_application_enumerated_custom_fake_context[]) {
+                    {
+                        .apdu_expected = &test_apdu[3],
+                        .value_expected = ERROR_CLASS_PROPRIETARY_FIRST,
+                        .result = -2,
+                    },
+                    {
+                        .apdu_expected = &test_apdu[1],
+                        .value_expected = ERROR_CODE_PROPRIETARY_LAST,
+                        .result = -1,
+                    },
+                    {
+                        .result = -E2BIG, /* for excessive calls */
+                    },
+                },
+
+            .result_expected = 0, /* zero total length of APDU */
+        },
+        {
+            .description_oneliner =
+                "Call with valid apdu, return positive apdu_len",
+
+            .apdu_prefill = 0xABU, /* arbitrary */
+
+            .apdu = &test_apdu[0],
+            .invoke_id = 0xFEU,
+            .service = SERVICE_CONFIRMED_ACKNOWLEDGE_ALARM,
+            .error_class = ERROR_CLASS_PROPRIETARY_LAST,
+            .error_code = ERROR_CODE_PROPRIETARY_FIRST,
+
+            .expected_call_history =
+                (void *[]) {
+                    encode_application_enumerated,
+                    encode_application_enumerated, NULL, /* mark end of array */
+                },
+
+            .encode_application_enumerated_custom_fake_contexts_len = 3,
+            .encode_application_enumerated_custom_fake_contexts =
+                (struct encode_application_enumerated_custom_fake_context[]) {
+                    {
+                        .apdu_expected = &test_apdu[3],
+                        .value_expected = ERROR_CLASS_PROPRIETARY_LAST,
+                        .result = 4,
+                    },
+                    {
+                        .apdu_expected = &test_apdu[7],
+                        .value_expected = ERROR_CODE_PROPRIETARY_FIRST,
+                        .result = 5,
+                    },
+                    {
+                        .result = -E2BIG, /* for excessive calls */
+                    },
+                },
+
+            .result_expected = 3 + 4 + 5, /* total length of APDU */
+        },
+    };
+
+    for (int i = 0; i < ARRAY_SIZE(test_cases); ++i) {
+        const struct test_case *const tc = &test_cases[i];
+
+        printk("Checking test_cases[%i]: %s\n", i,
+            (tc->description_oneliner != NULL) ? tc->description_oneliner : "");
+
+        /*
+         * Set up pre-conditions
+         */
+        RESET_HISTORY_AND_FAKES();
+
+        /* NOTE: Point to the return type field in the first returns struct.
+         *       This custom_fake:
+         *     - uses *_fake.return_val_seq and CONTAINER_OF()
+         *         to determine the beginning of the array of structures.
+         *     - uses *_fake.return_val_seq_id to index into
+         *         the array of structures.
+         *       This overloading is to allow the return_val_seq to
+         *       also contain call-specific output parameters to be
+         *       applied by the custom_fake.
+         */
+        encode_application_enumerated_fake.return_val =
+            -E2BIG; /* for excessive calls */
+        SET_RETURN_SEQ(encode_application_enumerated,
+            &tc->encode_application_enumerated_custom_fake_contexts[0].result,
+            tc->encode_application_enumerated_custom_fake_contexts_len);
+        encode_application_enumerated_fake.custom_fake =
+            encode_application_enumerated_custom_fake;
+
+        memset(test_apdu, tc->apdu_prefill, sizeof(test_apdu));
+
+        /*
+         * Call code_under_test
+         */
+        int result = bacerror_encode_apdu(tc->apdu, tc->invoke_id, tc->service,
+            tc->error_class, tc->error_code);
+
+        /*
+         * Verify expected behavior of code_under_test:
+         *   - call history, args per call
+         *   - results
+         *   - outputs
+         */
+        if (tc->expected_call_history != NULL) {
+            for (int j = 0; j < fff.call_history_idx; ++j) {
+                zassert_equal(
+                    fff.call_history[j], tc->expected_call_history[j], NULL);
+            }
+            zassert_is_null(
+                tc->expected_call_history[fff.call_history_idx], NULL);
+        } else {
+            zassert_equal(fff.call_history_idx, 0, NULL);
+        }
+
+        const int encode_application_enumerated_fake_call_count_expected =
+            (tc->encode_application_enumerated_custom_fake_contexts == NULL)
+            ? 0
+            : tc->encode_application_enumerated_custom_fake_contexts_len - 1;
+
+        zassert_equal(encode_application_enumerated_fake.call_count,
+            encode_application_enumerated_fake_call_count_expected, NULL);
+        for (int j = 0;
+             j < encode_application_enumerated_fake_call_count_expected; ++j) {
+            zassert_equal(encode_application_enumerated_fake.arg0_history[j],
+                tc->encode_application_enumerated_custom_fake_contexts[j]
+                    .apdu_expected,
+                NULL);
+            zassert_equal(encode_application_enumerated_fake.arg1_history[j],
+                tc->encode_application_enumerated_custom_fake_contexts[j]
+                    .value_expected,
+                NULL);
+        }
+
+        if (tc->apdu != NULL) {
+            zassert_equal(test_apdu[0], PDU_TYPE_ERROR, NULL);
+            zassert_equal(test_apdu[1], tc->invoke_id, NULL);
+            zassert_equal(test_apdu[2], tc->service, NULL);
+
+            /* Verify remaining APDU bytes were not modified by code under test
+             */
+            for (int j = 3; j < sizeof(test_apdu); ++j) {
+                zassert_equal(test_apdu[j], tc->apdu_prefill, NULL);
+            }
+        }
+
+        zassert_equal(result, tc->result_expected, NULL);
+    }
+}
+
+static void test_bacerror_decode_error_class_and_code(void)
+{
+#if !BACNET_SVC_SERVER
+    uint8_t test_apdu[32] = { 0 };
+
+    uint8_t test_invoke_id = 0; /* bacerror_decode_service_request */
+    BACNET_CONFIRMED_SERVICE test_service =
+        0; /* bacerror_decode_service_request */
+    BACNET_ERROR_CLASS test_error_class = 0;
+    BACNET_ERROR_CODE test_error_code = 0;
+
+    struct test_case {
+        const char *description_oneliner;
+
+        BACNET_ERROR_CLASS error_class_prefill;
+        BACNET_ERROR_CODE error_code_prefill;
+
+        bool call_bacerror_decode_service_request;
+
+        uint8_t *apdu;
+        unsigned apdu_len;
+        uint8_t *invoke_id; /* bacerror_decode_service_request */
+        BACNET_CONFIRMED_SERVICE *service; /* bacerror_decode_service_request */
+        BACNET_ERROR_CLASS *error_class;
+        BACNET_ERROR_CODE *error_code;
+
+        void **expected_call_history;
+
+        /* Last FFF sequence entry is reused for excess calls.
+         * Have an extra entry that returns a distinct failure (-E2BIG)
+         *
+         * Expect one less call than _len, or 0 if sequence ptr is NULL
+         *
+         * Configure to return -E2BIG if excess calls.
+         */
+        int decode_tag_number_and_value_custom_fake_contexts_len;
+        struct decode_tag_number_and_value_custom_fake_context
+            *decode_tag_number_and_value_custom_fake_contexts;
+
+        int decode_enumerated_custom_fake_contexts_len;
+        struct decode_enumerated_custom_fake_context
+            *decode_enumerated_custom_fake_contexts;
+
+        uint8_t invoke_id_expected; /* bacerror_decode_service_request */
+        BACNET_CONFIRMED_SERVICE
+        service_expected; /* bacerror_decode_service_request */
+        BACNET_ERROR_CLASS error_class_expected;
+        BACNET_ERROR_CODE error_code_expected;
+
+        int result_expected; /* zero is error, >0 is len consumed */
+    } const test_cases[] = {
+        {
+            .description_oneliner = "Handle apdu ref of NULL",
+
+            .apdu = NULL,
+            .apdu_len = 1,
+            .error_class = &test_error_class,
+            .error_class_prefill = 1U,
+            .error_code = &test_error_code,
+            .error_code_prefill = 0xFFFFU,
+
+            .expected_call_history =
+                (void *[]) {
+                    NULL, /* mark end of array */
+                },
+
+            .result_expected = 0, /* zero total length of APDU consumed */
+        },
+        {
+            .description_oneliner = "Handle apdu_len of zero (0)",
+
+            .apdu =
+                (uint8_t[]) {
+                    0,
+                },
+            .apdu_len = 0,
+            .error_class = &test_error_class,
+            .error_class_prefill = 1U,
+            .error_code = &test_error_code,
+            .error_code_prefill = 0xFFFFU,
+
+            .expected_call_history =
+                (void *[]) {
+                    NULL, /* mark end of array */
+                },
+
+            .result_expected = 0, /* zero total length of APDU consumed */
+        },
+        {
+            .description_oneliner = "Handle invalid first tag",
+
+            .apdu =
+                (uint8_t[]) {
+                    0,
+                },
+            .apdu_len = 1,
+            .error_class = &test_error_class,
+            .error_class_prefill = 1U,
+            .error_code = &test_error_code,
+            .error_code_prefill = 0xFFFFU,
+
+            .expected_call_history =
+                (void *[]) {
+                    decode_tag_number_and_value, NULL, /* mark end of array */
+                },
+
+            .decode_tag_number_and_value_custom_fake_contexts_len = 2,
+            .decode_tag_number_and_value_custom_fake_contexts =
+                (struct decode_tag_number_and_value_custom_fake_context[]) {
+                    {
+                        .apdu_expected = &test_apdu[0],
+                        .tag_number =
+                            BACNET_APPLICATION_TAG_ENUMERATED - 1, /* err */
+                        .result = 1,
+                    },
+                    {
+                        .result = -E2BIG, /* for excessive calls */
+                    },
+                },
+
+            .result_expected = 0, /* zero total length of APDU consumed */
+        },
+        {
+            .description_oneliner = "Handle invalid second tag",
+
+            .apdu =
+                (uint8_t[]) {
+                    0,
+                },
+            .apdu_len = 1,
+            .error_class = &test_error_class,
+            .error_class_prefill = 1U,
+            .error_code = &test_error_code,
+            .error_code_prefill = 0xFFFFU,
+
+            .expected_call_history =
+                (void *[]) {
+                    decode_tag_number_and_value, decode_enumerated,
+                    decode_tag_number_and_value, NULL, /* mark end of array */
+                },
+
+            .decode_tag_number_and_value_custom_fake_contexts_len = 3,
+            .decode_tag_number_and_value_custom_fake_contexts =
+                (struct decode_tag_number_and_value_custom_fake_context[]) {
+                    {
+                        .apdu_expected = &test_apdu[0],
+
+                        .tag_number = BACNET_APPLICATION_TAG_ENUMERATED,
+                        .value = 42, /* arbitrary */
+                        .result = 1,
+                    },
+                    {
+                        .apdu_expected = &test_apdu[1 + 1],
+
+                        .tag_number =
+                            BACNET_APPLICATION_TAG_ENUMERATED + 1, /* err */
+                        .value = 24, /* arbitrary */
+                        .result = 1,
+                    },
+                    {
+                        .result = -E2BIG, /* for excessive calls */
+                    },
+                },
+
+            .decode_enumerated_custom_fake_contexts_len = 2,
+            .decode_enumerated_custom_fake_contexts =
+                (struct decode_enumerated_custom_fake_context[]) {
+                    {
+                        .apdu_expected = &test_apdu[1],
+
+                        .value = 3, /* arbitrary */
+                        .result = 1,
+                    },
+                    {
+                        .result = -E2BIG, /* for excessive calls */
+                    },
+                },
+
+            .result_expected = 0, /* length of APDU consumed */
+        },
+        {
+            .description_oneliner = "Handle valid inputs",
+
+            .apdu =
+                (uint8_t[]) {
+                    0,
+                },
+            .apdu_len = 1,
+            .error_class = &test_error_class,
+            .error_class_prefill = 1U,
+            .error_code = &test_error_code,
+            .error_code_prefill = 0xFFFFU,
+
+            .expected_call_history =
+                (void *[]) {
+                    decode_tag_number_and_value, decode_enumerated,
+                    decode_tag_number_and_value, decode_enumerated,
+                    NULL, /* mark end of array */
+                },
+
+            .decode_tag_number_and_value_custom_fake_contexts_len = 3,
+            .decode_tag_number_and_value_custom_fake_contexts =
+                (struct decode_tag_number_and_value_custom_fake_context[]) {
+                    {
+                        .apdu_expected = &test_apdu[0],
+
+                        .tag_number = BACNET_APPLICATION_TAG_ENUMERATED,
+                        .value = 42, /* arbitrary */
+                        .result = 1,
+                    },
+                    {
+                        .apdu_expected = &test_apdu[1 + 2],
+
+                        .tag_number = BACNET_APPLICATION_TAG_ENUMERATED,
+                        .value = 24, /* arbitrary */
+                        .result = 3,
+                    },
+                    {
+                        .result = -E2BIG, /* for excessive calls */
+                    },
+                },
+
+            .decode_enumerated_custom_fake_contexts_len = 3,
+            .decode_enumerated_custom_fake_contexts =
+                (struct decode_enumerated_custom_fake_context[]) {
+                    {
+                        .apdu_expected = &test_apdu[1],
+
+                        .value = 3, /* error_class, arbitrary */
+                        .result = 2,
+                    },
+                    {
+                        .apdu_expected = &test_apdu[1 + 2 + 3],
+
+                        .value = 7, /* error_code, arbitrary */
+                        .result = 4,
+                    },
+                    {
+                        .result = -E2BIG, /* for excessive calls */
+                    },
+                },
+
+            .error_class_expected = 3,
+            .error_code_expected = 7,
+
+            .result_expected = 1 + 2 + 3 + 4, /* length of APDU consumed */
+        },
+        {
+            .description_oneliner = "decode_service_request, apdu ref NULL",
+
+            .call_bacerror_decode_service_request = true,
+
+            .apdu = NULL,
+            .apdu_len = 3,
+            .invoke_id = &test_invoke_id,
+            .service = &test_service,
+            .error_class = &test_error_class,
+            .error_class_prefill = 1U,
+            .error_code = &test_error_code,
+            .error_code_prefill = 0xFFFFU,
+
+            .expected_call_history =
+                (void *[]) {
+                    NULL, /* mark end of array */
+                },
+
+            .decode_tag_number_and_value_custom_fake_contexts_len = 1,
+            .decode_tag_number_and_value_custom_fake_contexts =
+                (struct decode_tag_number_and_value_custom_fake_context[]) {
+                    {
+                        .result = -E2BIG, /* for excessive calls */
+                    },
+                },
+
+            .decode_enumerated_custom_fake_contexts_len = 1,
+            .decode_enumerated_custom_fake_contexts =
+                (struct decode_enumerated_custom_fake_context[]) {
+                    {
+                        .result = -E2BIG, /* for excessive calls */
+                    },
+                },
+
+            .invoke_id_expected = 0xFEU, /* apdu[0] */
+            .service_expected = 0xFDU, /* apdu[1] */
+            .error_class_expected = 3,
+            .error_code_expected = 7,
+
+            .result_expected = 0, /* length of APDU consumed */
+        },
+        {
+            .description_oneliner =
+                "decode_service_request invalid inputs, apdu_len = 0",
+
+            .call_bacerror_decode_service_request = true,
+
+            .apdu =
+                (uint8_t[]) {
+                    0xBEU, /* apdu[0]: invoke_id */
+                    0xBDU, /* apdu[1]: service */
+                    0,
+                },
+            .apdu_len = 0,
+            .invoke_id = &test_invoke_id,
+            .service = &test_service,
+            .error_class = &test_error_class,
+            .error_class_prefill = 1U,
+            .error_code = &test_error_code,
+            .error_code_prefill = 0xFFFFU,
+
+            .expected_call_history =
+                (void *[]) {
+                    NULL, /* mark end of array */
+                },
+
+            .decode_tag_number_and_value_custom_fake_contexts_len = 1,
+            .decode_tag_number_and_value_custom_fake_contexts =
+                (struct decode_tag_number_and_value_custom_fake_context[]) {
+                    {
+                        .result = -E2BIG, /* for excessive calls */
+                    },
+                },
+
+            .decode_enumerated_custom_fake_contexts_len = 1,
+            .decode_enumerated_custom_fake_contexts =
+                (struct decode_enumerated_custom_fake_context[]) {
+                    {
+                        .result = -E2BIG, /* for excessive calls */
+                    },
+                },
+
+            .invoke_id_expected = 0xFEU, /* apdu[0] */
+            .service_expected = 0xFDU, /* apdu[1] */
+            .error_class_expected = 3,
+            .error_code_expected = 7,
+
+            .result_expected = 0, /* length of APDU consumed */
+        },
+        {
+            .description_oneliner =
+                "decode_service_request invalid inputs, apdu_len = 2",
+
+            .call_bacerror_decode_service_request = true,
+
+            .apdu =
+                (uint8_t[]) {
+                    0xBEU, /* apdu[0]: invoke_id */
+                    0xBDU, /* apdu[1]: service */
+                    0,
+                },
+            .apdu_len = 2,
+            .invoke_id = &test_invoke_id,
+            .service = &test_service,
+            .error_class = &test_error_class,
+            .error_class_prefill = 1U,
+            .error_code = &test_error_code,
+            .error_code_prefill = 0xFFFFU,
+
+            .expected_call_history =
+                (void *[]) {
+                    NULL, /* mark end of array */
+                },
+
+            .decode_tag_number_and_value_custom_fake_contexts_len = 1,
+            .decode_tag_number_and_value_custom_fake_contexts =
+                (struct decode_tag_number_and_value_custom_fake_context[]) {
+                    {
+                        .result = -E2BIG, /* for excessive calls */
+                    },
+                },
+
+            .decode_enumerated_custom_fake_contexts_len = 1,
+            .decode_enumerated_custom_fake_contexts =
+                (struct decode_enumerated_custom_fake_context[]) {
+                    {
+                        .result = -E2BIG, /* for excessive calls */
+                    },
+                },
+
+            .invoke_id_expected = 0xFEU, /* apdu[0] */
+            .service_expected = 0xFDU, /* apdu[1] */
+            .error_class_expected = 3,
+            .error_code_expected = 7,
+
+            .result_expected = 0, /* length of APDU consumed */
+        },
+        {
+            .description_oneliner = "decode_service_request valid inputs",
+
+            .call_bacerror_decode_service_request = true,
+
+            .apdu =
+                (uint8_t[]) {
+                    0xFEU, /* apdu[0]: invoke_id */
+                    0xFDU, /* apdu[1]: service */
+                    0,
+                },
+            .apdu_len = 3,
+            .invoke_id = &test_invoke_id,
+            .service = &test_service,
+            .error_class = &test_error_class,
+            .error_class_prefill = 1U,
+            .error_code = &test_error_code,
+            .error_code_prefill = 0xFFFFU,
+
+            .expected_call_history =
+                (void *[]) {
+                    decode_tag_number_and_value, decode_enumerated,
+                    decode_tag_number_and_value, decode_enumerated,
+                    NULL, /* mark end of array */
+                },
+
+            .decode_tag_number_and_value_custom_fake_contexts_len = 3,
+            .decode_tag_number_and_value_custom_fake_contexts =
+                (struct decode_tag_number_and_value_custom_fake_context[]) {
+                    {
+                        .apdu_expected = &test_apdu[2 + 0],
+
+                        .tag_number = BACNET_APPLICATION_TAG_ENUMERATED,
+                        .value = 142, /* arbitrary */
+                        .result = 1,
+                    },
+                    {
+                        .apdu_expected = &test_apdu[2 + 1 + 2],
+
+                        .tag_number = BACNET_APPLICATION_TAG_ENUMERATED,
+                        .value = 124, /* arbitrary */
+                        .result = 3,
+                    },
+                    {
+                        .result = -E2BIG, /* for excessive calls */
+                    },
+                },
+
+            .decode_enumerated_custom_fake_contexts_len = 3,
+            .decode_enumerated_custom_fake_contexts =
+                (struct decode_enumerated_custom_fake_context[]) {
+                    {
+                        .apdu_expected = &test_apdu[2 + 1],
+
+                        .value = 3, /* error_class, arbitrary */
+                        .result = 2,
+                    },
+                    {
+                        .apdu_expected = &test_apdu[2 + 1 + 2 + 3],
+
+                        .value = 7, /* error_code, arbitrary */
+                        .result = 4,
+                    },
+                    {
+                        .result = -E2BIG, /* for excessive calls */
+                    },
+                },
+
+            .invoke_id_expected = 0xFEU, /* apdu[0] */
+            .service_expected = 0xFDU, /* apdu[1] */
+            .error_class_expected = 3,
+            .error_code_expected = 7,
+
+            .result_expected = 2 + 1 + 2 + 3 + 4, /* length of APDU consumed */
+        },
+        {
+            .description_oneliner =
+                "decode_service_request valid inputs, invoke_id is NULL",
+
+            .call_bacerror_decode_service_request = true,
+
+            .apdu =
+                (uint8_t[]) {
+                    0xFEU, /* apdu[0]: invoke_id */
+                    0xFDU, /* apdu[1]: service */
+                    0,
+                },
+            .apdu_len = 3,
+            .invoke_id = NULL,
+            .service = &test_service,
+            .error_class = &test_error_class,
+            .error_class_prefill = 1U,
+            .error_code = &test_error_code,
+            .error_code_prefill = 0xFFFFU,
+
+            .expected_call_history =
+                (void *[]) {
+                    decode_tag_number_and_value, decode_enumerated,
+                    decode_tag_number_and_value, decode_enumerated,
+                    NULL, /* mark end of array */
+                },
+
+            .decode_tag_number_and_value_custom_fake_contexts_len = 3,
+            .decode_tag_number_and_value_custom_fake_contexts =
+                (struct decode_tag_number_and_value_custom_fake_context[]) {
+                    {
+                        .apdu_expected = &test_apdu[2 + 0],
+
+                        .tag_number = BACNET_APPLICATION_TAG_ENUMERATED,
+                        .value = 142, /* arbitrary */
+                        .result = 1,
+                    },
+                    {
+                        .apdu_expected = &test_apdu[2 + 1 + 2],
+
+                        .tag_number = BACNET_APPLICATION_TAG_ENUMERATED,
+                        .value = 124, /* arbitrary */
+                        .result = 3,
+                    },
+                    {
+                        .result = -E2BIG, /* for excessive calls */
+                    },
+                },
+
+            .decode_enumerated_custom_fake_contexts_len = 3,
+            .decode_enumerated_custom_fake_contexts =
+                (struct decode_enumerated_custom_fake_context[]) {
+                    {
+                        .apdu_expected = &test_apdu[2 + 1],
+
+                        .value = 3, /* error_class, arbitrary */
+                        .result = 2,
+                    },
+                    {
+                        .apdu_expected = &test_apdu[2 + 1 + 2 + 3],
+
+                        .value = 7, /* error_code, arbitrary */
+                        .result = 4,
+                    },
+                    {
+                        .result = -E2BIG, /* for excessive calls */
+                    },
+                },
+
+            .invoke_id_expected = 0xFEU, /* apdu[0] */
+            .service_expected = 0xFDU, /* apdu[1] */
+            .error_class_expected = 3,
+            .error_code_expected = 7,
+
+            .result_expected = 2 + 1 + 2 + 3 + 4, /* length of APDU consumed */
+        },
+        {
+            .description_oneliner =
+                "decode_service_request valid inputs, service is NULL",
+
+            .call_bacerror_decode_service_request = true,
+
+            .apdu =
+                (uint8_t[]) {
+                    0xFCU, /* apdu[0]: invoke_id */
+                    0xFBU, /* apdu[1]: service */
+                    0,
+                },
+            .apdu_len = 3,
+            .invoke_id = &test_invoke_id,
+            .service = NULL,
+            .error_class = &test_error_class,
+            .error_class_prefill = 1U,
+            .error_code = &test_error_code,
+            .error_code_prefill = 0xFFFFU,
+
+            .expected_call_history =
+                (void *[]) {
+                    decode_tag_number_and_value, decode_enumerated,
+                    decode_tag_number_and_value, decode_enumerated,
+                    NULL, /* mark end of array */
+                },
+
+            .decode_tag_number_and_value_custom_fake_contexts_len = 3,
+            .decode_tag_number_and_value_custom_fake_contexts =
+                (struct decode_tag_number_and_value_custom_fake_context[]) {
+                    {
+                        .apdu_expected = &test_apdu[2 + 0],
+
+                        .tag_number = BACNET_APPLICATION_TAG_ENUMERATED,
+                        .value = 142, /* arbitrary */
+                        .result = 1,
+                    },
+                    {
+                        .apdu_expected = &test_apdu[2 + 1 + 2],
+
+                        .tag_number = BACNET_APPLICATION_TAG_ENUMERATED,
+                        .value = 124, /* arbitrary */
+                        .result = 3,
+                    },
+                    {
+                        .result = -E2BIG, /* for excessive calls */
+                    },
+                },
+
+            .decode_enumerated_custom_fake_contexts_len = 3,
+            .decode_enumerated_custom_fake_contexts =
+                (struct decode_enumerated_custom_fake_context[]) {
+                    {
+                        .apdu_expected = &test_apdu[2 + 1],
+
+                        .value = 3, /* error_class, arbitrary */
+                        .result = 2,
+                    },
+                    {
+                        .apdu_expected = &test_apdu[2 + 1 + 2 + 3],
+
+                        .value = 7, /* error_code, arbitrary */
+                        .result = 4,
+                    },
+                    {
+                        .result = -E2BIG, /* for excessive calls */
+                    },
+                },
+
+            .invoke_id_expected = 0xFCU, /* apdu[0] */
+            .service_expected = 0xFBU, /* apdu[1] */
+            .error_class_expected = 3,
+            .error_code_expected = 7,
+
+            .result_expected = 2 + 1 + 2 + 3 + 4, /* length of APDU consumed */
+        },
+    };
+
+    for (int i = 0; i < ARRAY_SIZE(test_cases); ++i) {
+        const struct test_case *const tc = &test_cases[i];
+
+        printk("Checking test_cases[%i]: %s\n", i,
+            (tc->description_oneliner != NULL) ? tc->description_oneliner : "");
+
+        /*
+         * Set up pre-conditions
+         */
+        RESET_HISTORY_AND_FAKES();
+
+        /* NOTE: Point to the return type field in the first returns struct.
+         *       This custom_fake:
+         *     - uses *_fake.return_val_seq and CONTAINER_OF()
+         *         to determine the beginning of the array of structures.
+         *     - uses *_fake.return_val_seq_id to index into
+         *         the array of structures.
+         *       This overloading is to allow the return_val_seq to
+         *       also contain call-specific output parameters to be
+         *       applied by the custom_fake.
+         */
+        decode_tag_number_and_value_fake.return_val =
+            -E2BIG; /* for excessive calls */
+        SET_RETURN_SEQ(decode_tag_number_and_value,
+            &tc->decode_tag_number_and_value_custom_fake_contexts[0].result,
+            tc->decode_tag_number_and_value_custom_fake_contexts_len);
+        decode_tag_number_and_value_fake.custom_fake =
+            decode_tag_number_and_value_custom_fake;
+
+        decode_enumerated_fake.return_val = -E2BIG; /* for excessive calls */
+        SET_RETURN_SEQ(decode_enumerated,
+            &tc->decode_enumerated_custom_fake_contexts[0].result,
+            tc->decode_enumerated_custom_fake_contexts_len);
+        decode_enumerated_fake.custom_fake = decode_enumerated_custom_fake;
+
+        memset(test_apdu, 0, sizeof(test_apdu));
+        if (tc->apdu != NULL) {
+            memcpy(test_apdu, tc->apdu, MIN(tc->apdu_len, sizeof(test_apdu)));
+        }
+        test_invoke_id =
+            ~tc->invoke_id_expected; /* bacerror_decode_service_request */
+        test_service =
+            ~tc->service_expected; /* bacerror_decode_service_request */
+        test_error_class = tc->error_class_prefill;
+        test_error_code = tc->error_code_prefill;
+
+        /*
+         * Call code_under_test
+         */
+        int result = -1;
+        if (tc->call_bacerror_decode_service_request) {
+            result = bacerror_decode_service_request(
+                ((tc->apdu != NULL) ? test_apdu : NULL), tc->apdu_len,
+                ((tc->invoke_id) ? &test_invoke_id : NULL),
+                ((tc->service) ? &test_service : NULL), tc->error_class,
+                tc->error_code);
+        } else {
+            result = bacerror_decode_error_class_and_code(
+                ((tc->apdu != NULL) ? test_apdu : NULL), tc->apdu_len,
+                tc->error_class, tc->error_code);
+        }
+
+        /*
+         * Verify expected behavior of code_under_test:
+         *   - call history, args per call
+         *   - results
+         *   - outputs
+         */
+        if (tc->expected_call_history != NULL) {
+            for (int j = 0; j < fff.call_history_idx; ++j) {
+                zassert_equal(
+                    fff.call_history[j], tc->expected_call_history[j], NULL);
+            }
+            zassert_is_null(
+                tc->expected_call_history[fff.call_history_idx], NULL);
+        } else {
+            zassert_equal(fff.call_history_idx, 0, NULL);
+        }
+
+        const int decode_tag_number_and_value_fake_call_count_expected =
+            (tc->decode_tag_number_and_value_custom_fake_contexts == NULL)
+            ? 0
+            : tc->decode_tag_number_and_value_custom_fake_contexts_len - 1;
+
+        zassert_equal(decode_tag_number_and_value_fake.call_count,
+            decode_tag_number_and_value_fake_call_count_expected, NULL);
+        for (int j = 0;
+             j < decode_tag_number_and_value_fake_call_count_expected; ++j) {
+            zassert_equal(decode_tag_number_and_value_fake.arg0_history[j],
+                tc->decode_tag_number_and_value_custom_fake_contexts[j]
+                    .apdu_expected,
+                NULL);
+            zassert_not_null(
+                decode_tag_number_and_value_fake.arg1_history[j], NULL);
+            zassert_not_null(
+                decode_tag_number_and_value_fake.arg2_history[j], NULL);
+        }
+
+        const int decode_enumerated_fake_call_count_expected =
+            (tc->decode_enumerated_custom_fake_contexts == NULL)
+            ? 0
+            : tc->decode_enumerated_custom_fake_contexts_len - 1;
+
+        zassert_equal(decode_enumerated_fake.call_count,
+            decode_enumerated_fake_call_count_expected, NULL);
+        for (int j = 0; j < decode_enumerated_fake_call_count_expected; ++j) {
+            zassert_equal(decode_enumerated_fake.arg0_history[j],
+                tc->decode_enumerated_custom_fake_contexts[j].apdu_expected,
+                NULL);
+            zassert_equal(decode_enumerated_fake.arg1_history[j],
+                tc->decode_tag_number_and_value_custom_fake_contexts[j].value,
+                NULL);
+            zassert_not_null(decode_enumerated_fake.arg2_history[j], NULL);
+        }
+
+        if ((tc->apdu != NULL) && tc->result_expected > 0) {
+            if (tc->call_bacerror_decode_service_request) {
+                if (tc->invoke_id != NULL) {
+                    zassert_equal(test_invoke_id, tc->invoke_id_expected, NULL);
+                }
+
+                if (tc->service != NULL) {
+                    zassert_equal(test_service, tc->service_expected, NULL);
+                }
+            }
+
+            if (tc->error_class != NULL) {
+                zassert_equal(test_error_class, tc->error_class_expected, NULL);
+            }
+            if (tc->error_code != NULL) {
+                zassert_equal(test_error_code, tc->error_code_expected, NULL);
+            }
+        } else {
+#if 0 /* NOTE: outputs are only valid if result > 0 */
+            zassert_equal(test_error_class, tc->error_class_prefill, NULL);
+            zassert_equal(test_error_code, tc->error_code_prefill, NULL);
+#endif
+        }
+
+        zassert_equal(result, tc->result_expected, NULL);
+    }
+#else
+    ztest_test_skip();
+#endif
+}
+
+void test_main(void)
+{
+    ztest_test_suite(bacnet_bacerror,
+        ztest_unit_test(test_bacerror_encode_apdu),
+        ztest_unit_test(test_bacerror_decode_error_class_and_code));
+    ztest_run_test_suite(bacnet_bacerror);
+}

--- a/test/ztest/include/zephyr/fff.h
+++ b/test/ztest/include/zephyr/fff.h
@@ -1,0 +1,8820 @@
+/*
+LICENSE
+
+The MIT License (MIT)
+
+Copyright (c) 2010 Michael Long
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#ifndef FAKE_FUNCTIONS
+#define FAKE_FUNCTIONS
+
+#include <stdarg.h>
+#include <string.h> /* For memset and memcpy */
+
+#define FFF_MAX_ARGS (20u)
+#ifndef FFF_ARG_HISTORY_LEN
+#define FFF_ARG_HISTORY_LEN (50u)
+#endif
+#ifndef FFF_CALL_HISTORY_LEN
+#define FFF_CALL_HISTORY_LEN (50u)
+#endif
+#ifndef FFF_GCC_FUNCTION_ATTRIBUTES
+#define FFF_GCC_FUNCTION_ATTRIBUTES
+#endif
+/* -- INTERNAL HELPER MACROS -- */
+#define SET_RETURN_SEQ(FUNCNAME, ARRAY_POINTER, ARRAY_LEN)                                         \
+	FUNCNAME##_fake.return_val_seq = ARRAY_POINTER;                                            \
+	FUNCNAME##_fake.return_val_seq_len = ARRAY_LEN;
+#define SET_CUSTOM_FAKE_SEQ(FUNCNAME, ARRAY_POINTER, ARRAY_LEN)                                    \
+	FUNCNAME##_fake.custom_fake_seq = ARRAY_POINTER;                                           \
+	FUNCNAME##_fake.custom_fake_seq_len = ARRAY_LEN;
+
+/* Defining a function to reset a fake function */
+#define RESET_FAKE(FUNCNAME)                                                                       \
+	{                                                                                          \
+		FUNCNAME##_reset();                                                                \
+	}
+
+#define DECLARE_ARG(type, n, FUNCNAME)                                                             \
+	type arg##n##_val;                                                                         \
+	type arg##n##_history[FFF_ARG_HISTORY_LEN];
+
+#define DECLARE_ALL_FUNC_COMMON                                                                    \
+	unsigned int call_count;                                                                   \
+	unsigned int arg_history_len;                                                              \
+	unsigned int arg_histories_dropped;
+
+#define DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                                  \
+	RETURN_TYPE return_val_history[FFF_ARG_HISTORY_LEN];
+
+#define SAVE_ARG(FUNCNAME, n)                                                                      \
+	memcpy((void *)&FUNCNAME##_fake.arg##n##_val, (void *)&arg##n, sizeof(arg##n));
+
+#define ROOM_FOR_MORE_HISTORY(FUNCNAME) FUNCNAME##_fake.call_count < FFF_ARG_HISTORY_LEN
+
+#define SAVE_RET_HISTORY(FUNCNAME, RETVAL)                                                          \
+	if ((FUNCNAME##_fake.call_count - 1) < FFF_ARG_HISTORY_LEN)                                 \
+		memcpy((void *)&FUNCNAME##_fake.return_val_history[FUNCNAME##_fake.call_count - 1], \
+		       (const void *)&RETVAL, sizeof(RETVAL));
+
+#define SAVE_ARG_HISTORY(FUNCNAME, ARGN)                                                           \
+	memcpy((void *)&FUNCNAME##_fake.arg##ARGN##_history[FUNCNAME##_fake.call_count],           \
+	       (void *)&arg##ARGN, sizeof(arg##ARGN));
+
+#define HISTORY_DROPPED(FUNCNAME) FUNCNAME##_fake.arg_histories_dropped++
+
+#define DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                              \
+	RETURN_TYPE return_val;                                                                    \
+	int return_val_seq_len;                                                                    \
+	int return_val_seq_idx;                                                                    \
+	RETURN_TYPE *return_val_seq;
+
+#define DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                          \
+	int custom_fake_seq_len;                                                                   \
+	int custom_fake_seq_idx;
+
+#define INCREMENT_CALL_COUNT(FUNCNAME) FUNCNAME##_fake.call_count++
+
+#define RETURN_FAKE_RESULT(FUNCNAME)                                                                \
+	if (FUNCNAME##_fake.return_val_seq_len) { /* then its a sequence */                         \
+		if (FUNCNAME##_fake.return_val_seq_idx < FUNCNAME##_fake.return_val_seq_len) {      \
+			SAVE_RET_HISTORY(                                                           \
+				FUNCNAME,                                                           \
+				FUNCNAME##_fake.return_val_seq[FUNCNAME##_fake.return_val_seq_idx]) \
+			return FUNCNAME##_fake                                                      \
+				.return_val_seq[FUNCNAME##_fake.return_val_seq_idx++];              \
+		}                                                                                   \
+		SAVE_RET_HISTORY(                                                                   \
+			FUNCNAME,                                                                   \
+			FUNCNAME##_fake.return_val_seq[FUNCNAME##_fake.return_val_seq_len - 1])     \
+		return FUNCNAME##_fake.return_val_seq[FUNCNAME##_fake.return_val_seq_len -          \
+						      1]; /* return last element */                 \
+	}                                                                                           \
+	SAVE_RET_HISTORY(FUNCNAME, FUNCNAME##_fake.return_val)                                      \
+	return FUNCNAME##_fake.return_val;
+
+#ifdef __cplusplus
+#define FFF_EXTERN_C extern "C" {
+#define FFF_END_EXTERN_C }
+#else /* ansi c */
+#define FFF_EXTERN_C
+#define FFF_END_EXTERN_C
+#endif /* cpp/ansi c */
+
+#define DEFINE_RESET_FUNCTION(FUNCNAME)                                                            \
+	void FUNCNAME##_reset(void)                                                                \
+	{                                                                                          \
+		memset(&FUNCNAME##_fake, 0, sizeof(FUNCNAME##_fake));                              \
+		FUNCNAME##_fake.arg_history_len = FFF_ARG_HISTORY_LEN;                             \
+	}
+/* -- END INTERNAL HELPER MACROS -- */
+
+typedef void (*fff_function_t)(void);
+typedef struct {
+	fff_function_t call_history[FFF_CALL_HISTORY_LEN];
+	unsigned int call_history_idx;
+} fff_globals_t;
+
+FFF_EXTERN_C
+extern fff_globals_t fff;
+FFF_END_EXTERN_C
+
+#define DEFINE_FFF_GLOBALS                                                                         \
+	FFF_EXTERN_C                                                                               \
+	fff_globals_t fff;                                                                         \
+	FFF_END_EXTERN_C
+
+#define FFF_RESET_HISTORY()                                                                        \
+	fff.call_history_idx = 0;                                                                  \
+	memset(fff.call_history, 0, sizeof(fff.call_history));
+
+#define REGISTER_CALL(function)                                                                    \
+	if (fff.call_history_idx < FFF_CALL_HISTORY_LEN)                                           \
+		fff.call_history[fff.call_history_idx++] = (fff_function_t)function;
+
+#define DECLARE_FAKE_VOID_FUNC0(FUNCNAME)                                                          \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(void);                                                         \
+		void (**custom_fake_seq)(void);                                                    \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(void);
+
+#define DEFINE_FAKE_VOID_FUNC0(FUNCNAME)                                                           \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(void)                                            \
+	{                                                                                          \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](); \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len -     \
+							 1]();                                     \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake();                                             \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC0(FUNCNAME)                                                                  \
+	DECLARE_FAKE_VOID_FUNC0(FUNCNAME)                                                          \
+	DEFINE_FAKE_VOID_FUNC0(FUNCNAME)
+
+#define DECLARE_FAKE_VOID_FUNC1(FUNCNAME, ARG0_TYPE)                                               \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0);                                               \
+		void (**custom_fake_seq)(ARG0_TYPE arg0);                                          \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0);
+
+#define DEFINE_FAKE_VOID_FUNC1(FUNCNAME, ARG0_TYPE)                                                \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0)                                  \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0);                                             \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0);                                             \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0);                                         \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC1(FUNCNAME, ARG0_TYPE)                                                       \
+	DECLARE_FAKE_VOID_FUNC1(FUNCNAME, ARG0_TYPE)                                               \
+	DEFINE_FAKE_VOID_FUNC1(FUNCNAME, ARG0_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC2(FUNCNAME, ARG0_TYPE, ARG1_TYPE)                                    \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1);                               \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1);                          \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1);
+
+#define DEFINE_FAKE_VOID_FUNC2(FUNCNAME, ARG0_TYPE, ARG1_TYPE)                                     \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1)                  \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1);                                       \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1);                                       \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0, arg1);                                   \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC2(FUNCNAME, ARG0_TYPE, ARG1_TYPE)                                            \
+	DECLARE_FAKE_VOID_FUNC2(FUNCNAME, ARG0_TYPE, ARG1_TYPE)                                    \
+	DEFINE_FAKE_VOID_FUNC2(FUNCNAME, ARG0_TYPE, ARG1_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC3(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE)                         \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2);               \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2);          \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2);
+
+#define DEFINE_FAKE_VOID_FUNC3(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE)                          \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2)  \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2);                                 \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2);                                 \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2);                             \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC3(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE)                                 \
+	DECLARE_FAKE_VOID_FUNC3(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE)                         \
+	DEFINE_FAKE_VOID_FUNC3(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC4(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE)              \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3);                                               \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3);                                          \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3);
+
+#define DEFINE_FAKE_VOID_FUNC4(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE)               \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3)                                  \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3);                           \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3);                           \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3);                       \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC4(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE)                      \
+	DECLARE_FAKE_VOID_FUNC4(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE)              \
+	DEFINE_FAKE_VOID_FUNC4(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC5(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE)   \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4);                               \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4);                          \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4);
+
+#define DEFINE_FAKE_VOID_FUNC5(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE)    \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4)                  \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4);                     \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4);                     \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4);                 \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC5(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE)           \
+	DECLARE_FAKE_VOID_FUNC5(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE)   \
+	DEFINE_FAKE_VOID_FUNC5(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC6(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE)                                                         \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5);               \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5);          \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5);
+
+#define DEFINE_FAKE_VOID_FUNC6(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,    \
+			       ARG5_TYPE)                                                          \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5)  \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5);               \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5);               \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5);           \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC6(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,           \
+			ARG5_TYPE)                                                                 \
+	DECLARE_FAKE_VOID_FUNC6(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE)                                                         \
+	DEFINE_FAKE_VOID_FUNC6(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,    \
+			       ARG5_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC7(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE)                                              \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6);                                               \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6);                                          \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6);
+
+#define DEFINE_FAKE_VOID_FUNC7(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,    \
+			       ARG5_TYPE, ARG6_TYPE)                                               \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6)                                  \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6);         \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6);         \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6);     \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC7(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,           \
+			ARG5_TYPE, ARG6_TYPE)                                                      \
+	DECLARE_FAKE_VOID_FUNC7(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE)                                              \
+	DEFINE_FAKE_VOID_FUNC7(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,    \
+			       ARG5_TYPE, ARG6_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC8(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE)                                   \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7);                               \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7);                          \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7);
+
+#define DEFINE_FAKE_VOID_FUNC8(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,    \
+			       ARG5_TYPE, ARG6_TYPE, ARG7_TYPE)                                    \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7)                  \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);   \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);   \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7);                                         \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC8(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,           \
+			ARG5_TYPE, ARG6_TYPE, ARG7_TYPE)                                           \
+	DECLARE_FAKE_VOID_FUNC8(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE)                                   \
+	DEFINE_FAKE_VOID_FUNC8(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,    \
+			       ARG5_TYPE, ARG6_TYPE, ARG7_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC9(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE)                        \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8);               \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8);          \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8);
+
+#define DEFINE_FAKE_VOID_FUNC9(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,    \
+			       ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE)                         \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8)  \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8);                                             \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8);                                             \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8);                                   \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC9(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,           \
+			ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE)                                \
+	DECLARE_FAKE_VOID_FUNC9(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE)                        \
+	DEFINE_FAKE_VOID_FUNC9(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,    \
+			       ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC10(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE)            \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9);                                               \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9);                                          \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9);
+
+#define DEFINE_FAKE_VOID_FUNC10(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE)             \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9)                                  \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9);                                       \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9);                                       \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9);                             \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC10(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,          \
+			 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE)                    \
+	DECLARE_FAKE_VOID_FUNC10(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE)            \
+	DEFINE_FAKE_VOID_FUNC10(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC11(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE)                                                       \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, ARG10_TYPE arg10);                             \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, ARG10_TYPE arg10);                        \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9, ARG10_TYPE arg10);
+
+#define DEFINE_FAKE_VOID_FUNC11(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE) \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9, ARG10_TYPE arg10)                \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10);                                \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10);                                \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, arg10);                      \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC11(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,          \
+			 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE)        \
+	DECLARE_FAKE_VOID_FUNC11(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE)                                                       \
+	DEFINE_FAKE_VOID_FUNC11(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC12(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE, ARG11_TYPE)                                           \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11);           \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11);      \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9, ARG10_TYPE arg10,                \
+						  ARG11_TYPE arg11);
+
+#define DEFINE_FAKE_VOID_FUNC12(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE)                                                        \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9, ARG10_TYPE arg10,                \
+						  ARG11_TYPE arg11)                                \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11);                         \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11);                         \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, arg10, arg11);               \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC12(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,          \
+			 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE,        \
+			 ARG11_TYPE)                                                               \
+	DECLARE_FAKE_VOID_FUNC12(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE, ARG11_TYPE)                                           \
+	DEFINE_FAKE_VOID_FUNC12(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC13(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE, ARG11_TYPE, ARG12_TYPE)                               \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,            \
+				    ARG12_TYPE arg12);                                             \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,       \
+					 ARG12_TYPE arg12);                                        \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9, ARG10_TYPE arg10,                \
+						  ARG11_TYPE arg11, ARG12_TYPE arg12);
+
+#define DEFINE_FAKE_VOID_FUNC13(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE)                                            \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9, ARG10_TYPE arg10,                \
+						  ARG11_TYPE arg11, ARG12_TYPE arg12)              \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12);                  \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12);                  \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, arg10, arg11, arg12);        \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC13(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,          \
+			 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE,        \
+			 ARG11_TYPE, ARG12_TYPE)                                                   \
+	DECLARE_FAKE_VOID_FUNC13(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE, ARG11_TYPE, ARG12_TYPE)                               \
+	DEFINE_FAKE_VOID_FUNC13(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC14(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE)                   \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,            \
+				    ARG12_TYPE arg12, ARG13_TYPE arg13);                           \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,       \
+					 ARG12_TYPE arg12, ARG13_TYPE arg13);                      \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13);
+
+#define DEFINE_FAKE_VOID_FUNC14(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE)                                \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13)            \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13);           \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13);           \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, arg10, arg11, arg12, arg13); \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC14(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,          \
+			 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE,        \
+			 ARG11_TYPE, ARG12_TYPE, ARG13_TYPE)                                       \
+	DECLARE_FAKE_VOID_FUNC14(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE)                   \
+	DEFINE_FAKE_VOID_FUNC14(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC15(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE)       \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,            \
+				    ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14);         \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,       \
+					 ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14);    \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9, ARG10_TYPE arg10,                \
+						  ARG11_TYPE arg11, ARG12_TYPE arg12,              \
+						  ARG13_TYPE arg13, ARG14_TYPE arg14);
+
+#define DEFINE_FAKE_VOID_FUNC15(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE)                    \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9, ARG10_TYPE arg10,                \
+						  ARG11_TYPE arg11, ARG12_TYPE arg12,              \
+						  ARG13_TYPE arg13, ARG14_TYPE arg14)              \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14);    \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14);    \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, arg10, arg11, arg12, arg13,  \
+						    arg14);                                        \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC15(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,          \
+			 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE,        \
+			 ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE)                           \
+	DECLARE_FAKE_VOID_FUNC15(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE)       \
+	DEFINE_FAKE_VOID_FUNC15(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC16(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE,       \
+				 ARG15_TYPE)                                                       \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,            \
+				    ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,          \
+				    ARG15_TYPE arg15);                                             \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,       \
+					 ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,     \
+					 ARG15_TYPE arg15);                                        \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15);
+
+#define DEFINE_FAKE_VOID_FUNC16(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE)        \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15)                                                \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		SAVE_ARG(FUNCNAME, 15);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 15);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15);                                            \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15);                                            \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, arg10, arg11, arg12, arg13,  \
+						    arg14, arg15);                                 \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC16(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,          \
+			 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE,        \
+			 ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE)               \
+	DECLARE_FAKE_VOID_FUNC16(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE,       \
+				 ARG15_TYPE)                                                       \
+	DEFINE_FAKE_VOID_FUNC16(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC17(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE,       \
+				 ARG15_TYPE, ARG16_TYPE)                                           \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME)                                              \
+		DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,            \
+				    ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,          \
+				    ARG15_TYPE arg15, ARG16_TYPE arg16);                           \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,       \
+					 ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,     \
+					 ARG15_TYPE arg15, ARG16_TYPE arg16);                      \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16);
+
+#define DEFINE_FAKE_VOID_FUNC17(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE,        \
+				ARG16_TYPE)                                                        \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16)                              \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		SAVE_ARG(FUNCNAME, 15);                                                            \
+		SAVE_ARG(FUNCNAME, 16);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 15);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 16);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16);                                     \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16);                                     \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, arg10, arg11, arg12, arg13,  \
+						    arg14, arg15, arg16);                          \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC17(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,          \
+			 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE,        \
+			 ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE)   \
+	DECLARE_FAKE_VOID_FUNC17(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE,       \
+				 ARG15_TYPE, ARG16_TYPE)                                           \
+	DEFINE_FAKE_VOID_FUNC17(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE,        \
+				ARG16_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC18(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE,       \
+				 ARG15_TYPE, ARG16_TYPE, ARG17_TYPE)                               \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME)                                              \
+		DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME)                                              \
+		DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,            \
+				    ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,          \
+				    ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17);         \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,       \
+					 ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,     \
+					 ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17);    \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17);
+
+#define DEFINE_FAKE_VOID_FUNC18(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE,        \
+				ARG16_TYPE, ARG17_TYPE)                                            \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17)            \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		SAVE_ARG(FUNCNAME, 15);                                                            \
+		SAVE_ARG(FUNCNAME, 16);                                                            \
+		SAVE_ARG(FUNCNAME, 17);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 15);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 16);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 17);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16, arg17);                              \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16, arg17);                              \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, arg10, arg11, arg12, arg13,  \
+						    arg14, arg15, arg16, arg17);                   \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC18(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,          \
+			 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE,        \
+			 ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE,   \
+			 ARG17_TYPE)                                                               \
+	DECLARE_FAKE_VOID_FUNC18(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE,       \
+				 ARG15_TYPE, ARG16_TYPE, ARG17_TYPE)                               \
+	DEFINE_FAKE_VOID_FUNC18(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE,        \
+				ARG16_TYPE, ARG17_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC19(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE,       \
+				 ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE)                   \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME)                                              \
+		DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME)                                              \
+		DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME)                                              \
+		DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,            \
+				    ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,          \
+				    ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,          \
+				    ARG18_TYPE arg18);                                             \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,       \
+					 ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,     \
+					 ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,     \
+					 ARG18_TYPE arg18);                                        \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,            \
+		ARG18_TYPE arg18);
+
+#define DEFINE_FAKE_VOID_FUNC19(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE,        \
+				ARG16_TYPE, ARG17_TYPE, ARG18_TYPE)                                \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,            \
+		ARG18_TYPE arg18)                                                                  \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		SAVE_ARG(FUNCNAME, 15);                                                            \
+		SAVE_ARG(FUNCNAME, 16);                                                            \
+		SAVE_ARG(FUNCNAME, 17);                                                            \
+		SAVE_ARG(FUNCNAME, 18);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 15);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 16);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 17);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 18);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16, arg17, arg18);                       \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16, arg17, arg18);                       \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, arg10, arg11, arg12, arg13,  \
+						    arg14, arg15, arg16, arg17, arg18);            \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC19(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,          \
+			 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE,        \
+			 ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE,   \
+			 ARG17_TYPE, ARG18_TYPE)                                                   \
+	DECLARE_FAKE_VOID_FUNC19(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE,       \
+				 ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE)                   \
+	DEFINE_FAKE_VOID_FUNC19(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE,        \
+				ARG16_TYPE, ARG17_TYPE, ARG18_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC20(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE,       \
+				 ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ARG19_TYPE)       \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME)                                              \
+		DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME)                                              \
+		DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME)                                              \
+		DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME)                                              \
+		DECLARE_ARG(ARG19_TYPE, 19, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,            \
+				    ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,          \
+				    ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,          \
+				    ARG18_TYPE arg18, ARG19_TYPE arg19);                           \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,       \
+					 ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,     \
+					 ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,     \
+					 ARG18_TYPE arg18, ARG19_TYPE arg19);                      \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,            \
+		ARG18_TYPE arg18, ARG19_TYPE arg19);
+
+#define DEFINE_FAKE_VOID_FUNC20(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE,        \
+				ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ARG19_TYPE)                    \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,            \
+		ARG18_TYPE arg18, ARG19_TYPE arg19)                                                \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		SAVE_ARG(FUNCNAME, 15);                                                            \
+		SAVE_ARG(FUNCNAME, 16);                                                            \
+		SAVE_ARG(FUNCNAME, 17);                                                            \
+		SAVE_ARG(FUNCNAME, 18);                                                            \
+		SAVE_ARG(FUNCNAME, 19);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 15);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 16);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 17);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 18);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 19);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16, arg17, arg18, arg19);                \
+			} else {                                                                   \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16, arg17, arg18, arg19);                \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, arg10, arg11, arg12, arg13,  \
+						    arg14, arg15, arg16, arg17, arg18, arg19);     \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC20(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,          \
+			 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE,        \
+			 ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE,   \
+			 ARG17_TYPE, ARG18_TYPE, ARG19_TYPE)                                       \
+	DECLARE_FAKE_VOID_FUNC20(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,  \
+				 ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,            \
+				 ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE,       \
+				 ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ARG19_TYPE)       \
+	DEFINE_FAKE_VOID_FUNC20(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE,        \
+				ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ARG19_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC0(RETURN_TYPE, FUNCNAME)                                            \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)(void);                                                  \
+		RETURN_TYPE (**custom_fake_seq)(void);                                             \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(void);
+
+#define DEFINE_FAKE_VALUE_FUNC0(RETURN_TYPE, FUNCNAME)                                             \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(void)                                     \
+	{                                                                                          \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++]();         \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1]();       \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len -     \
+							 1]();                                     \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret = FUNCNAME##_fake.custom_fake();                           \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake();                                      \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC0(RETURN_TYPE, FUNCNAME)                                                    \
+	DECLARE_FAKE_VALUE_FUNC0(RETURN_TYPE, FUNCNAME)                                            \
+	DEFINE_FAKE_VALUE_FUNC0(RETURN_TYPE, FUNCNAME)
+
+#define DECLARE_FAKE_VALUE_FUNC1(RETURN_TYPE, FUNCNAME, ARG0_TYPE)                                 \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)(ARG0_TYPE arg0);                                        \
+		RETURN_TYPE (**custom_fake_seq)(ARG0_TYPE arg0);                                   \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0);
+
+#define DEFINE_FAKE_VALUE_FUNC1(RETURN_TYPE, FUNCNAME, ARG0_TYPE)                                  \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0)                           \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](arg0);     \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](arg0);   \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0);                                             \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0);                       \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0);                                  \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC1(RETURN_TYPE, FUNCNAME, ARG0_TYPE)                                         \
+	DECLARE_FAKE_VALUE_FUNC1(RETURN_TYPE, FUNCNAME, ARG0_TYPE)                                 \
+	DEFINE_FAKE_VALUE_FUNC1(RETURN_TYPE, FUNCNAME, ARG0_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC2(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE)                      \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1);                        \
+		RETURN_TYPE (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1);                   \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1);
+
+#define DEFINE_FAKE_VALUE_FUNC2(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE)                       \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1)           \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq                  \
+							  [FUNCNAME##_fake.custom_fake_seq_idx++]( \
+								  arg0, arg1);                     \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](arg0,    \
+											  arg1);   \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1);                                       \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1);                 \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0, arg1);                            \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC2(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE)                              \
+	DECLARE_FAKE_VALUE_FUNC2(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE)                      \
+	DEFINE_FAKE_VALUE_FUNC2(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC3(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE)           \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2);        \
+		RETURN_TYPE (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2);   \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2);
+
+#define DEFINE_FAKE_VALUE_FUNC3(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE)            \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2)                           \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq                  \
+							  [FUNCNAME##_fake.custom_fake_seq_idx++]( \
+								  arg0, arg1, arg2);               \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2);                         \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2);                                 \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2);           \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2);                      \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC3(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE)                   \
+	DECLARE_FAKE_VALUE_FUNC3(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE)           \
+	DEFINE_FAKE_VALUE_FUNC3(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC4(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE)                                                        \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3);                  \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3);                  \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3);
+
+#define DEFINE_FAKE_VALUE_FUNC4(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE) \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3)           \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq                  \
+							  [FUNCNAME##_fake.custom_fake_seq_idx++]( \
+								  arg0, arg1, arg2, arg3);         \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3);                   \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3);                           \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3);     \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3);                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC4(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE)        \
+	DECLARE_FAKE_VALUE_FUNC4(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE)                                                        \
+	DEFINE_FAKE_VALUE_FUNC4(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC5(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE)                                             \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4);  \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4);  \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4);
+
+#define DEFINE_FAKE_VALUE_FUNC5(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, \
+				ARG4_TYPE)                                                         \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4)    \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq                  \
+							  [FUNCNAME##_fake.custom_fake_seq_idx++]( \
+								  arg0, arg1, arg2, arg3, arg4);   \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4);             \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4);                     \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret =                                                          \
+				FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4);         \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4);          \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC5(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,        \
+			 ARG4_TYPE)                                                                \
+	DECLARE_FAKE_VALUE_FUNC5(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE)                                             \
+	DEFINE_FAKE_VALUE_FUNC5(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, \
+				ARG4_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC6(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE)                                  \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5);                                                                  \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5);                                                                  \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3,           \
+							 ARG4_TYPE arg4, ARG5_TYPE arg5);
+
+#define DEFINE_FAKE_VALUE_FUNC6(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, \
+				ARG4_TYPE, ARG5_TYPE)                                              \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3,           \
+							 ARG4_TYPE arg4, ARG5_TYPE arg5)           \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5);       \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5);       \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5);               \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret =                                                          \
+				FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5);   \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5);    \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC6(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,        \
+			 ARG4_TYPE, ARG5_TYPE)                                                     \
+	DECLARE_FAKE_VALUE_FUNC6(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE)                                  \
+	DEFINE_FAKE_VALUE_FUNC6(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, \
+				ARG4_TYPE, ARG5_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC7(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE)                       \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6);                                                  \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6);                                                  \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3,           \
+							 ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+							 ARG6_TYPE arg6);
+
+#define DEFINE_FAKE_VALUE_FUNC7(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, \
+				ARG4_TYPE, ARG5_TYPE, ARG6_TYPE)                                   \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3,           \
+							 ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+							 ARG6_TYPE arg6)                           \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6); \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6);         \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3,      \
+								      arg4, arg5, arg6);           \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,     \
+							   arg6);                                  \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC7(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,        \
+			 ARG4_TYPE, ARG5_TYPE, ARG6_TYPE)                                          \
+	DECLARE_FAKE_VALUE_FUNC7(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE)                       \
+	DEFINE_FAKE_VALUE_FUNC7(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, \
+				ARG4_TYPE, ARG5_TYPE, ARG6_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC8(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE)            \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7);                                  \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7);                                  \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3,           \
+							 ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+							 ARG6_TYPE arg6, ARG7_TYPE arg7);
+
+#define DEFINE_FAKE_VALUE_FUNC8(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, \
+				ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE)                        \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3,           \
+							 ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+							 ARG6_TYPE arg6, ARG7_TYPE arg7)           \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq                  \
+							  [FUNCNAME##_fake.custom_fake_seq_idx++]( \
+								  arg0, arg1, arg2, arg3, arg4,    \
+								  arg5, arg6, arg7);               \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7);                                     \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);   \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3,      \
+								      arg4, arg5, arg6, arg7);     \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,     \
+							   arg6, arg7);                            \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC8(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,        \
+			 ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE)                               \
+	DECLARE_FAKE_VALUE_FUNC8(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE)            \
+	DEFINE_FAKE_VALUE_FUNC8(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, \
+				ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC9(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE) \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8);                  \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8);                  \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8);
+
+#define DEFINE_FAKE_VALUE_FUNC9(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, \
+				ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE)             \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8)                    \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq                  \
+							  [FUNCNAME##_fake.custom_fake_seq_idx++]( \
+								  arg0, arg1, arg2, arg3, arg4,    \
+								  arg5, arg6, arg7, arg8);         \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8);                               \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8);                                             \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(                             \
+				arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);             \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,     \
+							   arg6, arg7, arg8);                      \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC9(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,        \
+			 ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE)                    \
+	DECLARE_FAKE_VALUE_FUNC9(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE) \
+	DEFINE_FAKE_VALUE_FUNC9(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, \
+				ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC10(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE)                                            \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9);  \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9);  \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9);
+
+#define DEFINE_FAKE_VALUE_FUNC10(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE)                                                        \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9)    \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq                  \
+							  [FUNCNAME##_fake.custom_fake_seq_idx++]( \
+								  arg0, arg1, arg2, arg3, arg4,    \
+								  arg5, arg6, arg7, arg8, arg9);   \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9);                         \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9);                                       \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(                             \
+				arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);       \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,     \
+							   arg6, arg7, arg8, arg9);                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC10(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+			  ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE)        \
+	DECLARE_FAKE_VALUE_FUNC10(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE)                                            \
+	DEFINE_FAKE_VALUE_FUNC10(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC11(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE)                                \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10);                                                                \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10);                                                                \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10);
+
+#define DEFINE_FAKE_VALUE_FUNC11(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE)                                            \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10)                                                                  \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10);                  \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10);                  \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10);                                \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret =                                                          \
+				FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,    \
+							    arg6, arg7, arg8, arg9, arg10);        \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,     \
+							   arg6, arg7, arg8, arg9, arg10);         \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC11(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+			  ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,        \
+			  ARG10_TYPE)                                                              \
+	DECLARE_FAKE_VALUE_FUNC11(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE)                                \
+	DEFINE_FAKE_VALUE_FUNC11(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC12(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE)                    \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11);                                              \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11);                                              \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11);
+
+#define DEFINE_FAKE_VALUE_FUNC12(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE)                                \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11)                                                \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11);           \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11);           \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11);                         \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret =                                                          \
+				FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,    \
+							    arg6, arg7, arg8, arg9, arg10, arg11); \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,     \
+							   arg6, arg7, arg8, arg9, arg10, arg11);  \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC12(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+			  ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,        \
+			  ARG10_TYPE, ARG11_TYPE)                                                  \
+	DECLARE_FAKE_VALUE_FUNC12(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE)                    \
+	DEFINE_FAKE_VALUE_FUNC12(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC13(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE)        \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12);                            \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12);                            \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12);
+
+#define DEFINE_FAKE_VALUE_FUNC13(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE)                    \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12)                              \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12);    \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12);    \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12);                  \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret =                                                          \
+				FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,    \
+							    arg6, arg7, arg8, arg9, arg10, arg11,  \
+							    arg12);                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,     \
+							   arg6, arg7, arg8, arg9, arg10, arg11,   \
+							   arg12);                                 \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC13(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+			  ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,        \
+			  ARG10_TYPE, ARG11_TYPE, ARG12_TYPE)                                      \
+	DECLARE_FAKE_VALUE_FUNC13(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE)        \
+	DEFINE_FAKE_VALUE_FUNC13(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC14(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,        \
+				  ARG13_TYPE)                                                      \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13);          \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13);          \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13);
+
+#define DEFINE_FAKE_VALUE_FUNC14(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE)        \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13)            \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq                  \
+							  [FUNCNAME##_fake.custom_fake_seq_idx++]( \
+								  arg0, arg1, arg2, arg3, arg4,    \
+								  arg5, arg6, arg7, arg8, arg9,    \
+								  arg10, arg11, arg12, arg13);     \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13);                                    \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13);           \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret =                                                          \
+				FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,    \
+							    arg6, arg7, arg8, arg9, arg10, arg11,  \
+							    arg12, arg13);                         \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,     \
+							   arg6, arg7, arg8, arg9, arg10, arg11,   \
+							   arg12, arg13);                          \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC14(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+			  ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,        \
+			  ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE)                          \
+	DECLARE_FAKE_VALUE_FUNC14(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,        \
+				  ARG13_TYPE)                                                      \
+	DEFINE_FAKE_VALUE_FUNC14(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC15(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,        \
+				  ARG13_TYPE, ARG14_TYPE)                                          \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14);                                                                \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14);                                                                \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14);
+
+#define DEFINE_FAKE_VALUE_FUNC15(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,        \
+				 ARG14_TYPE)                                                       \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14)                                                                  \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14);                             \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14);                             \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14);    \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret =                                                          \
+				FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,    \
+							    arg6, arg7, arg8, arg9, arg10, arg11,  \
+							    arg12, arg13, arg14);                  \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,     \
+							   arg6, arg7, arg8, arg9, arg10, arg11,   \
+							   arg12, arg13, arg14);                   \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC15(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+			  ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,        \
+			  ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE)              \
+	DECLARE_FAKE_VALUE_FUNC15(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,        \
+				  ARG13_TYPE, ARG14_TYPE)                                          \
+	DEFINE_FAKE_VALUE_FUNC15(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,        \
+				 ARG14_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC16(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,        \
+				  ARG13_TYPE, ARG14_TYPE, ARG15_TYPE)                              \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, ARG15_TYPE arg15);                                              \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, ARG15_TYPE arg15);                                              \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15);
+
+#define DEFINE_FAKE_VALUE_FUNC16(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,        \
+				 ARG14_TYPE, ARG15_TYPE)                                           \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15)                                                \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		SAVE_ARG(FUNCNAME, 15);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 15);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, arg15);                      \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, arg15);                      \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15);                                            \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret =                                                          \
+				FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,    \
+							    arg6, arg7, arg8, arg9, arg10, arg11,  \
+							    arg12, arg13, arg14, arg15);           \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,     \
+							   arg6, arg7, arg8, arg9, arg10, arg11,   \
+							   arg12, arg13, arg14, arg15);            \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC16(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+			  ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,        \
+			  ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE)  \
+	DECLARE_FAKE_VALUE_FUNC16(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,        \
+				  ARG13_TYPE, ARG14_TYPE, ARG15_TYPE)                              \
+	DEFINE_FAKE_VALUE_FUNC16(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,        \
+				 ARG14_TYPE, ARG15_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC17(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,        \
+				  ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE)                  \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME)                                              \
+		DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16);                            \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16);                            \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16);
+
+#define DEFINE_FAKE_VALUE_FUNC17(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,        \
+				 ARG14_TYPE, ARG15_TYPE, ARG16_TYPE)                               \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16)                              \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		SAVE_ARG(FUNCNAME, 15);                                                            \
+		SAVE_ARG(FUNCNAME, 16);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 15);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 16);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, arg15, arg16);               \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, arg15, arg16);               \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16);                                     \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret =                                                          \
+				FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,    \
+							    arg6, arg7, arg8, arg9, arg10, arg11,  \
+							    arg12, arg13, arg14, arg15, arg16);    \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,     \
+							   arg6, arg7, arg8, arg9, arg10, arg11,   \
+							   arg12, arg13, arg14, arg15, arg16);     \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC17(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+			  ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,        \
+			  ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE,  \
+			  ARG16_TYPE)                                                              \
+	DECLARE_FAKE_VALUE_FUNC17(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,        \
+				  ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE)                  \
+	DEFINE_FAKE_VALUE_FUNC17(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,        \
+				 ARG14_TYPE, ARG15_TYPE, ARG16_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC18(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,        \
+				  ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE)      \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME)                                              \
+		DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME)                                              \
+		DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17);          \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17);          \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17);
+
+#define DEFINE_FAKE_VALUE_FUNC18(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,        \
+				 ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE)                   \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17)            \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		SAVE_ARG(FUNCNAME, 15);                                                            \
+		SAVE_ARG(FUNCNAME, 16);                                                            \
+		SAVE_ARG(FUNCNAME, 17);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 15);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 16);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 17);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, arg15, arg16, arg17);        \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, arg15, arg16, arg17);        \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16, arg17);                              \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(                             \
+				arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, \
+				arg11, arg12, arg13, arg14, arg15, arg16, arg17);                  \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,     \
+							   arg6, arg7, arg8, arg9, arg10, arg11,   \
+							   arg12, arg13, arg14, arg15, arg16,      \
+							   arg17);                                 \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC18(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+			  ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,        \
+			  ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE,  \
+			  ARG16_TYPE, ARG17_TYPE)                                                  \
+	DECLARE_FAKE_VALUE_FUNC18(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,        \
+				  ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE)      \
+	DEFINE_FAKE_VALUE_FUNC18(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,        \
+				 ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC19(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,        \
+				  ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE,      \
+				  ARG18_TYPE)                                                      \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME)                                              \
+		DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME)                                              \
+		DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME)                                              \
+		DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,           \
+		 ARG18_TYPE arg18);                                                                \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,           \
+		 ARG18_TYPE arg18);                                                                \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,            \
+		ARG18_TYPE arg18);
+
+#define DEFINE_FAKE_VALUE_FUNC19(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,        \
+				 ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE)       \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,            \
+		ARG18_TYPE arg18)                                                                  \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		SAVE_ARG(FUNCNAME, 15);                                                            \
+		SAVE_ARG(FUNCNAME, 16);                                                            \
+		SAVE_ARG(FUNCNAME, 17);                                                            \
+		SAVE_ARG(FUNCNAME, 18);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 15);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 16);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 17);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 18);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, arg15, arg16, arg17, arg18); \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, arg15, arg16, arg17, arg18); \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16, arg17, arg18);                       \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(                             \
+				arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, \
+				arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18);           \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,     \
+							   arg6, arg7, arg8, arg9, arg10, arg11,   \
+							   arg12, arg13, arg14, arg15, arg16,      \
+							   arg17, arg18);                          \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC19(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+			  ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,        \
+			  ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE,  \
+			  ARG16_TYPE, ARG17_TYPE, ARG18_TYPE)                                      \
+	DECLARE_FAKE_VALUE_FUNC19(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,        \
+				  ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE,      \
+				  ARG18_TYPE)                                                      \
+	DEFINE_FAKE_VALUE_FUNC19(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,        \
+				 ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE)
+
+#define DECLARE_FAKE_VALUE_FUNC20(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,        \
+				  ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE,      \
+				  ARG18_TYPE, ARG19_TYPE)                                          \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME)                                              \
+		DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME)                                              \
+		DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME)                                              \
+		DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME)                                              \
+		DECLARE_ARG(ARG19_TYPE, 19, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,           \
+		 ARG18_TYPE arg18, ARG19_TYPE arg19);                                              \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,           \
+		 ARG18_TYPE arg18, ARG19_TYPE arg19);                                              \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,            \
+		ARG18_TYPE arg18, ARG19_TYPE arg19);
+
+#define DEFINE_FAKE_VALUE_FUNC20(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,        \
+				 ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE,       \
+				 ARG19_TYPE)                                                       \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,            \
+		ARG18_TYPE arg18, ARG19_TYPE arg19)                                                \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		SAVE_ARG(FUNCNAME, 15);                                                            \
+		SAVE_ARG(FUNCNAME, 16);                                                            \
+		SAVE_ARG(FUNCNAME, 17);                                                            \
+		SAVE_ARG(FUNCNAME, 18);                                                            \
+		SAVE_ARG(FUNCNAME, 19);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 15);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 16);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 17);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 18);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 19);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, arg15, arg16, arg17, arg18,  \
+							arg19);                                    \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+			} else {                                                                   \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, arg15, arg16, arg17, arg18,  \
+							arg19);                                    \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16, arg17, arg18, arg19);                \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret = FUNCNAME##_fake.custom_fake(                             \
+				arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, \
+				arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19);    \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+			return FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,     \
+							   arg6, arg7, arg8, arg9, arg10, arg11,   \
+							   arg12, arg13, arg14, arg15, arg16,      \
+							   arg17, arg18, arg19);                   \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC20(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+			  ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE,        \
+			  ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE,  \
+			  ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ARG19_TYPE)                          \
+	DECLARE_FAKE_VALUE_FUNC20(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,          \
+				  ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,           \
+				  ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,        \
+				  ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE,      \
+				  ARG18_TYPE, ARG19_TYPE)                                          \
+	DEFINE_FAKE_VALUE_FUNC20(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,        \
+				 ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE,       \
+				 ARG19_TYPE)
+
+#define DECLARE_FAKE_VOID_FUNC2_VARARG(FUNCNAME, ARG0_TYPE, ...)                                   \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, va_list ap);                                   \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, va_list ap);                              \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ...);
+
+#define DEFINE_FAKE_VOID_FUNC2_VARARG(FUNCNAME, ARG0_TYPE, ...)                                    \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ...)                             \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg0);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, ap);                                         \
+				va_end(ap);                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg0);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, ap);                                         \
+				va_end(ap);                                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			va_list ap;                                                                \
+			va_start(ap, arg0);                                                        \
+			FUNCNAME##_fake.custom_fake(arg0, ap);                                     \
+			va_end(ap);                                                                \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC2_VARARG(FUNCNAME, ARG0_TYPE, ...)                                           \
+	DECLARE_FAKE_VOID_FUNC2_VARARG(FUNCNAME, ARG0_TYPE, ...)                                   \
+	DEFINE_FAKE_VOID_FUNC2_VARARG(FUNCNAME, ARG0_TYPE, ...)
+
+#define DECLARE_FAKE_VOID_FUNC3_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...)                        \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, va_list ap);                   \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, va_list ap);              \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ...);
+
+#define DEFINE_FAKE_VOID_FUNC3_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...)                         \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ...)             \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg1);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, ap);                                   \
+				va_end(ap);                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg1);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, ap);                                   \
+				va_end(ap);                                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			va_list ap;                                                                \
+			va_start(ap, arg1);                                                        \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, ap);                               \
+			va_end(ap);                                                                \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC3_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...)                                \
+	DECLARE_FAKE_VOID_FUNC3_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...)                        \
+	DEFINE_FAKE_VOID_FUNC3_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...)
+
+#define DECLARE_FAKE_VOID_FUNC4_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ...)             \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, va_list ap);   \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 va_list ap);                                              \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ...);
+
+#define DEFINE_FAKE_VOID_FUNC4_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ...)              \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ...)                                             \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg2);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, ap);                             \
+				va_end(ap);                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg2);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, ap);                             \
+				va_end(ap);                                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			va_list ap;                                                                \
+			va_start(ap, arg2);                                                        \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, ap);                         \
+			va_end(ap);                                                                \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC4_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ...)                     \
+	DECLARE_FAKE_VOID_FUNC4_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ...)             \
+	DEFINE_FAKE_VOID_FUNC4_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ...)
+
+#define DECLARE_FAKE_VOID_FUNC5_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ...)  \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, va_list ap);                                   \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, va_list ap);                              \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ...);
+
+#define DEFINE_FAKE_VOID_FUNC5_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ...)   \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ...)                             \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg3);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, ap);                       \
+				va_end(ap);                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg3);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, ap);                       \
+				va_end(ap);                                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			va_list ap;                                                                \
+			va_start(ap, arg3);                                                        \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, ap);                   \
+			va_end(ap);                                                                \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC5_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ...)          \
+	DECLARE_FAKE_VOID_FUNC5_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ...)  \
+	DEFINE_FAKE_VOID_FUNC5_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ...)
+
+#define DECLARE_FAKE_VOID_FUNC6_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ...)                                             \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, va_list ap);                   \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, va_list ap);              \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ...);
+
+#define DEFINE_FAKE_VOID_FUNC6_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,        \
+				      ARG4_TYPE, ...)                                              \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ...)             \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg4);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, ap);                 \
+				va_end(ap);                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg4);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, ap);                 \
+				va_end(ap);                                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			va_list ap;                                                                \
+			va_start(ap, arg4);                                                        \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, ap);             \
+			va_end(ap);                                                                \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC6_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,    \
+			       ...)                                                                \
+	DECLARE_FAKE_VOID_FUNC6_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ...)                                             \
+	DEFINE_FAKE_VOID_FUNC6_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,        \
+				      ARG4_TYPE, ...)
+
+#define DECLARE_FAKE_VOID_FUNC7_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ...)                                  \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5, va_list ap);   \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 va_list ap);                                              \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ...);
+
+#define DEFINE_FAKE_VOID_FUNC7_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,        \
+				      ARG4_TYPE, ARG5_TYPE, ...)                                   \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ...)                                             \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg5);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, ap);           \
+				va_end(ap);                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg5);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, ap);           \
+				va_end(ap);                                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			va_list ap;                                                                \
+			va_start(ap, arg5);                                                        \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, ap);       \
+			va_end(ap);                                                                \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC7_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,    \
+			       ARG5_TYPE, ...)                                                     \
+	DECLARE_FAKE_VOID_FUNC7_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ...)                                  \
+	DEFINE_FAKE_VOID_FUNC7_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,        \
+				      ARG4_TYPE, ARG5_TYPE, ...)
+
+#define DECLARE_FAKE_VOID_FUNC8_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ...)                       \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, va_list ap);                                   \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, va_list ap);                              \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ...);
+
+#define DEFINE_FAKE_VOID_FUNC8_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,        \
+				      ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ...)                        \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ...)                             \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg6);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, ap);     \
+				va_end(ap);                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg6);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, ap);     \
+				va_end(ap);                                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			va_list ap;                                                                \
+			va_start(ap, arg6);                                                        \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6, ap); \
+			va_end(ap);                                                                \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC8_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,    \
+			       ARG5_TYPE, ARG6_TYPE, ...)                                          \
+	DECLARE_FAKE_VOID_FUNC8_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ...)                       \
+	DEFINE_FAKE_VOID_FUNC8_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,        \
+				      ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ...)
+
+#define DECLARE_FAKE_VOID_FUNC9_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ...)            \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, va_list ap);                   \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, va_list ap);              \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ...);
+
+#define DEFINE_FAKE_VOID_FUNC9_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,        \
+				      ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ...)             \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ...)             \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg7);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						ap);                                               \
+				va_end(ap);                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg7);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						ap);                                               \
+				va_end(ap);                                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			va_list ap;                                                                \
+			va_start(ap, arg7);                                                        \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, ap);                                     \
+			va_end(ap);                                                                \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC9_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,    \
+			       ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ...)                               \
+	DECLARE_FAKE_VOID_FUNC9_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ...)            \
+	DEFINE_FAKE_VOID_FUNC9_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,        \
+				      ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ...)
+
+#define DECLARE_FAKE_VOID_FUNC10_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					...)                                                       \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, va_list ap);   \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 va_list ap);                                              \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ...);
+
+#define DEFINE_FAKE_VOID_FUNC10_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ...) \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ...)                                             \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg8);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, ap);                                         \
+				va_end(ap);                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg8);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, ap);                                         \
+				va_end(ap);                                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			va_list ap;                                                                \
+			va_start(ap, arg8);                                                        \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, ap);                               \
+			va_end(ap);                                                                \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC10_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ...)                   \
+	DECLARE_FAKE_VOID_FUNC10_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					...)                                                       \
+	DEFINE_FAKE_VOID_FUNC10_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ...)
+
+#define DECLARE_FAKE_VOID_FUNC11_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ...)                                            \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, va_list ap);                                   \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, va_list ap);                              \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9, ...);
+
+#define DEFINE_FAKE_VOID_FUNC11_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ...)                                             \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9, ...)                             \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg9);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, ap);                                   \
+				va_end(ap);                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg9);                                                \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, ap);                                   \
+				va_end(ap);                                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			va_list ap;                                                                \
+			va_start(ap, arg9);                                                        \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, ap);                         \
+			va_end(ap);                                                                \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC11_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ...)        \
+	DECLARE_FAKE_VOID_FUNC11_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ...)                                            \
+	DEFINE_FAKE_VOID_FUNC11_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ...)
+
+#define DECLARE_FAKE_VOID_FUNC12_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ARG10_TYPE, ...)                                \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, ARG10_TYPE arg10, va_list ap);                 \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, ARG10_TYPE arg10, va_list ap);            \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9, ARG10_TYPE arg10, ...);
+
+#define DEFINE_FAKE_VOID_FUNC12_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ARG10_TYPE, ...)                                 \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9, ARG10_TYPE arg10, ...)           \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg10);                                               \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, ap);                            \
+				va_end(ap);                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg10);                                               \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, ap);                            \
+				va_end(ap);                                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			va_list ap;                                                                \
+			va_start(ap, arg10);                                                       \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, arg10, ap);                  \
+			va_end(ap);                                                                \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC12_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				...)                                                               \
+	DECLARE_FAKE_VOID_FUNC12_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ARG10_TYPE, ...)                                \
+	DEFINE_FAKE_VOID_FUNC12_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ARG10_TYPE, ...)
+
+#define DECLARE_FAKE_VOID_FUNC13_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ...)                    \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,            \
+				    va_list ap);                                                   \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,       \
+					 va_list ap);                                              \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9, ARG10_TYPE arg10,                \
+						  ARG11_TYPE arg11, ...);
+
+#define DEFINE_FAKE_VOID_FUNC13_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ...)                     \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9, ARG10_TYPE arg10,                \
+						  ARG11_TYPE arg11, ...)                           \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg11);                                               \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, ap);                     \
+				va_end(ap);                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg11);                                               \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, ap);                     \
+				va_end(ap);                                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			va_list ap;                                                                \
+			va_start(ap, arg11);                                                       \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, arg10, arg11, ap);           \
+			va_end(ap);                                                                \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC13_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ...)                                                   \
+	DECLARE_FAKE_VOID_FUNC13_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ...)                    \
+	DEFINE_FAKE_VOID_FUNC13_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ...)
+
+#define DECLARE_FAKE_VOID_FUNC14_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ...)        \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,            \
+				    ARG12_TYPE arg12, va_list ap);                                 \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,       \
+					 ARG12_TYPE arg12, va_list ap);                            \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9, ARG10_TYPE arg10,                \
+						  ARG11_TYPE arg11, ARG12_TYPE arg12, ...);
+
+#define DEFINE_FAKE_VOID_FUNC14_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ...)         \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9, ARG10_TYPE arg10,                \
+						  ARG11_TYPE arg11, ARG12_TYPE arg12, ...)         \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg12);                                               \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, ap);              \
+				va_end(ap);                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg12);                                               \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, ap);              \
+				va_end(ap);                                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			va_list ap;                                                                \
+			va_start(ap, arg12);                                                       \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, arg10, arg11, arg12, ap);    \
+			va_end(ap);                                                                \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC14_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ...)                                       \
+	DECLARE_FAKE_VOID_FUNC14_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ...)        \
+	DEFINE_FAKE_VOID_FUNC14_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ...)
+
+#define DECLARE_FAKE_VOID_FUNC15_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, \
+					...)                                                       \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,            \
+				    ARG12_TYPE arg12, ARG13_TYPE arg13, va_list ap);               \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,       \
+					 ARG12_TYPE arg12, ARG13_TYPE arg13, va_list ap);          \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ...);
+
+#define DEFINE_FAKE_VOID_FUNC15_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,  \
+				       ...)                                                        \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ...)       \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg13);                                               \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, ap);       \
+				va_end(ap);                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg13);                                               \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, ap);       \
+				va_end(ap);                                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			va_list ap;                                                                \
+			va_start(ap, arg13);                                                       \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, arg10, arg11, arg12, arg13,  \
+						    ap);                                           \
+			va_end(ap);                                                                \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC15_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ...)                           \
+	DECLARE_FAKE_VOID_FUNC15_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, \
+					...)                                                       \
+	DEFINE_FAKE_VOID_FUNC15_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,  \
+				       ...)
+
+#define DECLARE_FAKE_VOID_FUNC16_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, \
+					ARG14_TYPE, ...)                                           \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,            \
+				    ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,          \
+				    va_list ap);                                                   \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,       \
+					 ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,     \
+					 va_list ap);                                              \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9, ARG10_TYPE arg10,                \
+						  ARG11_TYPE arg11, ARG12_TYPE arg12,              \
+						  ARG13_TYPE arg13, ARG14_TYPE arg14, ...);
+
+#define DEFINE_FAKE_VOID_FUNC16_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,  \
+				       ARG14_TYPE, ...)                                            \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,  \
+						  ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,  \
+						  ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,  \
+						  ARG9_TYPE arg9, ARG10_TYPE arg10,                \
+						  ARG11_TYPE arg11, ARG12_TYPE arg12,              \
+						  ARG13_TYPE arg13, ARG14_TYPE arg14, ...)         \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg14);                                               \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						ap);                                               \
+				va_end(ap);                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg14);                                               \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						ap);                                               \
+				va_end(ap);                                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			va_list ap;                                                                \
+			va_start(ap, arg14);                                                       \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, arg10, arg11, arg12, arg13,  \
+						    arg14, ap);                                    \
+			va_end(ap);                                                                \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC16_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ...)               \
+	DECLARE_FAKE_VOID_FUNC16_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, \
+					ARG14_TYPE, ...)                                           \
+	DEFINE_FAKE_VOID_FUNC16_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,  \
+				       ARG14_TYPE, ...)
+
+#define DECLARE_FAKE_VOID_FUNC17_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, \
+					ARG14_TYPE, ARG15_TYPE, ...)                               \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,            \
+				    ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,          \
+				    ARG15_TYPE arg15, va_list ap);                                 \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,       \
+					 ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,     \
+					 ARG15_TYPE arg15, va_list ap);                            \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ...);
+
+#define DEFINE_FAKE_VOID_FUNC17_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,  \
+				       ARG14_TYPE, ARG15_TYPE, ...)                                \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ...)                                           \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		SAVE_ARG(FUNCNAME, 15);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 15);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg15);                                               \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, ap);                                        \
+				va_end(ap);                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg15);                                               \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, ap);                                        \
+				va_end(ap);                                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			va_list ap;                                                                \
+			va_start(ap, arg15);                                                       \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, arg10, arg11, arg12, arg13,  \
+						    arg14, arg15, ap);                             \
+			va_end(ap);                                                                \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC17_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ...)   \
+	DECLARE_FAKE_VOID_FUNC17_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, \
+					ARG14_TYPE, ARG15_TYPE, ...)                               \
+	DEFINE_FAKE_VOID_FUNC17_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,  \
+				       ARG14_TYPE, ARG15_TYPE, ...)
+
+#define DECLARE_FAKE_VOID_FUNC18_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, \
+					ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ...)                   \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME)                                              \
+		DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,            \
+				    ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,          \
+				    ARG15_TYPE arg15, ARG16_TYPE arg16, va_list ap);               \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,       \
+					 ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,     \
+					 ARG15_TYPE arg15, ARG16_TYPE arg16, va_list ap);          \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ...);
+
+#define DEFINE_FAKE_VOID_FUNC18_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,  \
+				       ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ...)                    \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ...)                         \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		SAVE_ARG(FUNCNAME, 15);                                                            \
+		SAVE_ARG(FUNCNAME, 16);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 15);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 16);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg16);                                               \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16, ap);                                 \
+				va_end(ap);                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg16);                                               \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16, ap);                                 \
+				va_end(ap);                                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			va_list ap;                                                                \
+			va_start(ap, arg16);                                                       \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, arg10, arg11, arg12, arg13,  \
+						    arg14, arg15, arg16, ap);                      \
+			va_end(ap);                                                                \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC18_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE,        \
+				ARG16_TYPE, ...)                                                   \
+	DECLARE_FAKE_VOID_FUNC18_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, \
+					ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ...)                   \
+	DEFINE_FAKE_VOID_FUNC18_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,  \
+				       ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ...)
+
+#define DECLARE_FAKE_VOID_FUNC19_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, \
+					ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ...)       \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME)                                              \
+		DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME)                                              \
+		DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,            \
+				    ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,          \
+				    ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,          \
+				    va_list ap);                                                   \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,       \
+					 ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,     \
+					 ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,     \
+					 va_list ap);                                              \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ...);
+
+#define DEFINE_FAKE_VOID_FUNC19_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,  \
+				       ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ...)        \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ...)       \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		SAVE_ARG(FUNCNAME, 15);                                                            \
+		SAVE_ARG(FUNCNAME, 16);                                                            \
+		SAVE_ARG(FUNCNAME, 17);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 15);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 16);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 17);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg17);                                               \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16, arg17, ap);                          \
+				va_end(ap);                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg17);                                               \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16, arg17, ap);                          \
+				va_end(ap);                                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			va_list ap;                                                                \
+			va_start(ap, arg17);                                                       \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, arg10, arg11, arg12, arg13,  \
+						    arg14, arg15, arg16, arg17, ap);               \
+			va_end(ap);                                                                \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC19_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE,        \
+				ARG16_TYPE, ARG17_TYPE, ...)                                       \
+	DECLARE_FAKE_VOID_FUNC19_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, \
+					ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ...)       \
+	DEFINE_FAKE_VOID_FUNC19_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,  \
+				       ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ...)
+
+#define DECLARE_FAKE_VOID_FUNC20_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, \
+					ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE,            \
+					ARG18_TYPE, ...)                                           \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME)                                              \
+		DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME)                                              \
+		DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME)                                              \
+		DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		void (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,                \
+				    ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,                \
+				    ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,                \
+				    ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,            \
+				    ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,          \
+				    ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,          \
+				    ARG18_TYPE arg18, va_list ap);                                 \
+		void (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2,           \
+					 ARG3_TYPE arg3, ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+					 ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8,           \
+					 ARG9_TYPE arg9, ARG10_TYPE arg10, ARG11_TYPE arg11,       \
+					 ARG12_TYPE arg12, ARG13_TYPE arg13, ARG14_TYPE arg14,     \
+					 ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,     \
+					 ARG18_TYPE arg18, va_list ap);                            \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,            \
+		ARG18_TYPE arg18, ...);
+
+#define DEFINE_FAKE_VOID_FUNC20_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,  \
+				       ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, \
+				       ...)                                                        \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	void FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                                 \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,            \
+		ARG18_TYPE arg18, ...)                                                             \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		SAVE_ARG(FUNCNAME, 15);                                                            \
+		SAVE_ARG(FUNCNAME, 16);                                                            \
+		SAVE_ARG(FUNCNAME, 17);                                                            \
+		SAVE_ARG(FUNCNAME, 18);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 15);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 16);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 17);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 18);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg18);                                               \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_idx++](   \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16, arg17, arg18, ap);                   \
+				va_end(ap);                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg18);                                               \
+				FUNCNAME##_fake                                                    \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16, arg17, arg18, ap);                   \
+				va_end(ap);                                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			va_list ap;                                                                \
+			va_start(ap, arg18);                                                       \
+			FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, arg6,      \
+						    arg7, arg8, arg9, arg10, arg11, arg12, arg13,  \
+						    arg14, arg15, arg16, arg17, arg18, ap);        \
+			va_end(ap);                                                                \
+		}                                                                                  \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VOID_FUNC20_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, ARG4_TYPE,   \
+				ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, \
+				ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ARG14_TYPE, ARG15_TYPE,        \
+				ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ...)                           \
+	DECLARE_FAKE_VOID_FUNC20_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,      \
+					ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,     \
+					ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, \
+					ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE,            \
+					ARG18_TYPE, ...)                                           \
+	DEFINE_FAKE_VOID_FUNC20_VARARG(FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE,       \
+				       ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE,      \
+				       ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,  \
+				       ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, \
+				       ...)
+
+#define DECLARE_FAKE_VALUE_FUNC2_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ...)                     \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)(ARG0_TYPE arg0, va_list ap);                            \
+		RETURN_TYPE (**custom_fake_seq)(ARG0_TYPE arg0, va_list ap);                       \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ...);
+
+#define DEFINE_FAKE_VALUE_FUNC2_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ...)                      \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ...)                      \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg0);                                                \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](arg0, ap); \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg0);                                                \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](arg0,    \
+											  ap);     \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, ap);                                         \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret;                                                           \
+			va_list ap;                                                                \
+			va_start(ap, arg0);                                                        \
+			ret = FUNCNAME##_fake.custom_fake(arg0, ap);                               \
+			va_end(ap);                                                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC2_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ...)                             \
+	DECLARE_FAKE_VALUE_FUNC2_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ...)                     \
+	DEFINE_FAKE_VALUE_FUNC2_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ...)
+
+#define DECLARE_FAKE_VALUE_FUNC3_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...)          \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)(ARG0_TYPE arg0, ARG1_TYPE arg1, va_list ap);            \
+		RETURN_TYPE (**custom_fake_seq)(ARG0_TYPE arg0, ARG1_TYPE arg1, va_list ap);       \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ...);
+
+#define DEFINE_FAKE_VALUE_FUNC3_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...)           \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1, ...)      \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg1);                                                \
+				RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq                  \
+							  [FUNCNAME##_fake.custom_fake_seq_idx++]( \
+								  arg0, arg1, ap);                 \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg1);                                                \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, ap);                           \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, ap);                                   \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret;                                                           \
+			va_list ap;                                                                \
+			va_start(ap, arg1);                                                        \
+			ret = FUNCNAME##_fake.custom_fake(arg0, arg1, ap);                         \
+			va_end(ap);                                                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC3_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...)                  \
+	DECLARE_FAKE_VALUE_FUNC3_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...)          \
+	DEFINE_FAKE_VALUE_FUNC3_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ...)
+
+#define DECLARE_FAKE_VALUE_FUNC4_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					...)                                                       \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, va_list ap);                      \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, va_list ap);                      \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ...);
+
+#define DEFINE_FAKE_VALUE_FUNC4_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,     \
+				       ...)                                                        \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ...)                      \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg2);                                                \
+				RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq                  \
+							  [FUNCNAME##_fake.custom_fake_seq_idx++]( \
+								  arg0, arg1, arg2, ap);           \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg2);                                                \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, ap);                     \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, ap);                             \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret;                                                           \
+			va_list ap;                                                                \
+			va_start(ap, arg2);                                                        \
+			ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, ap);                   \
+			va_end(ap);                                                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC4_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ...)       \
+	DECLARE_FAKE_VALUE_FUNC4_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					...)                                                       \
+	DEFINE_FAKE_VALUE_FUNC4_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ...)
+
+#define DECLARE_FAKE_VALUE_FUNC5_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ...)                                            \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, va_list ap);      \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, va_list ap);      \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3, ...);
+
+#define DEFINE_FAKE_VALUE_FUNC5_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,     \
+				       ARG3_TYPE, ...)                                             \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3, ...)      \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg3);                                                \
+				RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq                  \
+							  [FUNCNAME##_fake.custom_fake_seq_idx++]( \
+								  arg0, arg1, arg2, arg3, ap);     \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg3);                                                \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, ap);               \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, ap);                       \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret;                                                           \
+			va_list ap;                                                                \
+			va_start(ap, arg3);                                                        \
+			ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, ap);             \
+			va_end(ap);                                                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC5_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, \
+				...)                                                               \
+	DECLARE_FAKE_VALUE_FUNC5_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ...)                                            \
+	DEFINE_FAKE_VALUE_FUNC5_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,     \
+				       ARG3_TYPE, ...)
+
+#define DECLARE_FAKE_VALUE_FUNC6_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ...)                                 \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 va_list ap);                                                                      \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 va_list ap);                                                                      \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3,           \
+							 ARG4_TYPE arg4, ...);
+
+#define DEFINE_FAKE_VALUE_FUNC6_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,     \
+				       ARG3_TYPE, ARG4_TYPE, ...)                                  \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3,           \
+							 ARG4_TYPE arg4, ...)                      \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg4);                                                \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, ap);         \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg4);                                                \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, ap);         \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, ap);                 \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret;                                                           \
+			va_list ap;                                                                \
+			va_start(ap, arg4);                                                        \
+			ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, ap);       \
+			va_end(ap);                                                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC6_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, \
+				ARG4_TYPE, ...)                                                    \
+	DECLARE_FAKE_VALUE_FUNC6_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ...)                                 \
+	DEFINE_FAKE_VALUE_FUNC6_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,     \
+				       ARG3_TYPE, ARG4_TYPE, ...)
+
+#define DECLARE_FAKE_VALUE_FUNC7_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ...)                      \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, va_list ap);                                                      \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, va_list ap);                                                      \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3,           \
+							 ARG4_TYPE arg4, ARG5_TYPE arg5, ...);
+
+#define DEFINE_FAKE_VALUE_FUNC7_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,     \
+				       ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ...)                       \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3,           \
+							 ARG4_TYPE arg4, ARG5_TYPE arg5, ...)      \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg5);                                                \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5, ap);   \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg5);                                                \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, ap);   \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, ap);           \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret;                                                           \
+			va_list ap;                                                                \
+			va_start(ap, arg5);                                                        \
+			ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5, ap); \
+			va_end(ap);                                                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC7_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, \
+				ARG4_TYPE, ARG5_TYPE, ...)                                         \
+	DECLARE_FAKE_VALUE_FUNC7_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ...)                      \
+	DEFINE_FAKE_VALUE_FUNC7_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,     \
+				       ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ...)
+
+#define DECLARE_FAKE_VALUE_FUNC8_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ...)           \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, va_list ap);                                      \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, va_list ap);                                      \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3,           \
+							 ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+							 ARG6_TYPE arg6, ...);
+
+#define DEFINE_FAKE_VALUE_FUNC8_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,     \
+				       ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ...)            \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3,           \
+							 ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+							 ARG6_TYPE arg6, ...)                      \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg6);                                                \
+				RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq                  \
+							  [FUNCNAME##_fake.custom_fake_seq_idx++]( \
+								  arg0, arg1, arg2, arg3, arg4,    \
+								  arg5, arg6, ap);                 \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg6);                                                \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							ap);                                       \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, ap);     \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret;                                                           \
+			va_list ap;                                                                \
+			va_start(ap, arg6);                                                        \
+			ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,      \
+							  arg6, ap);                               \
+			va_end(ap);                                                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC8_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, \
+				ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ...)                              \
+	DECLARE_FAKE_VALUE_FUNC8_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ...)           \
+	DEFINE_FAKE_VALUE_FUNC8_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,     \
+				       ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ...)
+
+#define DECLARE_FAKE_VALUE_FUNC9_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					...)                                                       \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, va_list ap);                      \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, va_list ap);                      \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3,           \
+							 ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+							 ARG6_TYPE arg6, ARG7_TYPE arg7, ...);
+
+#define DEFINE_FAKE_VALUE_FUNC9_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,     \
+				       ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ...) \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3,           \
+							 ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+							 ARG6_TYPE arg6, ARG7_TYPE arg7, ...)      \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg7);                                                \
+				RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq                  \
+							  [FUNCNAME##_fake.custom_fake_seq_idx++]( \
+								  arg0, arg1, arg2, arg3, arg4,    \
+								  arg5, arg6, arg7, ap);           \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg7);                                                \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, ap);                                 \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						ap);                                               \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret;                                                           \
+			va_list ap;                                                                \
+			va_start(ap, arg7);                                                        \
+			ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,      \
+							  arg6, arg7, ap);                         \
+			va_end(ap);                                                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC9_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE, ARG3_TYPE, \
+				ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ...)                   \
+	DECLARE_FAKE_VALUE_FUNC9_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					...)                                                       \
+	DEFINE_FAKE_VALUE_FUNC9_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,     \
+				       ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ...)
+
+#define DECLARE_FAKE_VALUE_FUNC10_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ...)                                           \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, va_list ap);      \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, va_list ap);      \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ...);
+
+#define DEFINE_FAKE_VALUE_FUNC10_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ...)                                            \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ...)               \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg8);                                                \
+				RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq                  \
+							  [FUNCNAME##_fake.custom_fake_seq_idx++]( \
+								  arg0, arg1, arg2, arg3, arg4,    \
+								  arg5, arg6, arg7, arg8, ap);     \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg8);                                                \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, ap);                           \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, ap);                                         \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret;                                                           \
+			va_list ap;                                                                \
+			va_start(ap, arg8);                                                        \
+			ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,      \
+							  arg6, arg7, arg8, ap);                   \
+			va_end(ap);                                                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC10_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ...)                                                              \
+	DECLARE_FAKE_VALUE_FUNC10_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ...)                                           \
+	DEFINE_FAKE_VALUE_FUNC10_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ...)
+
+#define DECLARE_FAKE_VALUE_FUNC11_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ...)                                \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 va_list ap);                                                                      \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 va_list ap);                                                                      \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3,           \
+							 ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+							 ARG6_TYPE arg6, ARG7_TYPE arg7,           \
+							 ARG8_TYPE arg8, ARG9_TYPE arg9, ...);
+
+#define DEFINE_FAKE_VALUE_FUNC11_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ...)                                 \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(ARG0_TYPE arg0, ARG1_TYPE arg1,           \
+							 ARG2_TYPE arg2, ARG3_TYPE arg3,           \
+							 ARG4_TYPE arg4, ARG5_TYPE arg5,           \
+							 ARG6_TYPE arg6, ARG7_TYPE arg7,           \
+							 ARG8_TYPE arg8, ARG9_TYPE arg9, ...)      \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg9);                                                \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, ap);                     \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg9);                                                \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, ap);                     \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, ap);                                   \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret;                                                           \
+			va_list ap;                                                                \
+			va_start(ap, arg9);                                                        \
+			ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,      \
+							  arg6, arg7, arg8, arg9, ap);             \
+			va_end(ap);                                                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC11_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ...)                                                   \
+	DECLARE_FAKE_VALUE_FUNC11_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ...)                                \
+	DEFINE_FAKE_VALUE_FUNC11_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ...)
+
+#define DECLARE_FAKE_VALUE_FUNC12_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ...)                    \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, va_list ap);                                                    \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, va_list ap);                                                    \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ...);
+
+#define DEFINE_FAKE_VALUE_FUNC12_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ...)                     \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ...)                                                             \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg10);                                               \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, ap);              \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg10);                                               \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, ap);              \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, ap);                            \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret;                                                           \
+			va_list ap;                                                                \
+			va_start(ap, arg10);                                                       \
+			ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,      \
+							  arg6, arg7, arg8, arg9, arg10, ap);      \
+			va_end(ap);                                                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC12_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ...)                                       \
+	DECLARE_FAKE_VALUE_FUNC12_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ...)                    \
+	DEFINE_FAKE_VALUE_FUNC12_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ...)
+
+#define DECLARE_FAKE_VALUE_FUNC13_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ...)        \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, va_list ap);                                  \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, va_list ap);                                  \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ...);
+
+#define DEFINE_FAKE_VALUE_FUNC13_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ...)         \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ...)                                           \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg11);                                               \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, ap);       \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg11);                                               \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, ap);       \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, ap);                     \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret;                                                           \
+			va_list ap;                                                                \
+			va_start(ap, arg11);                                                       \
+			ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,      \
+							  arg6, arg7, arg8, arg9, arg10, arg11,    \
+							  ap);                                     \
+			va_end(ap);                                                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC13_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ...)                           \
+	DECLARE_FAKE_VALUE_FUNC13_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ...)        \
+	DEFINE_FAKE_VALUE_FUNC13_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ...)
+
+#define DECLARE_FAKE_VALUE_FUNC14_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, \
+					 ...)                                                      \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, va_list ap);                \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, va_list ap);                \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ...);
+
+#define DEFINE_FAKE_VALUE_FUNC14_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,  \
+					...)                                                       \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ...)                         \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg12);                                               \
+				RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq                  \
+							  [FUNCNAME##_fake.custom_fake_seq_idx++]( \
+								  arg0, arg1, arg2, arg3, arg4,    \
+								  arg5, arg6, arg7, arg8, arg9,    \
+								  arg10, arg11, arg12, ap);        \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg12);                                               \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							ap);                                       \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, ap);              \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret;                                                           \
+			va_list ap;                                                                \
+			va_start(ap, arg12);                                                       \
+			ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,      \
+							  arg6, arg7, arg8, arg9, arg10, arg11,    \
+							  arg12, ap);                              \
+			va_end(ap);                                                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC14_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ...)               \
+	DECLARE_FAKE_VALUE_FUNC14_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, \
+					 ...)                                                      \
+	DEFINE_FAKE_VALUE_FUNC14_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,  \
+					...)
+
+#define DECLARE_FAKE_VALUE_FUNC15_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, \
+					 ARG13_TYPE, ...)                                          \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 va_list ap);                                                                      \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 va_list ap);                                                                      \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ...);
+
+#define DEFINE_FAKE_VALUE_FUNC15_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,  \
+					ARG13_TYPE, ...)                                           \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13, ...)       \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg13);                                               \
+				RETURN_TYPE ret = FUNCNAME##_fake.custom_fake_seq                  \
+							  [FUNCNAME##_fake.custom_fake_seq_idx++]( \
+								  arg0, arg1, arg2, arg3, arg4,    \
+								  arg5, arg6, arg7, arg8, arg9,    \
+								  arg10, arg11, arg12, arg13, ap); \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg13);                                               \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, ap);                                \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, ap);       \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret;                                                           \
+			va_list ap;                                                                \
+			va_start(ap, arg13);                                                       \
+			ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,      \
+							  arg6, arg7, arg8, arg9, arg10, arg11,    \
+							  arg12, arg13, ap);                       \
+			va_end(ap);                                                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC15_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE, ...)   \
+	DECLARE_FAKE_VALUE_FUNC15_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, \
+					 ARG13_TYPE, ...)                                          \
+	DEFINE_FAKE_VALUE_FUNC15_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,  \
+					ARG13_TYPE, ...)
+
+#define DECLARE_FAKE_VALUE_FUNC16_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, \
+					 ARG13_TYPE, ARG14_TYPE, ...)                              \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, va_list ap);                                                    \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, va_list ap);                                                    \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ...);
+
+#define DEFINE_FAKE_VALUE_FUNC16_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,  \
+					ARG13_TYPE, ARG14_TYPE, ...)                               \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ...)                                                             \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg14);                                               \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, ap);                         \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg14);                                               \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, ap);                         \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						ap);                                               \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret;                                                           \
+			va_list ap;                                                                \
+			va_start(ap, arg14);                                                       \
+			ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,      \
+							  arg6, arg7, arg8, arg9, arg10, arg11,    \
+							  arg12, arg13, arg14, ap);                \
+			va_end(ap);                                                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC16_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,        \
+				 ARG14_TYPE, ...)                                                  \
+	DECLARE_FAKE_VALUE_FUNC16_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, \
+					 ARG13_TYPE, ARG14_TYPE, ...)                              \
+	DEFINE_FAKE_VALUE_FUNC16_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,  \
+					ARG13_TYPE, ARG14_TYPE, ...)
+
+#define DECLARE_FAKE_VALUE_FUNC17_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, \
+					 ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ...)                  \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, ARG15_TYPE arg15, va_list ap);                                  \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, ARG15_TYPE arg15, va_list ap);                                  \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ...);
+
+#define DEFINE_FAKE_VALUE_FUNC17_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,  \
+					ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ...)                   \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ...)                                           \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		SAVE_ARG(FUNCNAME, 15);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 15);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg15);                                               \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, arg15, ap);                  \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg15);                                               \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, arg15, ap);                  \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, ap);                                        \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret;                                                           \
+			va_list ap;                                                                \
+			va_start(ap, arg15);                                                       \
+			ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,      \
+							  arg6, arg7, arg8, arg9, arg10, arg11,    \
+							  arg12, arg13, arg14, arg15, ap);         \
+			va_end(ap);                                                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC17_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,        \
+				 ARG14_TYPE, ARG15_TYPE, ...)                                      \
+	DECLARE_FAKE_VALUE_FUNC17_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, \
+					 ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ...)                  \
+	DEFINE_FAKE_VALUE_FUNC17_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,  \
+					ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ...)
+
+#define DECLARE_FAKE_VALUE_FUNC18_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, \
+					 ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ...)      \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME)                                              \
+		DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, va_list ap);                \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, va_list ap);                \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ...);
+
+#define DEFINE_FAKE_VALUE_FUNC18_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,  \
+					ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ...)       \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ...)                         \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		SAVE_ARG(FUNCNAME, 15);                                                            \
+		SAVE_ARG(FUNCNAME, 16);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 15);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 16);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg16);                                               \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, arg15, arg16, ap);           \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg16);                                               \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, arg15, arg16, ap);           \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16, ap);                                 \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret;                                                           \
+			va_list ap;                                                                \
+			va_start(ap, arg16);                                                       \
+			ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,      \
+							  arg6, arg7, arg8, arg9, arg10, arg11,    \
+							  arg12, arg13, arg14, arg15, arg16, ap);  \
+			va_end(ap);                                                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC18_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,        \
+				 ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ...)                          \
+	DECLARE_FAKE_VALUE_FUNC18_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, \
+					 ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ...)      \
+	DEFINE_FAKE_VALUE_FUNC18_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,  \
+					ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ...)
+
+#define DECLARE_FAKE_VALUE_FUNC19_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, \
+					 ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE,           \
+					 ARG17_TYPE, ...)                                          \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME)                                              \
+		DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME)                                              \
+		DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,           \
+		 va_list ap);                                                                      \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,           \
+		 va_list ap);                                                                      \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ...);
+
+#define DEFINE_FAKE_VALUE_FUNC19_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,  \
+					ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE,            \
+					ARG17_TYPE, ...)                                           \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17, ...)       \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		SAVE_ARG(FUNCNAME, 15);                                                            \
+		SAVE_ARG(FUNCNAME, 16);                                                            \
+		SAVE_ARG(FUNCNAME, 17);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 15);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 16);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 17);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg17);                                               \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, arg15, arg16, arg17, ap);    \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg17);                                               \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, arg15, arg16, arg17, ap);    \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16, arg17, ap);                          \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret;                                                           \
+			va_list ap;                                                                \
+			va_start(ap, arg17);                                                       \
+			ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,      \
+							  arg6, arg7, arg8, arg9, arg10, arg11,    \
+							  arg12, arg13, arg14, arg15, arg16,       \
+							  arg17, ap);                              \
+			va_end(ap);                                                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC19_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,        \
+				 ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ...)              \
+	DECLARE_FAKE_VALUE_FUNC19_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, \
+					 ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE,           \
+					 ARG17_TYPE, ...)                                          \
+	DEFINE_FAKE_VALUE_FUNC19_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,  \
+					ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE,            \
+					ARG17_TYPE, ...)
+
+#define DECLARE_FAKE_VALUE_FUNC20_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, \
+					 ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE,           \
+					 ARG17_TYPE, ARG18_TYPE, ...)                              \
+	typedef struct FUNCNAME##_Fake {                                                           \
+		DECLARE_ARG(ARG0_TYPE, 0, FUNCNAME)                                                \
+		DECLARE_ARG(ARG1_TYPE, 1, FUNCNAME)                                                \
+		DECLARE_ARG(ARG2_TYPE, 2, FUNCNAME)                                                \
+		DECLARE_ARG(ARG3_TYPE, 3, FUNCNAME)                                                \
+		DECLARE_ARG(ARG4_TYPE, 4, FUNCNAME)                                                \
+		DECLARE_ARG(ARG5_TYPE, 5, FUNCNAME)                                                \
+		DECLARE_ARG(ARG6_TYPE, 6, FUNCNAME)                                                \
+		DECLARE_ARG(ARG7_TYPE, 7, FUNCNAME)                                                \
+		DECLARE_ARG(ARG8_TYPE, 8, FUNCNAME)                                                \
+		DECLARE_ARG(ARG9_TYPE, 9, FUNCNAME)                                                \
+		DECLARE_ARG(ARG10_TYPE, 10, FUNCNAME)                                              \
+		DECLARE_ARG(ARG11_TYPE, 11, FUNCNAME)                                              \
+		DECLARE_ARG(ARG12_TYPE, 12, FUNCNAME)                                              \
+		DECLARE_ARG(ARG13_TYPE, 13, FUNCNAME)                                              \
+		DECLARE_ARG(ARG14_TYPE, 14, FUNCNAME)                                              \
+		DECLARE_ARG(ARG15_TYPE, 15, FUNCNAME)                                              \
+		DECLARE_ARG(ARG16_TYPE, 16, FUNCNAME)                                              \
+		DECLARE_ARG(ARG17_TYPE, 17, FUNCNAME)                                              \
+		DECLARE_ARG(ARG18_TYPE, 18, FUNCNAME)                                              \
+		DECLARE_ALL_FUNC_COMMON                                                            \
+		DECLARE_VALUE_FUNCTION_VARIABLES(RETURN_TYPE)                                      \
+		DECLARE_RETURN_VALUE_HISTORY(RETURN_TYPE)                                          \
+		DECLARE_CUSTOM_FAKE_SEQ_VARIABLES                                                  \
+		RETURN_TYPE (*custom_fake)                                                         \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,           \
+		 ARG18_TYPE arg18, va_list ap);                                                    \
+		RETURN_TYPE (**custom_fake_seq)                                                    \
+		(ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,   \
+		 ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,   \
+		 ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,           \
+		 ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,           \
+		 ARG18_TYPE arg18, va_list ap);                                                    \
+	} FUNCNAME##_Fake;                                                                         \
+	extern FUNCNAME##_Fake FUNCNAME##_fake;                                                    \
+	void FUNCNAME##_reset(void);                                                               \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,            \
+		ARG18_TYPE arg18, ...);
+
+#define DEFINE_FAKE_VALUE_FUNC20_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,  \
+					ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE,            \
+					ARG17_TYPE, ARG18_TYPE, ...)                               \
+	FUNCNAME##_Fake FUNCNAME##_fake;                                                           \
+	RETURN_TYPE FFF_GCC_FUNCTION_ATTRIBUTES FUNCNAME(                                          \
+		ARG0_TYPE arg0, ARG1_TYPE arg1, ARG2_TYPE arg2, ARG3_TYPE arg3, ARG4_TYPE arg4,    \
+		ARG5_TYPE arg5, ARG6_TYPE arg6, ARG7_TYPE arg7, ARG8_TYPE arg8, ARG9_TYPE arg9,    \
+		ARG10_TYPE arg10, ARG11_TYPE arg11, ARG12_TYPE arg12, ARG13_TYPE arg13,            \
+		ARG14_TYPE arg14, ARG15_TYPE arg15, ARG16_TYPE arg16, ARG17_TYPE arg17,            \
+		ARG18_TYPE arg18, ...)                                                             \
+	{                                                                                          \
+		SAVE_ARG(FUNCNAME, 0);                                                             \
+		SAVE_ARG(FUNCNAME, 1);                                                             \
+		SAVE_ARG(FUNCNAME, 2);                                                             \
+		SAVE_ARG(FUNCNAME, 3);                                                             \
+		SAVE_ARG(FUNCNAME, 4);                                                             \
+		SAVE_ARG(FUNCNAME, 5);                                                             \
+		SAVE_ARG(FUNCNAME, 6);                                                             \
+		SAVE_ARG(FUNCNAME, 7);                                                             \
+		SAVE_ARG(FUNCNAME, 8);                                                             \
+		SAVE_ARG(FUNCNAME, 9);                                                             \
+		SAVE_ARG(FUNCNAME, 10);                                                            \
+		SAVE_ARG(FUNCNAME, 11);                                                            \
+		SAVE_ARG(FUNCNAME, 12);                                                            \
+		SAVE_ARG(FUNCNAME, 13);                                                            \
+		SAVE_ARG(FUNCNAME, 14);                                                            \
+		SAVE_ARG(FUNCNAME, 15);                                                            \
+		SAVE_ARG(FUNCNAME, 16);                                                            \
+		SAVE_ARG(FUNCNAME, 17);                                                            \
+		SAVE_ARG(FUNCNAME, 18);                                                            \
+		if (ROOM_FOR_MORE_HISTORY(FUNCNAME)) {                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 0);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 1);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 2);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 3);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 4);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 5);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 6);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 7);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 8);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 9);                                             \
+			SAVE_ARG_HISTORY(FUNCNAME, 10);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 11);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 12);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 13);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 14);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 15);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 16);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 17);                                            \
+			SAVE_ARG_HISTORY(FUNCNAME, 18);                                            \
+		} else {                                                                           \
+			HISTORY_DROPPED(FUNCNAME);                                                 \
+		}                                                                                  \
+		INCREMENT_CALL_COUNT(FUNCNAME);                                                    \
+		REGISTER_CALL(FUNCNAME);                                                           \
+		if (FUNCNAME##_fake.custom_fake_seq_len) { /* a sequence of custom fakes */        \
+			if (FUNCNAME##_fake.custom_fake_seq_idx <                                  \
+			    FUNCNAME##_fake.custom_fake_seq_len) {                                 \
+				va_list ap;                                                        \
+				va_start(ap, arg18);                                               \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_idx++](           \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, arg15, arg16, arg17, arg18,  \
+							ap);                                       \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+			} else {                                                                   \
+				va_list ap;                                                        \
+				va_start(ap, arg18);                                               \
+				RETURN_TYPE ret =                                                  \
+					FUNCNAME##_fake.custom_fake_seq                            \
+						[FUNCNAME##_fake.custom_fake_seq_len - 1](         \
+							arg0, arg1, arg2, arg3, arg4, arg5, arg6,  \
+							arg7, arg8, arg9, arg10, arg11, arg12,     \
+							arg13, arg14, arg15, arg16, arg17, arg18,  \
+							ap);                                       \
+				SAVE_RET_HISTORY(FUNCNAME, ret);                                   \
+				va_end(ap);                                                        \
+				return ret;                                                        \
+				return FUNCNAME##_fake                                             \
+					.custom_fake_seq[FUNCNAME##_fake.custom_fake_seq_len - 1]( \
+						arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7,    \
+						arg8, arg9, arg10, arg11, arg12, arg13, arg14,     \
+						arg15, arg16, arg17, arg18, ap);                   \
+			}                                                                          \
+		}                                                                                  \
+		if (FUNCNAME##_fake.custom_fake) {                                                 \
+			RETURN_TYPE ret;                                                           \
+			va_list ap;                                                                \
+			va_start(ap, arg18);                                                       \
+			ret = FUNCNAME##_fake.custom_fake(arg0, arg1, arg2, arg3, arg4, arg5,      \
+							  arg6, arg7, arg8, arg9, arg10, arg11,    \
+							  arg12, arg13, arg14, arg15, arg16,       \
+							  arg17, arg18, ap);                       \
+			va_end(ap);                                                                \
+			SAVE_RET_HISTORY(FUNCNAME, ret);                                           \
+			return ret;                                                                \
+		}                                                                                  \
+		RETURN_FAKE_RESULT(FUNCNAME)                                                       \
+	}                                                                                          \
+	DEFINE_RESET_FUNCTION(FUNCNAME)
+
+#define FAKE_VALUE_FUNC20_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,           \
+				 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE, ARG8_TYPE, \
+				 ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, ARG13_TYPE,        \
+				 ARG14_TYPE, ARG15_TYPE, ARG16_TYPE, ARG17_TYPE, ARG18_TYPE, ...)  \
+	DECLARE_FAKE_VALUE_FUNC20_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,   \
+					 ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,    \
+					 ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE, \
+					 ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE,           \
+					 ARG17_TYPE, ARG18_TYPE, ...)                              \
+	DEFINE_FAKE_VALUE_FUNC20_VARARG(RETURN_TYPE, FUNCNAME, ARG0_TYPE, ARG1_TYPE, ARG2_TYPE,    \
+					ARG3_TYPE, ARG4_TYPE, ARG5_TYPE, ARG6_TYPE, ARG7_TYPE,     \
+					ARG8_TYPE, ARG9_TYPE, ARG10_TYPE, ARG11_TYPE, ARG12_TYPE,  \
+					ARG13_TYPE, ARG14_TYPE, ARG15_TYPE, ARG16_TYPE,            \
+					ARG17_TYPE, ARG18_TYPE, ...)
+
+/* MSVC expand macro fix */
+#define EXPAND(x) x
+
+#define PP_NARG_MINUS2(...) EXPAND(PP_NARG_MINUS2_(__VA_ARGS__, PP_RSEQ_N_MINUS2()))
+
+#define PP_NARG_MINUS2_(...) EXPAND(PP_ARG_MINUS2_N(__VA_ARGS__))
+
+#define PP_ARG_MINUS2_N(returnVal, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13,     \
+			_14, _15, _16, _17, _18, _19, _20, N, ...)                                 \
+	N
+
+#define PP_RSEQ_N_MINUS2() 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0
+
+#define PP_NARG_MINUS1(...) EXPAND(PP_NARG_MINUS1_(__VA_ARGS__, PP_RSEQ_N_MINUS1()))
+
+#define PP_NARG_MINUS1_(...) EXPAND(PP_ARG_MINUS1_N(__VA_ARGS__))
+
+#define PP_ARG_MINUS1_N(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, \
+			_17, _18, _19, _20, N, ...)                                                \
+	N
+
+#define PP_RSEQ_N_MINUS1() 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0
+
+/* DECLARE AND DEFINE FAKE FUNCTIONS - PLACE IN TEST FILES */
+
+#define FAKE_VALUE_FUNC(...) EXPAND(FUNC_VALUE_(PP_NARG_MINUS2(__VA_ARGS__), __VA_ARGS__))
+
+#define FUNC_VALUE_(N, ...) EXPAND(FUNC_VALUE_N(N, __VA_ARGS__))
+
+#define FUNC_VALUE_N(N, ...) EXPAND(FAKE_VALUE_FUNC##N(__VA_ARGS__))
+
+#define FAKE_VOID_FUNC(...) EXPAND(FUNC_VOID_(PP_NARG_MINUS1(__VA_ARGS__), __VA_ARGS__))
+
+#define FUNC_VOID_(N, ...) EXPAND(FUNC_VOID_N(N, __VA_ARGS__))
+
+#define FUNC_VOID_N(N, ...) EXPAND(FAKE_VOID_FUNC##N(__VA_ARGS__))
+
+#define FAKE_VALUE_FUNC_VARARG(...)                                                                \
+	EXPAND(FUNC_VALUE_VARARG_(PP_NARG_MINUS2(__VA_ARGS__), __VA_ARGS__))
+
+#define FUNC_VALUE_VARARG_(N, ...) EXPAND(FUNC_VALUE_VARARG_N(N, __VA_ARGS__))
+
+#define FUNC_VALUE_VARARG_N(N, ...) EXPAND(FAKE_VALUE_FUNC##N##_VARARG(__VA_ARGS__))
+
+#define FAKE_VOID_FUNC_VARARG(...)                                                                 \
+	EXPAND(FUNC_VOID_VARARG_(PP_NARG_MINUS1(__VA_ARGS__), __VA_ARGS__))
+
+#define FUNC_VOID_VARARG_(N, ...) EXPAND(FUNC_VOID_VARARG_N(N, __VA_ARGS__))
+
+#define FUNC_VOID_VARARG_N(N, ...) EXPAND(FAKE_VOID_FUNC##N##_VARARG(__VA_ARGS__))
+
+/* DECLARE FAKE FUNCTIONS - PLACE IN HEADER FILES */
+
+#define DECLARE_FAKE_VALUE_FUNC(...)                                                               \
+	EXPAND(DECLARE_FUNC_VALUE_(PP_NARG_MINUS2(__VA_ARGS__), __VA_ARGS__))
+
+#define DECLARE_FUNC_VALUE_(N, ...) EXPAND(DECLARE_FUNC_VALUE_N(N, __VA_ARGS__))
+
+#define DECLARE_FUNC_VALUE_N(N, ...) EXPAND(DECLARE_FAKE_VALUE_FUNC##N(__VA_ARGS__))
+
+#define DECLARE_FAKE_VOID_FUNC(...)                                                                \
+	EXPAND(DECLARE_FUNC_VOID_(PP_NARG_MINUS1(__VA_ARGS__), __VA_ARGS__))
+
+#define DECLARE_FUNC_VOID_(N, ...) EXPAND(DECLARE_FUNC_VOID_N(N, __VA_ARGS__))
+
+#define DECLARE_FUNC_VOID_N(N, ...) EXPAND(DECLARE_FAKE_VOID_FUNC##N(__VA_ARGS__))
+
+#define DECLARE_FAKE_VALUE_FUNC_VARARG(...)                                                        \
+	EXPAND(DECLARE_FUNC_VALUE_VARARG_(PP_NARG_MINUS2(__VA_ARGS__), __VA_ARGS__))
+
+#define DECLARE_FUNC_VALUE_VARARG_(N, ...) EXPAND(DECLARE_FUNC_VALUE_VARARG_N(N, __VA_ARGS__))
+
+#define DECLARE_FUNC_VALUE_VARARG_N(N, ...) EXPAND(DECLARE_FAKE_VALUE_FUNC##N##_VARARG(__VA_ARGS__))
+
+#define DECLARE_FAKE_VOID_FUNC_VARARG(...)                                                         \
+	EXPAND(DECLARE_FUNC_VOID_VARARG_(PP_NARG_MINUS1(__VA_ARGS__), __VA_ARGS__))
+
+#define DECLARE_FUNC_VOID_VARARG_(N, ...) EXPAND(DECLARE_FUNC_VOID_VARARG_N(N, __VA_ARGS__))
+
+#define DECLARE_FUNC_VOID_VARARG_N(N, ...) EXPAND(DECLARE_FAKE_VOID_FUNC##N##_VARARG(__VA_ARGS__))
+
+/* DEFINE FAKE FUNCTIONS - PLACE IN SOURCE FILES */
+
+#define DEFINE_FAKE_VALUE_FUNC(...)                                                                \
+	EXPAND(DEFINE_FUNC_VALUE_(PP_NARG_MINUS2(__VA_ARGS__), __VA_ARGS__))
+
+#define DEFINE_FUNC_VALUE_(N, ...) EXPAND(DEFINE_FUNC_VALUE_N(N, __VA_ARGS__))
+
+#define DEFINE_FUNC_VALUE_N(N, ...) EXPAND(DEFINE_FAKE_VALUE_FUNC##N(__VA_ARGS__))
+
+#define DEFINE_FAKE_VOID_FUNC(...)                                                                 \
+	EXPAND(DEFINE_FUNC_VOID_(PP_NARG_MINUS1(__VA_ARGS__), __VA_ARGS__))
+
+#define DEFINE_FUNC_VOID_(N, ...) EXPAND(DEFINE_FUNC_VOID_N(N, __VA_ARGS__))
+
+#define DEFINE_FUNC_VOID_N(N, ...) EXPAND(DEFINE_FAKE_VOID_FUNC##N(__VA_ARGS__))
+
+#define DEFINE_FAKE_VALUE_FUNC_VARARG(...)                                                         \
+	EXPAND(DEFINE_FUNC_VALUE_VARARG_(PP_NARG_MINUS2(__VA_ARGS__), __VA_ARGS__))
+
+#define DEFINE_FUNC_VALUE_VARARG_(N, ...) EXPAND(DEFINE_FUNC_VALUE_VARARG_N(N, __VA_ARGS__))
+
+#define DEFINE_FUNC_VALUE_VARARG_N(N, ...) EXPAND(DEFINE_FAKE_VALUE_FUNC##N##_VARARG(__VA_ARGS__))
+
+#define DEFINE_FAKE_VOID_FUNC_VARARG(...)                                                          \
+	EXPAND(DEFINE_FUNC_VOID_VARARG_(PP_NARG_MINUS1(__VA_ARGS__), __VA_ARGS__))
+
+#define DEFINE_FUNC_VOID_VARARG_(N, ...) EXPAND(DEFINE_FUNC_VOID_VARARG_N(N, __VA_ARGS__))
+
+#define DEFINE_FUNC_VOID_VARARG_N(N, ...) EXPAND(DEFINE_FAKE_VOID_FUNC##N##_VARARG(__VA_ARGS__))
+
+#endif /* FAKE_FUNCTIONS */

--- a/test/ztest/include/zephyr/sys/util.h
+++ b/test/ztest/include/zephyr/sys/util.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2011-2014, Wind River Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Content copied out of <zephyr/sys/util.h> from Zephyr v3.2.0.
+ * Copyright and licensing retained.
+ */
+
+#ifndef BACNETSTACK_TEST_ZTEST_INCLUDE_ZEPHYR_SYS_UTIL_H_
+#define BACNETSTACK_TEST_ZTEST_INCLUDE_ZEPHYR_SYS_UTIL_H_
+
+/** @brief 0 if @p cond is true-ish; causes a compile error otherwise. */
+#define ZERO_OR_COMPILE_ERROR(cond) ((int) sizeof(char[1 - 2 * !(cond)]) - 1)
+
+#if defined(__cplusplus)
+
+/* The built-in function used below for type checking in C is not
+ * supported by GNU C++.
+ */
+#define ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))
+
+#else /* __cplusplus */
+
+/**
+ * @brief Zero if @p array has an array type, a compile error otherwise
+ *
+ * This macro is available only from C, not C++.
+ */
+#define IS_ARRAY(array) \
+	ZERO_OR_COMPILE_ERROR( \
+		!__builtin_types_compatible_p(__typeof__(array), \
+					      __typeof__(&(array)[0])))
+
+/**
+ * @brief Number of elements in the given @p array
+ *
+ * In C++, due to language limitations, this will accept as @p array
+ * any type that implements <tt>operator[]</tt>. The results may not be
+ * particularly meaningful in this case.
+ *
+ * In C, passing a pointer as @p array causes a compile error.
+ */
+#define ARRAY_SIZE(array) \
+	((size_t) (IS_ARRAY(array) + (sizeof(array) / sizeof((array)[0]))))
+
+#endif /* __cplusplus */
+
+/**
+ * @brief Get a pointer to a structure containing the element
+ *
+ * Example:
+ *
+ *	struct foo {
+ *		int bar;
+ *	};
+ *
+ *	struct foo my_foo;
+ *	int *ptr = &my_foo.bar;
+ *
+ *	struct foo *container = CONTAINER_OF(ptr, struct foo, bar);
+ *
+ * Above, @p container points at @p my_foo.
+ *
+ * @param ptr pointer to a structure element
+ * @param type name of the type that @p ptr is an element of
+ * @param field the name of the field within the struct @p ptr points to
+ * @return a pointer to the structure that contains @p ptr
+ */
+#define CONTAINER_OF(ptr, type, field) \
+	((type *)(((char *)(ptr)) - offsetof(type, field)))
+
+
+#ifndef MAX
+/**
+ * @brief Obtain the maximum of two values.
+ *
+ * @note Arguments are evaluated twice. Use Z_MAX for a GCC-only, single
+ * evaluation version
+ *
+ * @param a First value.
+ * @param b Second value.
+ *
+ * @returns Maximum value of @p a and @p b.
+ */
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+
+#ifndef MIN
+/**
+ * @brief Obtain the minimum of two values.
+ *
+ * @note Arguments are evaluated twice. Use Z_MIN for a GCC-only, single
+ * evaluation version
+ *
+ * @param a First value.
+ * @param b Second value.
+ *
+ * @returns Minimum value of @p a and @p b.
+ */
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+
+#endif /* BACNETSTACK_TEST_ZTEST_INCLUDE_ZEPHYR_SYS_UTIL_H_ */

--- a/zephyr/tests/unit/bacnet/bacerror/CMakeLists.txt
+++ b/zephyr/tests/unit/bacnet/bacerror/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Copyright (c) 2022 Legrand North America, LLC.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+if(NOT ZEPHYR_CURRENT_MODULE_DIR)
+  string(REGEX REPLACE "/zephyr/tests/[a-zA-Z_/-]*$" ""
+    ZEPHYR_CURRENT_MODULE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
+if(BOARD STREQUAL unit_testing)
+  find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+  set(target testbinary)
+else()
+  find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+  set(target app)
+endif()
+
+project(bacnet_bacerror)
+target_sources(${target} PRIVATE
+  ${ZEPHYR_CURRENT_MODULE_DIR}/src/bacnet/bacerror.c
+  ${ZEPHYR_CURRENT_MODULE_DIR}/test/unit/bacnet/bacerror/src/main.c
+  ${ZEPHYR_CURRENT_MODULE_DIR}/test/unit/bacnet/bacerror/src/fakes/bacdcode.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/main.c
+)
+
+
+# NOTE for Zephyr >= v3.2.0:
+# - Zephyr unittest builds for target 'testbinary' instead of 'app'.
+# - Zephyr unittest does not generate ZEPHYR_<modulename>_MODULE_DIR.
+# So we have to use relative paths to get to the source.
+
+target_include_directories(${target} PRIVATE
+  ${ZEPHYR_CURRENT_MODULE_DIR}/test/unit/bacnet/bacerror/src
+  ${ZEPHYR_CURRENT_MODULE_DIR}/src
+)

--- a/zephyr/tests/unit/bacnet/bacerror/main.c
+++ b/zephyr/tests/unit/bacnet/bacerror/main.c
@@ -1,0 +1,1 @@
+/* This file is intentionally empty */

--- a/zephyr/tests/unit/bacnet/bacerror/prj.conf
+++ b/zephyr/tests/unit/bacnet/bacerror/prj.conf
@@ -1,0 +1,1 @@
+# This file is intentionally empty

--- a/zephyr/tests/unit/bacnet/bacerror/testcase.yaml
+++ b/zephyr/tests/unit/bacnet/bacerror/testcase.yaml
@@ -1,0 +1,3 @@
+tests:
+  bacnet.bacerror.unit:
+    type: unit


### PR DESCRIPTION
Unit tests for bacerror.c functions using FFF fakes for APIs depended upon by the code under test.

This discovered a couple issues in the bacerror.c, which have also been fixed in this PR.