### PR TITLE
Fixed compilation with BACNET_SVC_SERVER=1 for apps.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,14 @@ readbdt:
 readfdt:
 	$(MAKE) -s -C apps $@
 
+.PHONY: readprop
+readprop:
+	$(MAKE) -s -C apps $@
+
+.PHONY: readpropm
+readpropm:
+	$(MAKE) -s -C apps $@
+
 .PHONY: remove-list-element
 remove-list-element:
 	$(MAKE) -s -C apps $@

--- a/apps/add-list-element/main.c
+++ b/apps/add-list-element/main.c
@@ -15,6 +15,10 @@
 
 #define PRINT_ENABLED 1
 
+#if BACNET_SVC_SERVER
+#error "App requires server-only features disabled! Set BACNET_SVC_SERVER=0"
+#endif
+
 #include "bacnet/bacdef.h"
 #include "bacnet/config.h"
 #include "bacnet/bactext.h"

--- a/apps/create-object/main.c
+++ b/apps/create-object/main.c
@@ -15,6 +15,10 @@
 
 #define PRINT_ENABLED 1
 
+#if BACNET_SVC_SERVER
+#error "App requires server-only features disabled! Set BACNET_SVC_SERVER=0"
+#endif
+
 #include "bacnet/bacdef.h"
 #include "bacnet/config.h"
 #include "bacnet/bactext.h"

--- a/apps/delete-object/main.c
+++ b/apps/delete-object/main.c
@@ -15,6 +15,10 @@
 
 #define PRINT_ENABLED 1
 
+#if BACNET_SVC_SERVER
+#error "App requires server-only features disabled! Set BACNET_SVC_SERVER=0"
+#endif
+
 #include "bacnet/bacdef.h"
 #include "bacnet/config.h"
 #include "bacnet/bactext.h"

--- a/apps/readfile/main.c
+++ b/apps/readfile/main.c
@@ -51,6 +51,10 @@
 #include "bacnet/basic/tsm/tsm.h"
 #include "bacnet/datalink/dlenv.h"
 
+#if BACNET_SVC_SERVER
+#error "App requires server-only features disabled! Set BACNET_SVC_SERVER=0"
+#endif
+
 /* buffer used for receive */
 static uint8_t Rx_Buf[MAX_MPDU] = { 0 };
 

--- a/apps/readprop/main.c
+++ b/apps/readprop/main.c
@@ -35,6 +35,10 @@
 
 #define PRINT_ENABLED 1
 
+#if BACNET_SVC_SERVER
+#error "App requires server-only features disabled! Set BACNET_SVC_SERVER=0"
+#endif
+
 #include "bacnet/bacdef.h"
 #include "bacnet/config.h"
 #include "bacnet/bactext.h"

--- a/apps/readpropm/main.c
+++ b/apps/readpropm/main.c
@@ -35,6 +35,10 @@
 
 #define PRINT_ENABLED 1
 
+#if BACNET_SVC_SERVER
+#error "App requires server-only features disabled! Set BACNET_SVC_SERVER=0"
+#endif
+
 #include "bacnet/bacdef.h"
 #include "bacnet/config.h"
 #include "bacnet/bactext.h"

--- a/apps/readrange/main.c
+++ b/apps/readrange/main.c
@@ -56,6 +56,10 @@
 #include "bacnet/datalink/dlenv.h"
 #include "bacnet/readrange.h"
 
+#if BACNET_SVC_SERVER
+#error "App requires server-only features disabled! Set BACNET_SVC_SERVER=0"
+#endif
+
 /* buffer used for receive */
 static uint8_t Rx_Buf[MAX_MPDU] = { 0 };
 

--- a/apps/remove-list-element/main.c
+++ b/apps/remove-list-element/main.c
@@ -39,6 +39,10 @@
 #include "bacnet/basic/tsm/tsm.h"
 #include "bacnet/datalink/dlenv.h"
 
+#if BACNET_SVC_SERVER
+#error "App requires server-only features disabled! Set BACNET_SVC_SERVER=0"
+#endif
+
 /* buffer used for receive */
 static uint8_t Rx_Buf[MAX_MPDU] = { 0 };
 /* target device data for the request */

--- a/apps/scov/main.c
+++ b/apps/scov/main.c
@@ -54,6 +54,10 @@
 #include "bacnet/basic/tsm/tsm.h"
 #include "bacnet/datalink/dlenv.h"
 
+#if BACNET_SVC_SERVER
+#error "App requires server-only features disabled! Set BACNET_SVC_SERVER=0"
+#endif
+
 /* buffer used for receive */
 static uint8_t Rx_Buf[MAX_MPDU] = { 0 };
 

--- a/apps/server-client/main.c
+++ b/apps/server-client/main.c
@@ -26,6 +26,10 @@
 #include "bacnet/datalink/datalink.h"
 #include "bacnet/datalink/dlenv.h"
 
+#if BACNET_SVC_SERVER
+#error "App requires server-only features disabled! Set BACNET_SVC_SERVER=0"
+#endif
+
 /* print with flush by default */
 #define PRINTF debug_aprintf
 

--- a/apps/writeprop/main.c
+++ b/apps/writeprop/main.c
@@ -56,6 +56,10 @@
 #define MAX_PROPERTY_VALUES 64
 #endif
 
+#if BACNET_SVC_SERVER
+#error "App requires server-only features disabled! Set BACNET_SVC_SERVER=0"
+#endif
+
 /* buffer used for receive */
 static uint8_t Rx_Buf[MAX_MPDU] = { 0 };
 

--- a/apps/writepropm/main.c
+++ b/apps/writepropm/main.c
@@ -33,6 +33,10 @@
 
 #define PRINT_ENABLED 1
 
+#if BACNET_SVC_SERVER
+#error "App requires server-only features disabled! Set BACNET_SVC_SERVER=0"
+#endif
+
 #include "bacnet/bacdef.h"
 #include "bacnet/config.h"
 #include "bacnet/bactext.h"

--- a/src/bacnet/basic/service/h_apdu.c
+++ b/src/bacnet/basic/service/h_apdu.c
@@ -559,16 +559,18 @@ void apdu_handler(BACNET_ADDRESS *src,
     uint16_t apdu_len)
 {
     BACNET_CONFIRMED_SERVICE_DATA service_data = { 0 };
-    BACNET_CONFIRMED_SERVICE_ACK_DATA service_ack_data = { 0 };
-    uint8_t invoke_id = 0;
     uint8_t service_choice = 0;
     uint8_t *service_request = NULL;
     uint16_t service_request_len = 0;
     int len = 0; /* counts where we are in PDU */
+#if !BACNET_SVC_SERVER
+    uint8_t invoke_id = 0;
+    BACNET_CONFIRMED_SERVICE_ACK_DATA service_ack_data = { 0 };
     BACNET_ERROR_CODE error_code = ERROR_CODE_SUCCESS;
     BACNET_ERROR_CLASS error_class = ERROR_CLASS_SERVICES;
     uint8_t reason = 0;
     bool server = false;
+#endif
 
     if (apdu) {
         /* PDU Type */
@@ -620,6 +622,7 @@ void apdu_handler(BACNET_ADDRESS *src,
                     }
                 }
                 break;
+#if !BACNET_SVC_SERVER
             case PDU_TYPE_SIMPLE_ACK:
                 if (apdu_len < 3) {
                     break;
@@ -716,6 +719,7 @@ void apdu_handler(BACNET_ADDRESS *src,
                 }
                 tsm_free_invoke_id(invoke_id);
                 break;
+#endif
             default:
                 break;
         }

--- a/src/bacnet/config.h
+++ b/src/bacnet/config.h
@@ -244,9 +244,10 @@
 */
 
 /*
-** Note: I've left everything enabled here in the default config.h. You should
-** use a local copy of config.h with settings configured for your needs to
-** make use of any code space reductions in your device.
+** Note: these are enabled by default for the example apps to build. 
+** Use a local copy named "bacnet-config.h" with settings configured for 
+** the product specific needs for code space reductions in your device.
+** Alternately, use a compiler and linker the have code reduction features.
 **/
 
 #define BACNET_SVC_I_HAVE_A    1

--- a/src/bacnet/create_object.c
+++ b/src/bacnet/create_object.c
@@ -351,6 +351,7 @@ int create_object_error_ack_encode(
     return len;
 }
 
+#if !BACNET_SVC_SERVER
 /**
  * @brief Decode a CreateObject-Error ACK APDU
  *
@@ -419,3 +420,4 @@ int create_object_error_ack_service_decode(
 
     return apdu_len;
 }
+#endif

--- a/src/bacnet/list_element.c
+++ b/src/bacnet/list_element.c
@@ -273,6 +273,7 @@ int list_element_error_ack_encode(
     return apdu_len;
 }
 
+#if !BACNET_SVC_SERVER
 /**
  * @brief Decoding for AddListElement or RemoveListElement Error Ack
  *  AddListElement-Error ::= SEQUENCE {
@@ -361,3 +362,4 @@ int list_element_error_ack_decode(
 
     return apdu_len;
 }
+#endif

--- a/src/bacnet/wpm.c
+++ b/src/bacnet/wpm.c
@@ -437,6 +437,7 @@ int wpm_error_ack_encode_apdu(
     return len;
 }
 
+#if !BACNET_SVC_SERVER
 /** Decoding for WritePropertyMultiple Error
  * @ingroup DSWPM
  *  WritePropertyMultiple-Error ::= SEQUENCE {
@@ -571,6 +572,7 @@ int wpm_error_ack_decode_apdu(
 
     return apdu_len;
 }
+#endif
 
 /**
  * @brief Convert an array of BACnetWriteAccessData to linked list


### PR DESCRIPTION
Fixed issue#551 where config.h set BACNET_SVC_SERVER=1 for apps. Now emitting error for client apps, and not including client functions in APDU handler.