### PR TITLE
[router-mstp] network_control_handler: Prevent npdu_len from wrapping around at npdu_len=1

### DIFF
--- a/apps/router-mstp/main.c
+++ b/apps/router-mstp/main.c
@@ -662,7 +662,8 @@ static void network_control_handler(uint16_t snet,
         case NETWORK_MESSAGE_I_AM_ROUTER_TO_NETWORK:
             /* add its DNETs to our routing table */
             fprintf(stderr, "for Networks: ");
-            while (npdu_len) {
+            len = 2;
+            while (npdu_len >= len) {
                 len = decode_unsigned16(&npdu[npdu_offset], &dnet);
                 fprintf(stderr, "%hu", dnet);
                 dnet_add(snet, dnet, src);


### PR DESCRIPTION
# Description
npdu_len can underflow here if npdu_len ever hits 1 during this loop iteration. This causes `npdu_len -= len` to underflow, which causes the loop to continue past the end of the NPDU. I haven't functionally tested this for regressions, but it no longer crashes.  

# Stack Trace
```
===================================================================3146750==
ERROR: AddressSanitizer: heap-buffer-overflow on address 0x603000000081 at pc 0x562848e878f7 bp 0x7fffeb15a740 sp 0x7fffeb15a738
READ of size 1 at 0x603000000081 thread T0
    #0 0x562848e878f6 in decode_unsigned16 /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/src/bacnet/bacint.c:58:42
    #1 0x562848e7c18c in network_control_handler /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/router-mstp/main.c:666:23
    #2 0x562848e7c18c in my_routing_npdu_handler /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/router-mstp/main.c:951:17
    #3 0x562848e7c18c in main /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/router-mstp/main.c:1162:9
    #4 0x7fd38cbef84f  (/usr/lib/libc.so.6+0x2384f) (BuildId: 2f005a79cd1a8e385972f5a102f16adba414d75e)
    #5 0x7fd38cbef909 in __libc_start_main (/usr/lib/libc.so.6+0x23909) (BuildId: 2f005a79cd1a8e385972f5a102f16adba414d75e)
    #6 0x562848d830b4 in _start (/mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/router-mstp/router-mstp+0x550b4) (BuildId: 6e8770379587bf25007614dd9ef036f573b9f666)
```