### PR TITLE
[libbacnet]: bacapp_data_len() + bacnet_tag_number_and_value_decode()

### DIFF
--- a/src/bacnet/bacapp.c
+++ b/src/bacnet/bacapp.c
@@ -1521,13 +1521,13 @@ int bacapp_data_len(
     uint8_t opening_tag_number_counter = 0;
     uint32_t value = 0;
 
-    if (IS_OPENING_TAG(apdu[0])) {
+    if (apdu_len_max > 0 && IS_OPENING_TAG(apdu[0])) {
         len = bacnet_tag_number_and_value_decode(
             &apdu[apdu_len], apdu_len_max - apdu_len, &tag_number, &value);
         apdu_len += len;
         opening_tag_number = tag_number;
         opening_tag_number_counter = 1;
-        while (opening_tag_number_counter) {
+        while (apdu_len < apdu_len_max && opening_tag_number_counter) {
             if (IS_OPENING_TAG(apdu[apdu_len])) {
                 len = bacnet_tag_number_and_value_decode(&apdu[apdu_len],
                     apdu_len_max - apdu_len, &tag_number, &value);

--- a/src/bacnet/bacapp.c
+++ b/src/bacnet/bacapp.c
@@ -1529,6 +1529,10 @@ int bacapp_data_len(
         /* error: exceeding our buffer limit */
         return BACNET_STATUS_ERROR;
     }
+    if (!bacnet_is_opening_tag(apdu, apdu_len_max)) {
+        /* error: opening tag is missing */
+        return BACNET_STATUS_ERROR;
+    }
     do {
         if (bacnet_is_opening_tag(apdu, apdu_len_max)) {
             len = bacnet_tag_number_and_value_decode(apdu,

--- a/src/bacnet/bacdcode.c
+++ b/src/bacnet/bacdcode.c
@@ -611,7 +611,7 @@ int bacnet_tag_number_and_value_decode(
 {
     int len = 0;
 
-    len = bacnet_tag_number_decode(apdu, apdu_len_max, tag_number);
+    len = bacnet_tag_number_decode(&apdu[0], apdu_len_max, tag_number);
     if (len > 0) {
         if (IS_EXTENDED_VALUE(apdu[0]) && (apdu_len_max > len)) {
             apdu_len_max -= len;

--- a/src/bacnet/bacdcode.c
+++ b/src/bacnet/bacdcode.c
@@ -548,7 +548,7 @@ int bacnet_tag_number_and_value_decode(
     int len = 0;
 
     len = bacnet_tag_number_decode(&apdu[0], apdu_len_max, tag_number);
-    if (len > 0) {
+    if (len > 0 && apdu_len_max > len) {
         apdu_len_max -= len;
         if (IS_EXTENDED_VALUE(apdu[0])) {
             /* tagged as uint32_t */

--- a/src/bacnet/bacdcode.c
+++ b/src/bacnet/bacdcode.c
@@ -518,7 +518,7 @@ bool bacnet_is_closing_tag(uint8_t *apdu, uint32_t apdu_size)
  * @param apdu  Pointer to the tag number.
  * @param apdu_size Number of bytes available to decode
  *
- * @return true if an opening tag has been found.
+ * @return true if a context specific tag has been found.
  */
 bool bacnet_is_context_specific(uint8_t *apdu, uint32_t apdu_size)
 {

--- a/src/bacnet/bacdcode.h
+++ b/src/bacnet/bacdcode.h
@@ -61,6 +61,13 @@ extern "C" {
         bool context_specific,
         uint32_t len_value_type);
 
+BACNET_STACK_EXPORT
+bool bacnet_is_opening_tag(uint8_t *apdu, uint32_t apdu_size);
+BACNET_STACK_EXPORT
+bool bacnet_is_closing_tag(uint8_t *apdu, uint32_t apdu_size);
+BACNET_STACK_EXPORT
+bool bacnet_is_context_specific(uint8_t *apdu, uint32_t apdu_size);
+
 /* from clause 20.2.1.3.2 Constructed Data */
 /* returns the number of apdu bytes consumed */
     BACNET_STACK_EXPORT

--- a/test/bacnet/wp/src/main.c
+++ b/test/bacnet/wp/src/main.c
@@ -61,11 +61,11 @@ static void testWritePropertyTag(BACNET_APPLICATION_DATA_VALUE *value)
     wpdata.application_data_len =
         bacapp_encode_application_data(&wpdata.application_data[0], value);
     len = wp_encode_apdu(&apdu[0], invoke_id, &wpdata);
-    zassert_not_equal(len, 0, NULL);
+    zassert_not_equal(len, 0, "len=%d", len);
     /* decode the data */
     apdu_len = len;
     len = wp_decode_apdu(&apdu[0], apdu_len, &test_invoke_id, &test_data);
-    zassert_not_equal(len, -1, NULL);
+    zassert_true(len > 0, "len=%d", len);
     zassert_equal(test_data.object_type, wpdata.object_type, NULL);
     zassert_equal(test_data.object_instance, wpdata.object_instance, NULL);
     zassert_equal(test_data.object_property, wpdata.object_property, NULL);


### PR DESCRIPTION
# Description
Both `bacapp_data_len()` and `bacnet_tag_number_and_value_decode()` don't enforce bounds checks on APDU accesses properly. 

# Stack Traces
```
===================================================================102467==
ERROR: AddressSanitizer: heap-buffer-overflow on address 0x621000001100 at pc 0x55df626e7635 bp 0x7fff3f5cf290 sp 0x7fff3f5cf288
READ of size 1 at 0x621000001100 thread T0
    #0 0x55df626e7634 in bacapp_data_len /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/src/bacnet/bacapp.c:1531:17
    #1 0x55df626fc424 in wp_decode_service_request /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/src/bacnet/wp.c:157:16
    #2 0x55df62706c81 in handler_write_property /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/src/bacnet/basic/service/h_wp.c:97:15
    #3 0x55df626fe954 in apdu_handler /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/src/bacnet/basic/service/h_apdu.c
    #4 0x55df626dfb46 in my_routing_npdu_handler /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/router-mstp/main.c:977:25
    #5 0x55df626dfb46 in main /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/router-mstp/main.c:1209:9
    #6 0x7fb78b67984f  (/usr/lib/libc.so.6+0x2384f) (BuildId: 2f005a79cd1a8e385972f5a102f16adba414d75e)
    #7 0x7fb78b679909 in __libc_start_main (/usr/lib/libc.so.6+0x23909) (BuildId: 2f005a79cd1a8e385972f5a102f16adba414d75e)
    #8 0x55df625e70b4 in _start (/mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/router-mstp/router-mstp+0x550b4) (BuildId: d5d971fa378f6dc89328ec3e921b6d203213d448)

===================================================================105503==
ERROR: AddressSanitizer: heap-buffer-overflow on address 0x61e000000a19 at pc 0x557d7d73eb56 bp 0x7fff72e7fc50 sp 0x7fff72e7fc48
READ of size 1 at 0x61e000000a19 thread T0
    #0 0x557d7d73eb55 in bacnet_tag_number_and_value_decode /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/src/bacnet/bacdcode.c:555:18
    #1 0x557d7d73d11e in bacapp_decode_context_data_len /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/src/bacnet/bacapp.c:1363:19
    #2 0x557d7d73d4f3 in bacapp_data_len /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/src/bacnet/bacapp.c:1546:23
    #3 0x557d7d752424 in wp_decode_service_request /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/src/bacnet/wp.c:157:16
    #4 0x557d7d75cc81 in handler_write_property /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/src/bacnet/basic/service/h_wp.c:97:15
    #5 0x557d7d754954 in apdu_handler /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/src/bacnet/basic/service/h_apdu.c
    #6 0x557d7d735b46 in my_routing_npdu_handler /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/router-mstp/main.c:977:25
    #7 0x557d7d735b46 in main /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/router-mstp/main.c:1209:9
    #8 0x7fd2a1f2e84f  (/usr/lib/libc.so.6+0x2384f) (BuildId: 2f005a79cd1a8e385972f5a102f16adba414d75e)
    #9 0x7fd2a1f2e909 in __libc_start_main (/usr/lib/libc.so.6+0x23909) (BuildId: 2f005a79cd1a8e385972f5a102f16adba414d75e)
    #10 0x557d7d63d0b4 in _start (/mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/router-mstp/router-mstp+0x550b4) (BuildId: d5d971fa378f6dc89328ec3e921b6d203213d448)
```