### PR TITLE
vmac.c : Fix a warning that 'device_id' is not used

### DIFF
--- a/src/bacnet/basic/bbmd6/vmac.c
+++ b/src/bacnet/basic/bbmd6/vmac.c
@@ -54,7 +54,11 @@ static bool VMAC_Debug = false;
     }
 #else
 #define PRINTF(...)
+
+#if !defined UNUSED
+#define UNUSED(x) ((void)(x))
 #endif
+#endif // PRINT_ENABLED
 
 /**
  * @brief Enable debugging if print is enabled
@@ -263,6 +267,9 @@ void VMAC_Cleanup(void)
     if (VMAC_List) {
         do {
             device_id = Keylist_Key(VMAC_List, index);
+#if !PRINT_ENABLED
+            UNUSED(device_id);
+#endif
             pVMAC = Keylist_Data_Delete_By_Index(VMAC_List, index);
             if (pVMAC) {
                 PRINTF("VMAC List: %lu [", (unsigned long)device_id);


### PR DESCRIPTION
When PRINT_ENABLED is 0, I have a warning with gcc (arm-none-eabi-gcc to be accurate): 'device_id' is not used.