### PR TITLE
Fix decoding empty array of complex type in RPM

### DIFF
--- a/src/bacnet/basic/service/h_rpm_a.c
+++ b/src/bacnet/basic/service/h_rpm_a.c
@@ -118,40 +118,49 @@ int rpm_ack_decode_service_request(
                    more than one element to decode */
                 value = calloc(1, sizeof(BACNET_APPLICATION_DATA_VALUE));
                 rpm_property->value = value;
-                while (value && (apdu_len > 0)) {
-                    len = bacapp_decode_known_property(apdu, (unsigned)apdu_len,
-                        value, rpm_object->object_type,
-                        rpm_property->propertyIdentifier);
-                    /* If len == 0 then it's an empty structure, which is OK. */
-                    if (len < 0) {
-                        /* problem decoding */
-                        PERROR("RPM Ack: unable to decode! %s:%s\n",
-                            bactext_object_type_name(rpm_object->object_type),
-                            bactext_property_name(
-                                rpm_property->propertyIdentifier));
-                        /* note: caller will free the memory */
-                        return BACNET_STATUS_ERROR;
-                    }
-                    decoded_len += len;
-                    apdu_len -= len;
-                    apdu += len;
-                    if (apdu_len && decode_is_closing_tag_number(apdu, 4)) {
-                        decoded_len++;
-                        apdu_len--;
-                        apdu++;
-                        break;
-                    } else if (len > 0) {
-                        old_value = value;
-                        value =
-                            calloc(1, sizeof(BACNET_APPLICATION_DATA_VALUE));
-                        old_value->next = value;
-                    } else {
-                        PERROR("RPM Ack: decoded %s:%s len=%d\n",
-                            bactext_object_type_name(rpm_object->object_type),
-                            bactext_property_name(
-                                rpm_property->propertyIdentifier),
-                            len);
-                        break;
+
+                /* Special case for an empty array - we decode it as null */
+                if (apdu_len && decode_is_closing_tag_number(apdu, 4)) {
+                    /* NULL value has tag 0, that was already set by calloc */
+                    decoded_len++;
+                    apdu_len--;
+                    apdu++;
+                } else {
+                    while (value && (apdu_len > 0)) {
+                        len = bacapp_decode_known_property(apdu, (unsigned)apdu_len,
+                            value, rpm_object->object_type,
+                            rpm_property->propertyIdentifier);
+                        /* If len == 0 then it's an empty structure, which is OK. */
+                        if (len < 0) {
+                            /* problem decoding */
+                            PERROR("RPM Ack: unable to decode! %s:%s\n",
+                                bactext_object_type_name(rpm_object->object_type),
+                                bactext_property_name(
+                                    rpm_property->propertyIdentifier));
+                            /* note: caller will free the memory */
+                            return BACNET_STATUS_ERROR;
+                        }
+                        decoded_len += len;
+                        apdu_len -= len;
+                        apdu += len;
+                        if (apdu_len && decode_is_closing_tag_number(apdu, 4)) {
+                            decoded_len++;
+                            apdu_len--;
+                            apdu++;
+                            break;
+                        } else if (len > 0) {
+                            old_value = value;
+                            value =
+                                calloc(1, sizeof(BACNET_APPLICATION_DATA_VALUE));
+                            old_value->next = value;
+                        } else {
+                            PERROR("RPM Ack: decoded %s:%s len=%d\n",
+                                bactext_object_type_name(rpm_object->object_type),
+                                bactext_property_name(
+                                    rpm_property->propertyIdentifier),
+                                len);
+                            break;
+                        }
                     }
                 }
             } else if (apdu_len && decode_is_opening_tag_number(apdu, 5)) {

--- a/src/bacnet/basic/service/h_rpm_a.c
+++ b/src/bacnet/basic/service/h_rpm_a.c
@@ -127,14 +127,16 @@ int rpm_ack_decode_service_request(
                     apdu++;
                 } else {
                     while (value && (apdu_len > 0)) {
-                        len = bacapp_decode_known_property(apdu, (unsigned)apdu_len,
-                            value, rpm_object->object_type,
+                        len = bacapp_decode_known_property(apdu,
+                            (unsigned)apdu_len, value, rpm_object->object_type,
                             rpm_property->propertyIdentifier);
-                        /* If len == 0 then it's an empty structure, which is OK. */
+                        /* If len == 0 then it's an empty structure, which is
+                         * OK. */
                         if (len < 0) {
                             /* problem decoding */
                             PERROR("RPM Ack: unable to decode! %s:%s\n",
-                                bactext_object_type_name(rpm_object->object_type),
+                                bactext_object_type_name(
+                                    rpm_object->object_type),
                                 bactext_property_name(
                                     rpm_property->propertyIdentifier));
                             /* note: caller will free the memory */
@@ -150,12 +152,13 @@ int rpm_ack_decode_service_request(
                             break;
                         } else if (len > 0) {
                             old_value = value;
-                            value =
-                                calloc(1, sizeof(BACNET_APPLICATION_DATA_VALUE));
+                            value = calloc(
+                                1, sizeof(BACNET_APPLICATION_DATA_VALUE));
                             old_value->next = value;
                         } else {
                             PERROR("RPM Ack: decoded %s:%s len=%d\n",
-                                bactext_object_type_name(rpm_object->object_type),
+                                bactext_object_type_name(
+                                    rpm_object->object_type),
                                 bactext_property_name(
                                     rpm_property->propertyIdentifier),
                                 len);


### PR DESCRIPTION
Working on my Calendars branch, I discovered that RPM fails when reading empty `Exception_Schedule` of a `Schedule` object.

<img width="428" alt="Screenshot_20231020_153004" src="https://github.com/bacnet-stack/bacnet-stack/assets/2041118/599edf32-0775-45ad-bf53-2b9fe5d68fd2">

This "works" in Master insofar as not returning error, but decoding is not implemented for Special_Event, so you likely get Null anyway.

A comment in `rpm_ack_decode_service_request()` says that `bacapp_decode_known_property()` returns 0 for "empty structure", but this is only true if decoding falls through to `bacapp_decode_generic_property()` or in special cases. Most of the decoders there don't follow this pattern. My Special_Event decoder also does not work that way.

This PR explicitly detects empty value so that empty array is *always* decoded as a single Null value, regardless of the "known property" type.

---

There's some weird corner cases with this (already there before my change):

- If an array contains just one element, you can't tell you read an array from the decoded value. I work around this in application code by having a list of "array" and "list" known properties.
- If an array is empty, you get one Null. But then you can't tell an empty array apart from an array really containing one Null. (Do arrays with null values occur in the wild?)

```
ARRAY_PROPERTIES = [
    PROP_ACTION,
    PROP_ACTION_TEXT,
    PROP_ASSIGNED_ACCESS_RIGHTS,
    PROP_ASSIGNED_LANDING_CALLS,
    PROP_AUTHENTICATION_FACTORS,
    PROP_AUTHENTICATION_POLICY_LIST,
    PROP_AUTHENTICATION_POLICY_NAMES,
    PROP_BIT_TEXT,
    PROP_CAR_DOOR_COMMAND,
    PROP_CAR_DOOR_STATUS,
    PROP_CAR_DOOR_TEXT,
    PROP_COMMAND_TIME_ARRAY,
    PROP_CONFIGURATION_FILES,
    PROP_CONTROL_GROUPS,
    PROP_EVENT_MESSAGE_TEXTS,
    PROP_EVENT_MESSAGE_TEXTS_CONFIG,
    PROP_EVENT_TIME_STAMPS,
    PROP_EXCEPTION_SCHEDULE,
    PROP_EXECUTION_DELAY,
    PROP_FLOOR_TEXT,
    PROP_GROUP_MEMBERS,
    PROP_GROUP_MEMBER_NAMES, // global group also has array in Present_Value
    PROP_IPV6_DNS_SERVER,
    PROP_IP_DNS_SERVER,
    PROP_LANDING_DOOR_STATUS,
    PROP_LINK_SPEEDS,
    PROP_LOG_DEVICE_OBJECT_PROPERTY,
    PROP_MAKING_CAR_CALL,
    PROP_MONITORED_OBJECTS,
    PROP_NEGATIVE_ACCESS_RULES,
    PROP_OBJECT_LIST,
    PROP_PORT_FILTER,
    PROP_POSITIVE_ACCESS_RULES,
    PROP_PROPERTY_LIST,
    PROP_REGISTERED_CAR_CALL,
    PROP_SHED_LEVELS,
    PROP_SHED_LEVEL_DESCRIPTIONS,
    PROP_STAGES,
    PROP_STAGE_NAMES,
    PROP_STATE_CHANGE_VALUES,
    PROP_STATE_TEXT,
    PROP_STRUCTURED_OBJECT_LIST,
    PROP_SUBORDINATE_ANNOTATIONS,
    PROP_SUBORDINATE_LIST,
    PROP_SUBORDINATE_NODE_TYPES,
    PROP_SUBORDINATE_RELATIONSHIPS,
    PROP_SUBORDINATE_TAGS,
    PROP_SUPPORTED_FORMATS,
    PROP_SUPPORTED_FORMAT_CLASSES,
    PROP_TAGS,
    PROP_TARGET_REFERENCES,
    PROP_VALUE_SOURCE_ARRAY,
    PROP_WEEKLY_SCHEDULE,
];

LIST_PROPERTIES = [
    // Present Value of Group is a List - but we can't check that this way
    PROP_ACCEPTED_MODES,
    PROP_ACCESS_ALARM_EVENTS,
    PROP_ACCESS_TRANSACTION_EVENTS,
    PROP_ACTIVE_COV_MULTIPLE_SUBSCRIPTIONS,
    PROP_ACTIVE_COV_SUBSCRIPTIONS,
    PROP_ACTIVE_VT_SESSIONS,
    PROP_ALARM_VALUES,
    PROP_AUTHORIZATION_EXEMPTIONS,
    PROP_BBMD_BROADCAST_DISTRIBUTION_TABLE,
    PROP_BBMD_FOREIGN_DEVICE_TABLE,
    PROP_COVU_RECIPIENTS,
    PROP_CREDENTIALS,
    PROP_CREDENTIALS_IN_ZONE,
    PROP_DATE_LIST,
    PROP_DEVICE_ADDRESS_BINDING,
    PROP_ENTRY_POINTS,
    PROP_EXIT_POINTS,
    PROP_FAILED_ATTEMPT_EVENTS,
    PROP_FAULT_SIGNALS,
    PROP_FAULT_VALUES,
    PROP_LANDING_CALLS,
    PROP_LIFE_SAFETY_ALARM_VALUES,
    PROP_LIST_OF_GROUP_MEMBERS,
    PROP_LIST_OF_OBJECT_PROPERTY_REFERENCES,
    PROP_LOG_BUFFER,
    PROP_MANUAL_SLAVE_ADDRESS_BINDING,
    PROP_MASKED_ALARM_VALUES,
    PROP_MEMBERS,
    PROP_MEMBER_OF,
    PROP_REASON_FOR_DISABLE,
    PROP_RECIPIENT_LIST,
    PROP_RESTART_NOTIFICATION_RECIPIENTS,
    PROP_ROUTING_TABLE,
    PROP_SLAVE_ADDRESS_BINDING,
    PROP_SUBSCRIBED_RECIPIENTS,
    PROP_TIME_SYNCHRONIZATION_RECIPIENTS,
    PROP_UTC_TIME_SYNCHRONIZATION_RECIPIENTS,
    PROP_VIRTUAL_MAC_ADDRESS_TABLE,
    PROP_VT_CLASSES_SUPPORTED,
    PROP_ZONE_MEMBERS,
];
```
