### PR TITLE
[router-mstp] DOS: routed_apdu_handler() null dereference 

### DIFF
--- a/apps/router-mstp/main.c
+++ b/apps/router-mstp/main.c
@@ -901,7 +901,7 @@ static void routed_apdu_handler(uint16_t snet,
             datalink_send_pdu(port->net, &remote_dest, npdu, &Tx_Buffer[0],
                 npdu_len + apdu_len);
         }
-    } else if (dest->net) {
+    } else if (port && dest->net) {
         debug_printf("Routing to Unknown Route %u\n", (unsigned)dest->net);
         /* Case 3: a global broadcast is required. */
         dest->mac_len = 0;


### PR DESCRIPTION
# Description
This bug is a null de-reference in router-mstp when the destination port is not present in the routing table list when processing a routed APDU.  

# Stack Trace
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==2924366==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000008 (pc 0x559c932f1a7d bp 0x7fffcdf787a0 sp 0x7fffcdf786c0 T0)
==2924366==The signal is caused by a READ memory access.
==2924366==Hint: address points to the zero page.
    #0 0x559c932f1a7d in routed_apdu_handler /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/router-mstp/main.c:914:19
    #1 0x559c932f1a7d in my_routing_npdu_handler /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/router-mstp/main.c:971:21
    #2 0x559c932f1a7d in main /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/router-mstp/main.c:1162:9
    #3 0x7f70316c584f  (/usr/lib/libc.so.6+0x2384f) (BuildId: 2f005a79cd1a8e385972f5a102f16adba414d75e)
    #4 0x7f70316c5909 in __libc_start_main (/usr/lib/libc.so.6+0x23909) (BuildId: 2f005a79cd1a8e385972f5a102f16adba414d75e)
    #5 0x559c931f90b4 in _start (/mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/router-mstp/router-mstp+0x550b4) (BuildId: 7ce7b49b690749996f0948ae1aa476c3f1d32d18)

```
