### PR TITLE
CMakeLists.txt: exclude h_routed_npdu.c when BAC_ROUTING=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,8 +161,8 @@ add_library(${PROJECT_NAME}
     src/bacnet/basic/binding/address.h
     src/bacnet/basic/npdu/h_npdu.c
     src/bacnet/basic/npdu/h_npdu.h
-    src/bacnet/basic/npdu/h_routed_npdu.c
-    src/bacnet/basic/npdu/h_routed_npdu.h
+    $<$<BOOL:${BAC_ROUTING}>:src/bacnet/basic/npdu/h_routed_npdu.c>
+    $<$<BOOL:${BAC_ROUTING}>:src/bacnet/basic/npdu/h_routed_npdu.h>
     src/bacnet/basic/npdu/s_router.c
     src/bacnet/basic/npdu/s_router.h
     src/bacnet/basic/object/access_credential.c


### PR DESCRIPTION
When calling cmake with -DBAC_ROUTING=OFF, basic/object/gateway/gw_device.c is correctly excluded from the build. 

It does contain however the definition for the functions `Routed_Device_GetNext` and `Routed_Device_Is_Valid_Network`, both of which are called in the `routed_apdu_handler` function of basic/npdu/h_routed_npdu.c. 

This is fine during compilation since these functions' prototypes are declared in basic/object/device.h but linking will fail.

Thus, make the compilation of h_routed_npdu.c conditional depending on the value of `BAC_ROUTING`.