### PR TITLE
ao.h: add BACNET_STACK_EXPORT macro to Analog_Output_Read_Property function

### DIFF
--- a/src/bacnet/basic/object/ao.h
+++ b/src/bacnet/basic/object/ao.h
@@ -184,6 +184,7 @@ extern "C" {
     bool Analog_Output_Max_Pres_Value_Set(
         uint32_t object_instance, float value);
 
+    BACNET_STACK_EXPORT
     int Analog_Output_Read_Property(
         BACNET_READ_PROPERTY_DATA * rpdata);
     BACNET_STACK_EXPORT


### PR DESCRIPTION
In commit 100df01cefe1fd6b26f984c75959c4e898221087 several new functions were added to the analog output objects. In the process however, one call to the BACNET_STACK_EXPORT macro was omitted, the one just before the declaration of Analog_Output_Read_Property:

```text
@@ -142,6 +157,33 @@ extern "C" {
         bool oos_flag);

     BACNET_STACK_EXPORT
+    bool Analog_Output_Overridden(
+        uint32_t instance);
+    BACNET_STACK_EXPORT
+    void Analog_Output_Overridden_Set(
+        uint32_t instance,
+        bool oos_flag);
+
+    BACNET_STACK_EXPORT
+    BACNET_RELIABILITY Analog_Output_Reliability(
+        uint32_t object_instance);
+    BACNET_STACK_EXPORT
+    bool Analog_Output_Reliability_Set(
+        uint32_t object_instance, BACNET_RELIABILITY value);
+
+    BACNET_STACK_EXPORT
+    float Analog_Output_Min_Pres_Value(
+        uint32_t object_instance);
+    BACNET_STACK_EXPORT
+    bool Analog_Output_Min_Pres_Value_Set(
+        uint32_t object_instance, float value);
+    BACNET_STACK_EXPORT
+    float Analog_Output_Max_Pres_Value(
+        uint32_t object_instance);
+    BACNET_STACK_EXPORT
+    bool Analog_Output_Max_Pres_Value_Set(
+        uint32_t object_instance, float value);
+
     int Analog_Output_Read_Property(
         BACNET_READ_PROPERTY_DATA * rpdata);
     BACNET_STACK_EXPORT
```

Add back the call to this macro so that Analog_Output_Read_Property is properly exported as a global symbol when the library is compiled with -DBUILD_SHARED_LIBS=ON using cmake. This macro expands to __declspec(dllexport) on Windows and __attribute__((visibility("default"))) on Linux. It is necessary when compiling with the -fvisibility-hidden flag.