### PR TITLE
Fix BACnet/IP builds for BBMD clients without BBMD tables.

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -49,6 +49,20 @@ jobs:
         make clean
         make BBMD=none all
 
+  bip-client-bbmd-apps:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Create Build Environment
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -qq libconfig-dev
+    - name: Build Demo Apps BBMD=none
+      run: |
+        gcc --version
+        make clean
+        make BBMD=client all
+    
   gateway:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get install -qq libconfig-dev
-    - name: Build Demo Apps BBMD=none
+    - name: Build Demo Apps BBMD=client
       run: |
         gcc --version
         make clean

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,14 @@ bip6-win32:
 bip6:
 	$(MAKE) BACDL=bip6 -s -C apps all
 
+.PHONY: bip
+bip:
+	$(MAKE) BACDL=bip -s -C apps all
+
+.PHONY: bip-client
+bip-client:
+	$(MAKE) BACDL=bip BBMD=client -s -C apps all
+
 .PHONY: ethernet
 ethernet:
 	$(MAKE) BACDL=ethernet -s -C apps all

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -50,6 +50,9 @@ ifeq (${BBMD},server)
 BBMD_DEFINE = -DBBMD_ENABLED=1
 endif
 ifeq (${BBMD},client)
+BBMD_DEFINE = -DBBMD_ENABLED=0 -DBBMD_CLIENT_ENABLED
+endif
+ifeq (${BBMD},full)
 BBMD_DEFINE = -DBBMD_ENABLED=1 -DBBMD_CLIENT_ENABLED
 endif
 

--- a/src/bacnet/basic/bbmd/h_bbmd.c
+++ b/src/bacnet/basic/bbmd/h_bbmd.c
@@ -77,11 +77,12 @@ static bool BVLC_NAT_Handling = false;
 static BACNET_IP_ADDRESS Remote_BBMD;
 /** if we are a foreign device, store the Time-To-Live Seconds here */
 static uint16_t Remote_BBMD_TTL_Seconds;
-#if BBMD_ENABLED
+#if BBMD_ENABLED || BBMD_CLIENT_ENABLED
 /* local buffer & length for sending */
 static uint8_t BVLC_Buffer[BIP_MPDU_MAX];
 static uint16_t BVLC_Buffer_Len;
-/* Broadcast Distribution Table */
+#endif
+#if BBMD_ENABLED/* Broadcast Distribution Table */
 #ifndef MAX_BBMD_ENTRIES
 #define MAX_BBMD_ENTRIES 128
 #endif
@@ -255,6 +256,8 @@ void bvlc_maintenance_timer(uint16_t seconds)
 {
 #if BBMD_ENABLED
     bvlc_foreign_device_table_maintenance_timer(&FD_Table[0], seconds);
+#else
+    (void)seconds;
 #endif
 }
 

--- a/src/bacnet/basic/object/netport.c
+++ b/src/bacnet/basic/object/netport.c
@@ -2618,6 +2618,7 @@ bool Network_Port_Read_Range(
 #if defined(BACDL_BIP) && BBMD_ENABLED
         case PROP_BBMD_ACCEPT_FD_REGISTRATIONS:
 #endif
+            (void)pInfo;
             pRequest->error_class = ERROR_CLASS_SERVICES;
             pRequest->error_code = ERROR_CODE_PROPERTY_IS_NOT_A_LIST;
             break;
@@ -2627,6 +2628,7 @@ bool Network_Port_Read_Range(
             pInfo->Handler = Network_Port_Read_Range_BDT;
             status = true;
 #else
+            (void)pInfo;
             pRequest->error_class = ERROR_CLASS_PROPERTY;
             pRequest->error_code = ERROR_CODE_UNKNOWN_PROPERTY;
 #endif
@@ -2637,11 +2639,13 @@ bool Network_Port_Read_Range(
             pInfo->Handler = Network_Port_Read_Range_FDT;
             status = true;
 #else
+            (void)pInfo;
             pRequest->error_class = ERROR_CLASS_PROPERTY;
             pRequest->error_code = ERROR_CODE_UNKNOWN_PROPERTY;
 #endif
             break;
         default:
+            (void)pInfo;
             pRequest->error_class = ERROR_CLASS_PROPERTY;
             pRequest->error_code = ERROR_CODE_UNKNOWN_PROPERTY;
             break;

--- a/src/bacnet/config.h
+++ b/src/bacnet/config.h
@@ -47,6 +47,9 @@
 #if !defined(BBMD_ENABLED)
 #define BBMD_ENABLED 1
 #endif
+#if !defined(BBMD_CLIENT_ENABLED)
+#define BBMD_CLIENT_ENABLED 1
+#endif
 #endif
 
 /* optional configuration for BACnet/IPv6 datalink layer */

--- a/src/bacnet/datalink/dlenv.c
+++ b/src/bacnet/datalink/dlenv.c
@@ -357,7 +357,9 @@ void dlenv_network_port_init(void)
 {
     const uint32_t instance = 1;
     BACNET_IP_ADDRESS addr = { 0 };
+#if BBMD_ENABLED
     uint8_t addr0, addr1, addr2, addr3;
+#endif
 
     Network_Port_Object_Instance_Number_Set(0, instance);
     Network_Port_Name_Set(instance, "BACnet/IP Port");


### PR DESCRIPTION
Fixes #521 using additional ifdef around data that is required for the BBMD client without a BBMD table.

Note: added another build in root Makefile: make bip-client

Note: changed apps/Makefile BBMD option 'client' and added BBMD option 'full'
```
ifeq (${BBMD},client)
BBMD_DEFINE = -DBBMD_ENABLED=0 -DBBMD_CLIENT_ENABLED
endif
ifeq (${BBMD},full)
BBMD_DEFINE = -DBBMD_ENABLED=1 -DBBMD_CLIENT_ENABLED
endif
```
