### PR TITLE
ao.c: set proper bounds for Analog_Output_Present_Value_Set and Analog_Output_Present_Value_Write

### DIFF
--- a/src/bacnet/basic/object/ao.c
+++ b/src/bacnet/basic/object/ao.c
@@ -340,7 +340,8 @@ bool Analog_Output_Present_Value_Set(
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
-        if ((priority >= 1) && (priority <= BACNET_MAX_PRIORITY)) {
+        if ((priority >= 1) && (priority <= BACNET_MAX_PRIORITY) &&
+                value >= pObject->Min_Pres_Value && value <= pObject->Max_Pres_Value) {
             pObject->Relinquished[priority - 1] = false;
             pObject->Priority_Array[priority - 1] = value;
             Analog_Output_Present_Value_COV_Detect(

--- a/src/bacnet/basic/object/ao.c
+++ b/src/bacnet/basic/object/ao.c
@@ -402,7 +402,7 @@ static bool Analog_Output_Present_Value_Write(uint32_t object_instance,
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if ((priority >= 1) && (priority <= BACNET_MAX_PRIORITY) &&
-            (value >= 0.0) && (value <= 100.0)) {
+            (value >= pObject->Min_Pres_Value) && (value <= pObject->Max_Pres_Value)) {
             if (priority != 6) {
                 old_value = Analog_Output_Present_Value(object_instance);
                 Analog_Output_Present_Value_Set(


### PR DESCRIPTION
`Analog_Output_Present_Value_Write` hard-coded the lower and upper bounds of a new value to 0 and 100. It should instead use the previously define `Min_Pres_Value` and `Max_Pres_Value` which are set to 0 and 100 by default.

There was no verification of the bounds within `Analog_Output_Present_Value_Set`, therefore using this function, an arbitrary value could be set. I changed this to not update the present value at all if it's outside of the defined bounds.

Maybe we could also change `Analog_Output_Present_Value_Set` to set the object's Present_Value to `Min_Pres_Value` and `Max_Pres_Value` respectively considering according to the standard they indicate "lowest/highest number in engineering units that can be reliably used for the Present_Value".