### PR TITLE
Read Range returns wrong error code, when BY_POSITION and RefIndx == 0

### DIFF
--- a/src/bacnet/basic/service/h_rr.c
+++ b/src/bacnet/basic/service/h_rr.c
@@ -76,13 +76,7 @@ static int Encode_RR_payload(uint8_t *apdu, BACNET_READ_RANGE_DATA *pRequest)
         /* We try and do some of the more generic error checking here to cut
          * down on duplication of effort */
 
-        if ((pRequest->RequestType == RR_BY_POSITION) &&
-            (pRequest->Range.RefIndex ==
-                0)) { /* First index is 1 so can't accept 0 */
-            pRequest->error_code =
-                ERROR_CODE_OTHER; /* I couldn't see anything more appropriate
-                                     so... */
-        } else if (((PropInfo.RequestTypes & RR_ARRAY_OF_LISTS) == 0) &&
+        if (((PropInfo.RequestTypes & RR_ARRAY_OF_LISTS) == 0) &&
             (pRequest->array_index != 0) &&
             (pRequest->array_index != BACNET_ARRAY_ALL)) {
             /* Array access attempted on a non array property */


### PR DESCRIPTION
Chapter of BACnet norm about Read Range service states in [15.8.1.1.4.1.1 Reference Index]:
_If the item with the index specified in this parameter does not exist, then no items match the criteria for being
read and returned_
Which tells us that we have to return **empty list** when asked in this two cases:
- BY_POSITION, RefIndex <= 0
- BY_POSITION, RefIndex > Buffer_Size

First condition currently isn't made, thats why I think it needs to be removed.