### PR TITLE
Fix BACnetARRAY encoder for index=ALL

### DIFF
--- a/src/bacnet/bacdcode.c
+++ b/src/bacnet/bacdcode.c
@@ -3129,7 +3129,7 @@ int bacnet_array_encode(uint32_t object_instance,
             /* encoded size is larger than APDU size */
             apdu_len = BACNET_STATUS_ABORT;
         } else {
-            for (index = 1; index < array_size; index++) {
+            for (index = 0; index < array_size; index++) {
                 len = encoder(object_instance, index, apdu);
                 if (apdu) {
                     apdu += len;

--- a/test/bacnet/bacdcode/src/main.c
+++ b/test/bacnet/bacdcode/src/main.c
@@ -1340,6 +1340,11 @@ static void test_bacnet_array_encode(void)
     zassert_equal(tag_number, BACNET_APPLICATION_TAG_UNSIGNED_INT, NULL);
     len = decode_unsigned(&apdu[len], len_value, &decoded_value);
     zassert_equal(decoded_value, array_size, NULL);
+    /* element zero - APDU too small */
+    apdu_len = bacnet_array_encode(object_instance, array_index, 
+        bacnet_array_property_element_encode,
+        array_size, apdu, 1);
+    zassert_true(apdu_len == BACNET_STATUS_ABORT, NULL);
     /* element 1 returns the first element */
     array_index = 1;
     apdu_len = bacnet_array_encode(object_instance, array_index, 
@@ -1349,12 +1354,28 @@ static void test_bacnet_array_encode(void)
     len = decode_tag_number_and_value(apdu, &tag_number, &len_value);
     zassert_true(len > 0, NULL);
     zassert_equal(tag_number, BACNET_APPLICATION_TAG_OBJECT_ID, NULL);
+    /* element 1 - APDU too small */
+    apdu_len = bacnet_array_encode(object_instance, array_index, 
+        bacnet_array_property_element_encode,
+        array_size, apdu, 1);
+    zassert_true(apdu_len == BACNET_STATUS_ABORT, NULL);
     /* element 2, in this test case, returns an error */
     array_index = 2;
     apdu_len = bacnet_array_encode(object_instance, array_index, 
         bacnet_array_property_element_encode,
         array_size, apdu, sizeof(apdu));
     zassert_true(apdu_len < 0, NULL);
+    /* ALL - fits in APDU */
+    array_index = BACNET_ARRAY_ALL;
+    apdu_len = bacnet_array_encode(object_instance, array_index, 
+        bacnet_array_property_element_encode,
+        array_size, apdu, sizeof(apdu));
+    zassert_true(apdu_len == 5, "len=%d", apdu_len);
+    /* ALL - APDU too small */
+    apdu_len = bacnet_array_encode(object_instance, array_index, 
+        bacnet_array_property_element_encode,
+        array_size, apdu, 4);
+    zassert_true(apdu_len == BACNET_STATUS_ABORT, NULL);
 }
 
 /**


### PR DESCRIPTION
In bacnet_array_encode(), when array-index = ALL for test-encoding start-index =0 (correct) but when writing to pdu then start-index=1. -> mso/state-text all { 'state-2' , 'state-3' }
Thank you, Andreas, for reporting the bug!
