### PR TITLE
Bugfix/bacaddr dnet only init

### DIFF
--- a/src/bacnet/bacaddr.c
+++ b/src/bacnet/bacaddr.c
@@ -156,7 +156,7 @@ bool bacnet_address_init(BACNET_ADDRESS *dest,
         for (i = 0; i < MAX_MAC_LEN; i++) {
             dest->mac[i] = 0;
         }
-        dest->mac_len = mac->len;
+        dest->mac_len = 0;
         for (i = 0; i < MAX_MAC_LEN; i++) {
             dest->adr[i] = 0;
         }

--- a/src/bacnet/basic/sys/platform.h
+++ b/src/bacnet/basic/sys/platform.h
@@ -40,17 +40,43 @@
 #   define BACNET_STACK_DEPRECATED(message)
 # endif
 
-#if defined(WIN32) || defined(WIN64)
-#include <strings.h>
+#if defined(_MSC_VER)
 #ifndef strcasecmp
 #define strcasecmp _stricmp
 #endif
 #ifndef strncasecmp
 #define strncasecmp _strnicmp
 #endif
-#include<stdio.h>
-#ifndef snprintf
-#define snprintf _snprintf
+#if (_MSC_VER < 1900)
+#include <stdio.h>
+#include <stdarg.h>
+#define snprintf c99_snprintf
+#define vsnprintf c99_vsnprintf
+
+__inline int c99_vsnprintf(char *outBuf, size_t size, const char *format,
+    va_list ap)
+{
+    int count = -1;
+
+    if (size != 0)
+        count = _vsnprintf_s(outBuf, size, _TRUNCATE, format, ap);
+    if (count == -1)
+        count = _vscprintf(format, ap);
+
+    return count;
+}
+
+__inline int c99_snprintf(char *outBuf, size_t size, const char *format, ...)
+{
+    int count;
+    va_list ap;
+
+    va_start(ap, format);
+    count = c99_vsnprintf(outBuf, size, format, ap);
+    va_end(ap);
+
+    return count;
+}
 #endif
 #elif defined(__ZEPHYR__)
 #  include <strings.h>

--- a/src/bacnet/basic/sys/platform.h
+++ b/src/bacnet/basic/sys/platform.h
@@ -2,7 +2,7 @@
  * @file
  * @author Steve Karg
  * @date 2022
- * @brief Platform libc and compiler abstraction layer 
+ * @brief Platform libc and compiler abstraction layer
   *
  * @section DESCRIPTION
  *
@@ -41,9 +41,15 @@
 # endif
 
 #if defined(WIN32) || defined(WIN64)
+#ifndef strcasecmp
 #define strcasecmp _stricmp
+#endif
+#ifndef strncasecmp
 #define strncasecmp _strnicmp
+#endif
+#ifndef snprintf
 #define snprintf _snprintf
+#endif
 #elif defined(__ZEPHYR__)
 #  include <strings.h>
 # endif
@@ -62,7 +68,7 @@
 #define BACNET_STACK_FALLTHROUGH() /* fall through */
 #elif defined(__GNUC__)
 #define BACNET_STACK_FALLTHROUGH() __attribute__ ((fallthrough))
-#else 
+#else
 #define BACNET_STACK_FALLTHROUGH() /* fall through */
 #endif
 

--- a/src/bacnet/basic/sys/platform.h
+++ b/src/bacnet/basic/sys/platform.h
@@ -41,12 +41,14 @@
 # endif
 
 #if defined(WIN32) || defined(WIN64)
+#include <strings.h>
 #ifndef strcasecmp
 #define strcasecmp _stricmp
 #endif
 #ifndef strncasecmp
 #define strncasecmp _strnicmp
 #endif
+#include<stdio.h>
 #ifndef snprintf
 #define snprintf _snprintf
 #endif

--- a/test/bacnet/bacaddr/src/main.c
+++ b/test/bacnet/bacaddr/src/main.c
@@ -99,6 +99,14 @@ static void test_BACNET_ADDRESS(void)
     dest.mac_len = 1;
     status = bacnet_address_same(&dest, &src);
     zassert_false(status, NULL);
+    /* only setting a DNET address */
+    dnet = 1234;
+    status = bacnet_address_init(&dest, NULL, dnet, NULL);
+    zassert_true(status, NULL);
+    status = bacnet_address_init(&src, NULL, dnet, NULL);
+    zassert_true(status, NULL);
+    status = bacnet_address_same(&dest, &src);
+    zassert_true(status, NULL);
 }
 
 #if defined(CONFIG_ZTEST_NEW_API)


### PR DESCRIPTION
Fixed bacnet_address_init() when setting only the dnet value

Fixed compile warning for string functions on win32/win64 builds