### PR TITLE
fix CMake for code::blocks build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -539,7 +539,9 @@ elseif(WIN32)
     $<$<BOOL:${BACDL_BIP}>:ws2_32>
     $<$<BOOL:${BACDL_BIP}>:iphlpapi>)
 
-  add_definitions("/W3 /D_CRT_SECURE_NO_WARNINGS /wd4244 /wd4018 /wd4267")
+  if(MSVC)
+    add_definitions("/W3 /D_CRT_SECURE_NO_WARNINGS /wd4244 /wd4018 /wd4267")
+  endif()
 
   target_sources(${PROJECT_NAME} PRIVATE
     ports/win32/bacport.h


### PR DESCRIPTION
fixed #528 by adding MSVC checking around MSVC specific options to allow CMake to build successfully on Windows with code::blocks tool option.