### PR TITLE
Change SubscribeCOV Cancellations to always reply with Result+

### DIFF
--- a/src/bacnet/basic/service/h_cov.c
+++ b/src/bacnet/basic/service/h_cov.c
@@ -743,10 +743,22 @@ static bool cov_subscribe(BACNET_ADDRESS *src,
         status = Device_Value_List_Supported(object_type);
         if (status) {
             status = cov_list_subscribe(src, cov_data, error_class, error_code);
+        } else if (cov_data->cancellationRequest) {
+            /* From BACnet Standard 135-2010-13.14.2
+               ...Cancellations that are issued for which no matching COV
+               context can be found shall succeed as if a context had
+               existed, returning 'Result(+)'. */
+            status = true;
         } else {
             *error_class = ERROR_CLASS_OBJECT;
             *error_code = ERROR_CODE_OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED;
         }
+    } else if (cov_data->cancellationRequest) {
+        /* From BACnet Standard 135-2010-13.14.2
+            ...Cancellations that are issued for which no matching COV
+            context can be found shall succeed as if a context had
+            existed, returning 'Result(+)'. */
+        status = true;
     } else {
         *error_class = ERROR_CLASS_OBJECT;
         *error_code = ERROR_CODE_UNKNOWN_OBJECT;


### PR DESCRIPTION
Per interpretation request during BACnet committee meeting today, changed SubscribeCOV Cancellations to always reply with Result(+) instead of object or service errors Result(-).