### PR TITLE
Fix segfault on mstp cleanup on linux port

### DIFF
--- a/ports/linux/dlmstp.c
+++ b/ports/linux/dlmstp.c
@@ -720,7 +720,6 @@ void dlmstp_get_broadcast_address(BACNET_ADDRESS *dest)
 
 bool dlmstp_init(char *ifname)
 {
-    unsigned long hThread = 0;
     pthread_condattr_t attr;
     int rv = 0;
 


### PR DESCRIPTION
Removed the local variable 'hThread' in 'dlmstp_init' which causes segmentation fault during service exit in dlmstp_cleanup function as this local variable shadows the global variable.