### PR TITLE
AFL + Libfuzzer harnesses 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,13 @@ router-ipv6:
 router-mstp:
 	$(MAKE) -s -C apps $@
 
+.PHONY: fuzz-libfuzzer
+fuzz-libfuzzer:
+	$(MAKE) -s -C apps $@
+
+.PHONY: fuzz-afl
+fuzz-afl:
+	$(MAKE) -s -C apps $@
 # Add "ports" to the build, if desired
 .PHONY: ports
 ports:	atmega168 bdk-atxx4-mstp at91sam7s stm32f10x stm32f4xx

--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,7 @@ fuzz-libfuzzer:
 .PHONY: fuzz-afl
 fuzz-afl:
 	$(MAKE) -s -C apps $@
+
 # Add "ports" to the build, if desired
 .PHONY: ports
 ports:	atmega168 bdk-atxx4-mstp at91sam7s stm32f10x stm32f4xx
@@ -304,6 +305,8 @@ clean: ports-clean
 	$(MAKE) -s -C apps/router-ipv6 clean
 	$(MAKE) -s -C apps/router-mstp clean
 	$(MAKE) -s -C apps/gateway clean
+	$(MAKE) -s -C apps/fuzz-afl clean
+	$(MAKE) -s -C apps/fuzz-libfuzzer clean
 	$(MAKE) -s -C ports/lwip clean
 	$(MAKE) -s -C test clean
 	rm -rf ./build

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -177,7 +177,7 @@ endif
 SUBDIRS = lib readprop writeprop readfile writefile reinit server dcc \
 	whohas whois iam ucov scov timesync epics readpropm readrange \
 	writepropm uptransfer getevent uevent abort error event ack-alarm \
-	server-client add-list-element remove-list-element
+	server-client add-list-element remove-list-element fuzz-libfuzzer fuzz-afl
 
 ifeq (${BACDL_DEFINE},-DBACDL_BIP=1)
 	SUBDIRS += whoisrouter iamrouter initrouter whatisnetnum netnumis
@@ -195,6 +195,30 @@ endif
 ifeq (${BACNET_PORT},win32)
 	SUBDIRS += mstpcap mstpcrc
 endif
+
+
+#####
+# Define target-specific fuzzing flags
+#####
+
+# AFL
+fuzz-afl: CC=afl-gcc 
+fuzz-afl: FUZZ_FLAGS=-DFUZZING=1
+fuzz-afl: LFLAGS += $(FUZZ_FLAGS)
+fuzz-afl: CFLAGS += $(FUZZ_FLAGS)
+fuzz-afl: export AFL_USE_ASAN=1
+
+# LIBFUZZER
+fuzz-libfuzzer: CC=clang 
+fuzz-libfuzzer: FUZZ_FLAGS=-DFUZZING=1 -fsanitize=fuzzer,address -g3 -Og -fno-optimize-sibling-calls -fno-omit-frame-pointer
+fuzz-libfuzzer: LFLAGS += $(FUZZ_FLAGS)
+fuzz-libfuzzer: CFLAGS += $(FUZZ_FLAGS)
+
+
+#####
+# Fuzz setup end
+#####
+
 
 .PHONY: all clean
 TARGETS = all clean
@@ -352,6 +376,14 @@ router-ipv6: $(BACNET_LIB_TARGET)
 
 .PHONY: router-mstp
 router-mstp: $(BACNET_LIB_TARGET)
+	$(MAKE) -B -C $@
+
+.PHONY: fuzz-libfuzzer
+fuzz-libfuzzer: $(BACNET_LIB_TARGET)
+	$(MAKE) -B -C $@
+
+.PHONY: fuzz-afl
+fuzz-afl: $(BACNET_LIB_TARGET)
 	$(MAKE) -B -C $@
 
 .PHONY: writepropm

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -177,7 +177,7 @@ endif
 SUBDIRS = lib readprop writeprop readfile writefile reinit server dcc \
 	whohas whois iam ucov scov timesync epics readpropm readrange \
 	writepropm uptransfer getevent uevent abort error event ack-alarm \
-	server-client add-list-element remove-list-element fuzz-libfuzzer fuzz-afl
+	server-client add-list-element remove-list-element
 
 ifeq (${BACDL_DEFINE},-DBACDL_BIP=1)
 	SUBDIRS += whoisrouter iamrouter initrouter whatisnetnum netnumis

--- a/apps/fuzz-afl/Makefile
+++ b/apps/fuzz-afl/Makefile
@@ -1,0 +1,79 @@
+#Makefile to build BACnet Application for the GCC port
+
+# tools - only if you need them.
+# Most platforms have this already defined
+# CC = gcc
+
+# Executable file name
+TARGET = fuzz-afl
+
+TARGET_BIN = ${TARGET}$(TARGET_EXT)
+
+# BACNET_PORT, BACNET_PORT_DIR, BACNET_PORT_SRC are defined in common Makefile
+# BACNET_SRC_DIR is defined in common apps Makefile
+BACNET_OBJECT_DIR = $(BACNET_SRC_DIR)/bacnet/basic/object
+SRC = main.c \
+	$(BACNET_OBJECT_DIR)/netport.c \
+	$(BACNET_OBJECT_DIR)/client/device-client.c
+
+PORT_MSTP_SRC = \
+	$(BACNET_PORT_DIR)/rs485.c \
+	$(BACNET_PORT_DIR)/dlmstp.c \
+	$(BACNET_SRC_DIR)/bacnet/datalink/mstp.c \
+	$(BACNET_SRC_DIR)/bacnet/datalink/mstptext.c \
+	$(BACNET_SRC_DIR)/bacnet/datalink/crc.c
+
+PORT_BIP_SRC = \
+	$(BACNET_PORT_DIR)/bip-init.c \
+	$(BACNET_SRC_DIR)/bacnet/datalink/bvlc.c \
+	$(BACNET_SRC_DIR)/bacnet/basic/bbmd/h_bbmd.c
+
+# WARNINGS, DEBUGGING, OPTIMIZATION are defined in common apps Makefile
+# BACNET_DEFINES is defined in common apps Makefile
+# put all the flags together
+INCLUDES = -I$(BACNET_SRC_DIR) -I$(BACNET_PORT_DIR)
+CFLAGS += $(WARNINGS) $(DEBUGGING) $(OPTIMIZATION) $(BACNET_DEFINES) $(INCLUDES)
+LFLAGS += -Wl,$(SYSTEM_LIB)
+ifneq (${BACNET_LIB},)
+LFLAGS += -Wl,$(BACNET_LIB)
+endif
+# GCC dead code removal
+CFLAGS += -ffunction-sections -fdata-sections
+LFLAGS += -Wl,--gc-sections
+
+BACNET_SRC = \
+	$(wildcard $(BACNET_SRC_DIR)/bacnet/*.c) \
+	$(wildcard $(BACNET_SRC_DIR)/bacnet/basic/*.c) \
+	$(wildcard $(BACNET_SRC_DIR)/bacnet/basic/binding/*.c) \
+	$(wildcard $(BACNET_SRC_DIR)/bacnet/basic/service/*.c) \
+	$(wildcard $(BACNET_SRC_DIR)/bacnet/basic/sys/*.c) \
+	$(BACNET_SRC_DIR)/bacnet/basic/npdu/h_routed_npdu.c \
+	$(BACNET_SRC_DIR)/bacnet/basic/npdu/s_router.c \
+	$(BACNET_SRC_DIR)/bacnet/basic/tsm/tsm.c
+
+SRCS = ${SRC} ${BACNET_SRC} ${PORT_MSTP_SRC} ${PORT_BIP_SRC}
+
+OBJS += ${SRCS:.c=.o}
+
+.PHONY: all
+all: Makefile ${TARGET_BIN}
+
+${TARGET_BIN}: ${OBJS}
+	${CC} ${PFLAGS} ${OBJS} ${LFLAGS} -o $@
+	size $@
+	cp $@ ../../bin
+
+.c.o:
+	${CC} -c ${CFLAGS} $*.c -o $@
+
+.PHONY: depend
+depend:
+	rm -f .depend
+	${CC} -MM ${CFLAGS} *.c >> .depend
+
+.PHONY: clean
+clean:
+	rm -f core ${TARGET_BIN} ${OBJS} $(TARGET).map
+
+.PHONY: include
+include: .depend

--- a/apps/fuzz-afl/README.md
+++ b/apps/fuzz-afl/README.md
@@ -1,0 +1,24 @@
+# Getting Started
+
+* Install [AFL](https://github.com/google/AFL), ensure afl-gcc exists on the system:
+
+```
+$ afl-gcc
+afl-cc 2.57b by <lcamtuf@google.com>
+```
+
+* Build via `make fuzz-afl` from repository root
+* Clone a decent [corpus](https://github.com/CrystalPeakSecurity/bacnet-corpus/tree/main)
+* Start AFL and feed it the input/output directories along with target executable
+
+```
+afl-fuzz -i </path/to/corpus/> -o </path/to/output_dir/> -m none ./apps/fuzz-afl/fuzz-afl
+```
+
+Caveats: 
+
+* This builds the target with ASAN (Address Sanitizer). This makes AFL require the `-m none` to not interpret ASAN's behavior as a crash
+* AFL uses a fork/exec model to launch the target. This is nice because each testcase is from a clean state. But this also brings in a lot of overhead. If you need something faster, check out ../fuzz-libfuzzer/
+
+
+

--- a/apps/fuzz-afl/main.c
+++ b/apps/fuzz-afl/main.c
@@ -1,0 +1,126 @@
+/**
+ * @file
+ * @author Steve Karg, Anthony Delorenzo
+ * @date 2020
+ * @brief
+ *
+ * @section LICENSE
+ *
+ * Copyright (C) 2020 Steve Karg <skarg@users.sourceforge.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <time.h>
+#include <assert.h>
+
+#include "bacnet/bacdef.h"
+#include "bacnet/config.h"
+#include "bacnet/bactext.h"
+#include "bacnet/bacerror.h"
+#include "bacnet/iam.h"
+#include "bacnet/arf.h"
+#include "bacnet/npdu.h"
+#include "bacnet/apdu.h"
+#include "bacnet/version.h"
+/* some demo modules we use */
+#include "bacnet/basic/sys/debug.h"
+#include "bacnet/basic/tsm/tsm.h"
+#include "bacnet/basic/binding/address.h"
+#include "bacnet/basic/services.h"
+/* port agnostic file */
+#include "bacport.h"
+/* our datalink layers */
+#include "bacnet/datalink/dlmstp.h"
+#include "bacnet/datalink/bip.h"
+#include "bacnet/datalink/bvlc.h"
+#include "bacnet/basic/bbmd/h_bbmd.h"
+
+// Pull in all of this... 
+#include "../router-mstp/main.c"
+
+static void Init_Service_Handlers()
+{
+
+    apdu_set_unconfirmed_handler(SERVICE_UNCONFIRMED_WHO_IS, handler_who_is_unicast);
+    apdu_set_unconfirmed_handler(SERVICE_UNCONFIRMED_WHO_HAS, handler_who_has);
+    apdu_set_unrecognized_service_handler_handler(handler_unrecognized_service);
+    apdu_set_confirmed_handler(SERVICE_CONFIRMED_READ_PROPERTY, handler_read_property);
+    apdu_set_confirmed_handler(SERVICE_CONFIRMED_READ_PROP_MULTIPLE, handler_read_property_multiple);
+    apdu_set_confirmed_handler(SERVICE_CONFIRMED_WRITE_PROPERTY, handler_write_property);
+    apdu_set_confirmed_handler(SERVICE_CONFIRMED_READ_RANGE, handler_read_range);
+    apdu_set_confirmed_handler(SERVICE_CONFIRMED_REINITIALIZE_DEVICE, handler_reinitialize_device);
+    apdu_set_unconfirmed_handler(SERVICE_UNCONFIRMED_UTC_TIME_SYNCHRONIZATION, handler_timesync_utc);
+    apdu_set_unconfirmed_handler(SERVICE_UNCONFIRMED_TIME_SYNCHRONIZATION, handler_timesync);
+    apdu_set_confirmed_handler(SERVICE_CONFIRMED_SUBSCRIBE_COV, handler_cov_subscribe);
+    apdu_set_unconfirmed_handler(SERVICE_UNCONFIRMED_COV_NOTIFICATION, handler_ucov_notification);
+    apdu_set_confirmed_handler(SERVICE_CONFIRMED_DEVICE_COMMUNICATION_CONTROL, handler_device_communication_control);
+    apdu_set_unconfirmed_handler(SERVICE_UNCONFIRMED_WHO_IS, handler_who_is);
+    apdu_set_unrecognized_service_handler_handler(handler_unrecognized_service);
+    apdu_set_confirmed_handler(SERVICE_CONFIRMED_READ_PROPERTY, handler_read_property);
+    apdu_set_unconfirmed_handler(SERVICE_UNCONFIRMED_I_AM, handler_i_am_add);
+}
+
+
+/*
+ * FIXME: This is a hack to get things linking correctly
+ */
+extern int cov_subscribe(void) {
+    return 0;
+}
+extern int Device_Value_List_Supported(void) {
+    return 0;
+}
+extern int Encode_RR_payload(void) {
+    return 0;
+}
+extern int Device_Objects_RR_Info(void) {
+    return 0;
+}
+extern int Device_Write_Property(void) {
+    return 0;
+}
+extern int Device_Reinitialize(void) {
+    return 0;
+}
+
+
+int main(int argc, char *argv[])
+{
+    BACNET_ADDRESS src = { 0 }; 
+    uint16_t pdu_len = 0;
+
+    Init_Service_Handlers();
+
+    pdu_len = read(0, &BIP_Rx_Buffer[0], sizeof(BIP_Rx_Buffer));
+
+    /* process fuzz input*/
+    if (pdu_len) {
+        my_routing_npdu_handler(BIP_Net, &src, &BIP_Rx_Buffer[0], pdu_len);
+    }
+
+    return 0;
+
+}

--- a/apps/fuzz-libfuzzer/Makefile
+++ b/apps/fuzz-libfuzzer/Makefile
@@ -1,0 +1,81 @@
+#Makefile to build BACnet Application for the GCC port
+
+# tools - only if you need them.
+# Most platforms have this already defined
+# CC = gcc
+
+# Executable file name
+TARGET = fuzz-libfuzzer
+
+TARGET_BIN = ${TARGET}$(TARGET_EXT)
+
+# BACNET_PORT, BACNET_PORT_DIR, BACNET_PORT_SRC are defined in common Makefile
+# BACNET_SRC_DIR is defined in common apps Makefile
+BACNET_OBJECT_DIR = $(BACNET_SRC_DIR)/bacnet/basic/object
+SRC = main.c \
+	$(BACNET_OBJECT_DIR)/netport.c \
+	$(BACNET_OBJECT_DIR)/bacfile.c \
+	$(BACNET_OBJECT_DIR)/gateway/gw_device.c \
+	$(BACNET_OBJECT_DIR)/client/device-client.c
+
+PORT_MSTP_SRC = \
+	$(BACNET_PORT_DIR)/rs485.c \
+	$(BACNET_PORT_DIR)/dlmstp.c \
+	$(BACNET_SRC_DIR)/bacnet/datalink/mstp.c \
+	$(BACNET_SRC_DIR)/bacnet/datalink/mstptext.c \
+	$(BACNET_SRC_DIR)/bacnet/datalink/crc.c
+
+PORT_BIP_SRC = \
+	$(BACNET_PORT_DIR)/bip-init.c \
+	$(BACNET_SRC_DIR)/bacnet/datalink/bvlc.c \
+	$(BACNET_SRC_DIR)/bacnet/basic/bbmd/h_bbmd.c
+
+# WARNINGS, DEBUGGING, OPTIMIZATION are defined in common apps Makefile
+# BACNET_DEFINES is defined in common apps Makefile
+# put all the flags together
+INCLUDES = -I$(BACNET_SRC_DIR) -I$(BACNET_PORT_DIR)
+CFLAGS += $(WARNINGS) $(DEBUGGING) $(OPTIMIZATION) $(BACNET_DEFINES) $(INCLUDES)
+LFLAGS += -Wl,$(SYSTEM_LIB)
+ifneq (${BACNET_LIB},)
+LFLAGS += -Wl,$(BACNET_LIB)
+endif
+# GCC dead code removal
+CFLAGS += -ffunction-sections -fdata-sections
+LFLAGS += -Wl,--gc-sections
+
+BACNET_SRC = \
+	$(wildcard $(BACNET_SRC_DIR)/bacnet/*.c) \
+	$(wildcard $(BACNET_SRC_DIR)/bacnet/basic/*.c) \
+	$(wildcard $(BACNET_SRC_DIR)/bacnet/basic/binding/*.c) \
+	$(wildcard $(BACNET_SRC_DIR)/bacnet/basic/service/*.c) \
+	$(wildcard $(BACNET_SRC_DIR)/bacnet/basic/sys/*.c) \
+	$(BACNET_SRC_DIR)/bacnet/basic/npdu/h_routed_npdu.c \
+	$(BACNET_SRC_DIR)/bacnet/basic/npdu/s_router.c \
+	$(BACNET_SRC_DIR)/bacnet/basic/tsm/tsm.c
+
+SRCS = ${SRC} ${BACNET_SRC} ${PORT_MSTP_SRC} ${PORT_BIP_SRC}
+
+OBJS += ${SRCS:.c=.o}
+
+.PHONY: all
+all: Makefile ${TARGET_BIN}
+
+${TARGET_BIN}: ${OBJS}
+	${CC} ${PFLAGS} ${OBJS} ${LFLAGS} -o $@
+	size $@
+	cp $@ ../../bin
+
+.c.o:
+	${CC} -c ${CFLAGS} $*.c -o $@
+
+.PHONY: depend
+depend:
+	rm -f .depend
+	${CC} -MM ${CFLAGS} *.c >> .depend
+
+.PHONY: clean
+clean:
+	rm -f core ${TARGET_BIN} ${OBJS} $(TARGET).map
+
+.PHONY: include
+include: .depend

--- a/apps/fuzz-libfuzzer/README.md
+++ b/apps/fuzz-libfuzzer/README.md
@@ -1,0 +1,51 @@
+# Getting Started
+
+* Ensure Clang & [compiler-rt](https://compiler-rt.llvm.org/) are installed on the system. On Arch Linux, this is package `compiler-rt`
+* Build via `make fuzz-libfuzzer` from repository root
+* Clone a decent [corpus](https://github.com/CrystalPeakSecurity/bacnet-corpus/tree/main)
+* Start and feed it the corpus directory
+
+```
+$ ./apps/fuzz-libfuzzer/fuzz-libfuzzer ../bacnet-corpus/corpus/
+INFO: Running with entropic power schedule (0xFF, 100).
+INFO: Seed: 4165043991
+INFO: Loaded 1 modules   (9101 inline 8-bit counters): 9101 [0x55a0d5487090, 0x55a0d548941d),
+INFO: Loaded 1 PC tables (9101 PCs): 9101 [0x55a0d5489420,0x55a0d54accf0),
+INFO:     5790 files found in ../bacnet-corpus/corpus/
+INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
+INFO: seed corpus: files: 5790 min: 1b max: 483b total: 305068b rss: 40Mb
+NPDU: Decoding failed; Discarded!
+...
+NPDU: DNET=65280.  Discarded!
+#5867	REDUCE cov: 208 ft: 249 corp: 66/1273b lim: 115 exec/s: 2933 rss: 106Mb L: 12/109 MS: 1 EraseBytes-
+Received Reserved for Use by ASHRAE
+WP: Failed to send PDU (Success)!
+	NEW_FUNC[1/3]: 0x55a0d533f98a in abort_encode_apdu /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/src/bacnet/abort.c:149
+	NEW_FUNC[2/3]: 0x55a0d538f29a in wp_decode_service_request /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/src/bacnet/wp.c:113
+#5940	NEW    cov: 216 ft: 257 corp: 68/1282b lim: 115 exec/s: 2970 rss: 106Mb L: 6/109 MS: 2 EraseBytes-ChangeBit-
+Received Reserved for Use by ASHRAE
+...
+=================================================================
+==2204295==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60200003b656 at pc 0x55a0d5350276 bp 0x7fff17646790 sp 0x7fff17646788
+READ of size 1 at 0x60200003b656 thread T0
+    #0 0x55a0d5350275 in decode_tag_number_and_value /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/src/bacnet/bacdcode.c:496:13
+    #1 0x55a0d5360b44 in bacerror_decode_error_class_and_code /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/src/bacnet/bacerror.c:78:16
+    #2 0x55a0d539851e in apdu_handler /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/src/bacnet/basic/service/h_apdu.c:684:27
+    #3 0x55a0d5331fff in my_routing_npdu_handler /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/fuzz-libfuzzer/./../router-mstp/main.c:977:25
+    #4 0x55a0d5331fff in LLVMFuzzerTestOneInput /mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/fuzz-libfuzzer/main.c:144:9
+    #5 0x55a0d5216878 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/fuzz-libfuzzer/fuzz-libfuzzer+0xc2878) (BuildId: 6c764deec893b5d17197c0a0183d5b491e36f6c9)
+    #6 0x55a0d5217550 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) (/mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/fuzz-libfuzzer/fuzz-libfuzzer+0xc3550) (BuildId: 6c764deec893b5d17197c0a0183d5b491e36f6c9)
+    #7 0x55a0d52185e1 in fuzzer::Fuzzer::MutateAndTestOne() (/mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/fuzz-libfuzzer/fuzz-libfuzzer+0xc45e1) (BuildId: 6c764deec893b5d17197c0a0183d5b491e36f6c9)
+    #8 0x55a0d5219407 in fuzzer::Fuzzer::Loop(std::vector<fuzzer::SizedFile, std::allocator<fuzzer::SizedFile>>&) (/mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/fuzz-libfuzzer/fuzz-libfuzzer+0xc5407) (BuildId: 6c764deec893b5d17197c0a0183d5b491e36f6c9)
+    #9 0x55a0d51f98d5 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/fuzz-libfuzzer/fuzz-libfuzzer+0xa58d5) (BuildId: 6c764deec893b5d17197c0a0183d5b491e36f6c9)
+    #10 0x55a0d51e3717 in main (/mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/fuzz-libfuzzer/fuzz-libfuzzer+0x8f717) (BuildId: 6c764deec893b5d17197c0a0183d5b491e36f6c9)
+    #11 0x7fc3c263984f  (/usr/lib/libc.so.6+0x2384f) (BuildId: 2f005a79cd1a8e385972f5a102f16adba414d75e)
+    #12 0x7fc3c2639909 in __libc_start_main (/usr/lib/libc.so.6+0x23909) (BuildId: 2f005a79cd1a8e385972f5a102f16adba414d75e)
+    #13 0x55a0d51e3754 in _start (/mnt/net/lab_share/Bacnet/bacnet-stack-fixes/apps/fuzz-libfuzzer/fuzz-libfuzzer+0x8f754) (BuildId: 6c764deec893b5d17197c0a0183d5b491e36f6c9)
+...
+```
+
+Caveat: 
+
+* Libfuzzer does not reinitialize the target on each testcase. This means that it will be much quicker than ../fuzz-afl/, BUT it will also be a little less stable. It also will not continue to fuzz after a crash is found (since the libfuzzer runtime shares a process with the target that just crashed). There may be some command line options to adopt a fork model.
+

--- a/apps/fuzz-libfuzzer/main.c
+++ b/apps/fuzz-libfuzzer/main.c
@@ -1,0 +1,149 @@
+/**
+ * @file
+ * @author Steve Karg, Anthony Delorenzo
+ * @date 2020
+ * @brief
+ *
+ * @section LICENSE
+ *
+ * Copyright (C) 2020 Steve Karg <skarg@users.sourceforge.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <time.h>
+#include <assert.h>
+
+
+#include "bacnet/bacdef.h"
+#include "bacnet/config.h"
+#include "bacnet/bactext.h"
+#include "bacnet/bacerror.h"
+#include "bacnet/iam.h"
+#include "bacnet/list_element.h"
+#include "bacnet/arf.h"
+#include "bacnet/npdu.h"
+#include "bacnet/apdu.h"
+#include "bacnet/version.h"
+/* some demo modules we use */
+#include "bacnet/basic/sys/debug.h"
+#include "bacnet/basic/tsm/tsm.h"
+#include "bacnet/basic/binding/address.h"
+#include "bacnet/basic/services.h"
+/* port agnostic file */
+#include "bacport.h"
+/* our datalink layers */
+#include "bacnet/datalink/dlmstp.h"
+#include "bacnet/datalink/bip.h"
+#include "bacnet/datalink/bvlc.h"
+#include "bacnet/basic/bbmd/h_bbmd.h"
+
+// Pull in all of this... 
+#include "../router-mstp/main.c"
+
+static void Init_Service_Handlers(void) {
+
+    apdu_set_unconfirmed_handler(SERVICE_UNCONFIRMED_WHO_IS, handler_who_is_unicast);
+    apdu_set_unconfirmed_handler(SERVICE_UNCONFIRMED_WHO_HAS, handler_who_has);
+    apdu_set_unrecognized_service_handler_handler(handler_unrecognized_service);
+    apdu_set_confirmed_handler(SERVICE_CONFIRMED_READ_PROPERTY, handler_read_property);
+    apdu_set_confirmed_handler(SERVICE_CONFIRMED_READ_PROP_MULTIPLE, handler_read_property_multiple);
+    apdu_set_confirmed_handler(SERVICE_CONFIRMED_WRITE_PROPERTY, handler_write_property);
+    apdu_set_confirmed_handler(SERVICE_CONFIRMED_READ_RANGE, handler_read_range);
+    apdu_set_confirmed_handler(SERVICE_CONFIRMED_REINITIALIZE_DEVICE, handler_reinitialize_device);
+    apdu_set_unconfirmed_handler(SERVICE_UNCONFIRMED_UTC_TIME_SYNCHRONIZATION, handler_timesync_utc);
+    apdu_set_unconfirmed_handler(SERVICE_UNCONFIRMED_TIME_SYNCHRONIZATION, handler_timesync);
+    apdu_set_confirmed_handler(SERVICE_CONFIRMED_SUBSCRIBE_COV, handler_cov_subscribe);
+    apdu_set_unconfirmed_handler(SERVICE_UNCONFIRMED_COV_NOTIFICATION, handler_ucov_notification);
+    apdu_set_confirmed_handler(SERVICE_CONFIRMED_DEVICE_COMMUNICATION_CONTROL, handler_device_communication_control);
+    apdu_set_unconfirmed_handler(SERVICE_UNCONFIRMED_WHO_IS, handler_who_is);
+    apdu_set_unrecognized_service_handler_handler(handler_unrecognized_service);
+    apdu_set_confirmed_handler(SERVICE_CONFIRMED_READ_PROPERTY, handler_read_property);
+    apdu_set_unconfirmed_handler(SERVICE_UNCONFIRMED_I_AM, handler_i_am_add);
+}
+
+
+/*
+ * FIXME: This is a hack to get things linking correctly
+ */
+extern int cov_subscribe(void) {
+    return 0;
+}
+extern int Device_Value_List_Supported(void) {
+    return 0;
+}
+extern int Encode_RR_payload(void) {
+    return 0;
+}
+extern int Device_Objects_RR_Info(void) {
+    return 0;
+}
+extern int Device_Write_Property(void) {
+    return 0;
+}
+extern int Device_Reinitialize(void) {
+    return 0;
+}
+
+extern bool Device_COV(BACNET_OBJECT_TYPE object_type, uint32_t object_instance) { 
+    return false;
+}
+extern void Device_COV_Clear(BACNET_OBJECT_TYPE object_type, uint32_t object_instance) {
+    return;
+}
+
+extern bool Device_Encode_Value_List(BACNET_OBJECT_TYPE object_type,
+    uint32_t object_instance,
+    BACNET_PROPERTY_VALUE *value_list) {
+
+    return false;
+
+}
+
+extern int Device_Add_List_Element(BACNET_LIST_ELEMENT_DATA * list_element) { 
+    return BACNET_STATUS_ERROR;
+}
+
+extern int Device_Remove_List_Element(BACNET_LIST_ELEMENT_DATA * list_element) { 
+    return BACNET_STATUS_ERROR;
+}
+
+extern bool Device_Write_Property_Local(BACNET_WRITE_PROPERTY_DATA *wp_data) {
+    return false;
+}
+
+int LLVMFuzzerTestOneInput(uint8_t *data, size_t size) {
+    BACNET_ADDRESS src = { 0 }; 
+
+    Init_Service_Handlers();
+
+    /* process fuzz input*/
+    if (size>0 && size<=0xffff) {
+        my_routing_npdu_handler(BIP_Net, &src, data, (uint16_t)size);
+    }
+
+    return 0;
+
+}

--- a/apps/router-mstp/main.c
+++ b/apps/router-mstp/main.c
@@ -1136,6 +1136,9 @@ static void control_c_hooks(void)
 }
 #endif
 
+
+#ifndef FUZZING
+
 /**
  * Main function of simple router demo.
  *
@@ -1199,3 +1202,6 @@ int main(int argc, char *argv[])
 
     return 0;
 }
+
+
+#endif // FUZZING


### PR DESCRIPTION
Hey Steve,

This one contains both fuzzer harnesses I threw together to fuzz this library (through router-mstp). Let me know if you have any Q's - they'll probably be useful to test any changes or new functionality that get added down the line. If there's functionality beyond what router-mstp exposes, I'm happy to help out re-targeting to hit that stuff as well. 

```
$ make fuzz-afl
$ make fuzz-libfuzzer 
```

I was going to git-submodule the corpus I collected, but I pushed it here instead: https://github.com/CrystalPeakSecurity/bacnet-corpus/tree/main/corpus 

Best,
Anthony 

