### PR TITLE
Fix MSTP slave FSM for Data-Expecting-Reply frames

### DIFF
--- a/ports/stm32f10x/dlmstp.c
+++ b/ports/stm32f10x/dlmstp.c
@@ -772,6 +772,9 @@ static void MSTP_Slave_Node_FSM(void)
                            to determine this is a local matter), then no reply
                            is possible. */
                         MSTP_Flag.ReceivedValidFrame = false;
+                    } else {
+                        /* indicate successful reception to higher layers */
+                        MSTP_Flag.ReceivePacketPending = true;
                     }
                 } else {
                     /* no reply when addressed as Broadcast */

--- a/ports/stm32f4xx/dlmstp.c
+++ b/ports/stm32f4xx/dlmstp.c
@@ -815,6 +815,9 @@ static void MSTP_Slave_Node_FSM(void)
                            to determine this is a local matter), then no reply
                            is possible. */
                         MSTP_Flag.ReceivedValidFrame = false;
+                    } else {
+                        /* indicate successful reception to higher layers */
+                        MSTP_Flag.ReceivePacketPending = true;
                     }
                 } else {
                     /* no reply when addressed as Broadcast */


### PR DESCRIPTION
Fix  #536 and #537 for MSTP slave FSM for Data-Expecting-Reply frames which need to indicate reception to higher layers.