### PR TITLE
Require bacdef.h as first bacnet header to include (#598)

### DIFF
--- a/ports/zephyr/bacnet-config.h
+++ b/ports/zephyr/bacnet-config.h
@@ -1,10 +1,6 @@
-/**
-* @file
-* @author Steve Karg
-* @date October 2019
-* @brief Header file for a basic GetEventInformation service send
+/**************************************************************************
 *
-* @section LICENSE
+* Copyright (c) 2024 Legrand North America, LLC.
 *
 * Permission is hereby granted, free of charge, to any person obtaining
 * a copy of this software and associated documentation files (the
@@ -24,33 +20,16 @@
 * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
-#ifndef SEND_GET_EVENT_INFORMATION_H
-#define SEND_GET_EVENT_INFORMATION_H
+*
+*********************************************************************/
 
-#include <stddef.h>
-#include <stdint.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
-#include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacapp.h"
-#include "bacnet/bacenum.h"
-#include "bacnet/apdu.h"
+#ifndef BACNET_PORTS_ZEPHYR_BACNET_CONFIG_H
+#define BACNET_PORTS_ZEPHYR_BACNET_CONFIG_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
-BACNET_STACK_EXPORT
-uint8_t Send_Get_Event_Information_Address(
-    BACNET_ADDRESS *dest, uint16_t max_apdu,
-    BACNET_OBJECT_ID *lastReceivedObjectIdentifier);
-BACNET_STACK_EXPORT
-uint8_t Send_Get_Event_Information(
-    uint32_t device_id, BACNET_OBJECT_ID *lastReceivedObjectIdentifier);
-
-#ifdef __cplusplus
-}
-#endif /* __cplusplus */
+#if ! defined BACNET_CONFIG_H || ! BACNET_CONFIG_H
+#error bacnet-config.h included outside of BACNET_CONFIG_H control
 #endif
+
+#include <zephyr/sys/util.h>  // Provides platform-specific defn of ARRAY_SIZE()
+
+#endif // BACNET_PORTS_ZEPHYR_BACNET_CONFIG_H

--- a/src/bacnet/abort.h
+++ b/src/bacnet/abort.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
 

--- a/src/bacnet/access_rule.h
+++ b/src/bacnet/access_rule.h
@@ -28,8 +28,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacapp.h"
 #include "bacnet/bacdevobjpropref.h"
 

--- a/src/bacnet/alarm_ack.h
+++ b/src/bacnet/alarm_ack.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/bacapp.h"

--- a/src/bacnet/apdu.h
+++ b/src/bacnet/apdu.h
@@ -26,7 +26,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include "bacnet/bacdef.h"
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacenum.h"
 
 typedef struct _confirmed_service_data {

--- a/src/bacnet/arf.h
+++ b/src/bacnet/arf.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacdcode.h"
 #include "bacnet/bacstr.h"

--- a/src/bacnet/assigned_access_rights.h
+++ b/src/bacnet/assigned_access_rights.h
@@ -28,8 +28,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacapp.h"
 #include "bacnet/bacdevobjpropref.h"
 

--- a/src/bacnet/authentication_factor.h
+++ b/src/bacnet/authentication_factor.h
@@ -28,8 +28,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacapp.h"
 
 typedef struct {

--- a/src/bacnet/authentication_factor_format.h
+++ b/src/bacnet/authentication_factor_format.h
@@ -28,8 +28,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 
 typedef struct {
     BACNET_AUTHENTICATION_FACTOR_TYPE format_type;

--- a/src/bacnet/awf.h
+++ b/src/bacnet/awf.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacdcode.h"
 

--- a/src/bacnet/bacaddr.h
+++ b/src/bacnet/bacaddr.h
@@ -27,9 +27,9 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/basic/sys/platform.h"
-#include "bacnet/bacdef.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bacnet/bacapp.h
+++ b/src/bacnet/bacapp.h
@@ -27,8 +27,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacdest.h"
 #include "bacnet/bacint.h"
 #include "bacnet/bacstr.h"

--- a/src/bacnet/bacdcode.h
+++ b/src/bacnet/bacdcode.h
@@ -27,9 +27,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/basic/sys/platform.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/datetime.h"
 #include "bacnet/bacstr.h"
 #include "bacnet/bacint.h"

--- a/src/bacnet/bacdef.h
+++ b/src/bacnet/bacdef.h
@@ -26,9 +26,8 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include "bacnet/bacenum.h"
-#include "bacnet/bacint.h"
 #include "bacnet/config.h"
+#include "bacnet/bacenum.h"
 
 #if defined(_MSC_VER)
 /* Silence the warnings about unsafe versions of library functions */
@@ -125,6 +124,15 @@
 #define MAX_BACNET_SERVICES_SUPPORTED 47
 #else
 #error MAX_ASHRAE_OBJECT_TYPE and MAX_BACNET_SERVICES_SUPPORTED not defined!
+#endif
+
+/* Support 64b integers when available */
+#ifdef UINT64_MAX
+typedef uint64_t BACNET_UNSIGNED_INTEGER;
+#define BACNET_UNSIGNED_INTEGER_MAX UINT64_MAX
+#else
+typedef uint32_t BACNET_UNSIGNED_INTEGER;
+#define BACNET_UNSIGNED_INTEGER_MAX UINT32_MAX
 #endif
 
 /* largest BACnet Instance Number */

--- a/src/bacnet/bacdest.h
+++ b/src/bacnet/bacdest.h
@@ -14,6 +14,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/bacstr.h"

--- a/src/bacnet/bacdevobjpropref.h
+++ b/src/bacnet/bacdevobjpropref.h
@@ -28,8 +28,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacint.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/basic/sys/platform.h"

--- a/src/bacnet/bacerror.h
+++ b/src/bacnet/bacerror.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
 

--- a/src/bacnet/bacint.h
+++ b/src/bacnet/bacint.h
@@ -27,15 +27,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-
-#ifdef UINT64_MAX
-typedef uint64_t BACNET_UNSIGNED_INTEGER;
-#define BACNET_UNSIGNED_INTEGER_MAX UINT64_MAX
-#else
-typedef uint32_t BACNET_UNSIGNED_INTEGER;
-#define BACNET_UNSIGNED_INTEGER_MAX UINT32_MAX
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bacnet/bacnet_stack_exports.h
+++ b/src/bacnet/bacnet_stack_exports.h
@@ -24,6 +24,7 @@
 #ifndef BACNET_STACK_EXPORTS_H
 #define BACNET_STACK_EXPORTS_H
 
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 
 #ifdef BACNET_STACK_STATIC_DEFINE
     /* We want a static library */

--- a/src/bacnet/bacprop.h
+++ b/src/bacnet/bacprop.h
@@ -26,6 +26,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
 

--- a/src/bacnet/bacpropstates.h
+++ b/src/bacnet/bacpropstates.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/bacapp.h"

--- a/src/bacnet/bacreal.h
+++ b/src/bacnet/bacreal.h
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 
 #ifdef __cplusplus

--- a/src/bacnet/bacstr.h
+++ b/src/bacnet/bacstr.h
@@ -27,8 +27,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/config.h"
 
 /* bit strings

--- a/src/bacnet/bactext.h
+++ b/src/bacnet/bactext.h
@@ -31,6 +31,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/indtext.h"
 

--- a/src/bacnet/bactimevalue.h
+++ b/src/bacnet/bactimevalue.h
@@ -28,10 +28,11 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/basic/sys/platform.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
+#include "bacnet/bacint.h"
 #include "bacnet/datetime.h"
 
 /**

--- a/src/bacnet/basic/bbmd/h_bbmd.h
+++ b/src/bacnet/basic/bbmd/h_bbmd.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/datalink/bvlc.h"
 
 #ifdef __cplusplus

--- a/src/bacnet/basic/bbmd6/h_bbmd6.h
+++ b/src/bacnet/basic/bbmd6/h_bbmd6.h
@@ -32,7 +32,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include "bacnet/bacdef.h"
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/datalink/bvlc6.h"
 

--- a/src/bacnet/basic/bbmd6/vmac.h
+++ b/src/bacnet/basic/bbmd6/vmac.h
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 
 /* define the max MAC as big as IPv6 + port number */

--- a/src/bacnet/basic/binding/address.h
+++ b/src/bacnet/basic/binding/address.h
@@ -27,8 +27,8 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacaddr.h"
 #include "bacnet/readrange.h"
 

--- a/src/bacnet/basic/client/bac-data.h
+++ b/src/bacnet/basic/client/bac-data.h
@@ -9,7 +9,7 @@
 #define BAC_DATA_H
 
 #include <stdint.h>
-#include "bacnet/bacdef.h"
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacenum.h"
 #include "bacnet/bacapp.h"
 #include "bacnet/rp.h"

--- a/src/bacnet/basic/client/bac-discover.h
+++ b/src/bacnet/basic/client/bac-discover.h
@@ -10,7 +10,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include "bacnet/bacdef.h"
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacenum.h"
 #include "bacnet/bacapp.h"
 #include "bacnet/rp.h"

--- a/src/bacnet/basic/client/bac-rw.h
+++ b/src/bacnet/basic/client/bac-rw.h
@@ -9,7 +9,7 @@
 #define BAC_RW_H
 
 #include <stdint.h>
-#include "bacnet/bacdef.h"
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacenum.h"
 #include "bacnet/bacapp.h"
 #include "bacnet/rp.h"

--- a/src/bacnet/basic/client/bac-task.h
+++ b/src/bacnet/basic/client/bac-task.h
@@ -10,6 +10,7 @@
 #define BACNET_TASK_H
 
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 
 #ifdef __cplusplus

--- a/src/bacnet/basic/npdu/h_npdu.h
+++ b/src/bacnet/basic/npdu/h_npdu.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/npdu.h"

--- a/src/bacnet/basic/npdu/h_routed_npdu.h
+++ b/src/bacnet/basic/npdu/h_routed_npdu.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/npdu/s_router.h
+++ b/src/bacnet/basic/npdu/s_router.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/object/acc.h
+++ b/src/bacnet/basic/object/acc.h
@@ -3,8 +3,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacint.h"
 #include "bacnet/rp.h"
 #include "bacnet/wp.h"

--- a/src/bacnet/basic/object/access_credential.h
+++ b/src/bacnet/basic/object/access_credential.h
@@ -27,8 +27,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/datetime.h"
 #include "bacnet/timestamp.h"

--- a/src/bacnet/basic/object/access_door.h
+++ b/src/bacnet/basic/object/access_door.h
@@ -27,8 +27,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/rp.h"
 #include "bacnet/wp.h"

--- a/src/bacnet/basic/object/access_point.h
+++ b/src/bacnet/basic/object/access_point.h
@@ -27,8 +27,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/timestamp.h"
 #include "bacnet/bacdevobjpropref.h"

--- a/src/bacnet/basic/object/access_rights.h
+++ b/src/bacnet/basic/object/access_rights.h
@@ -27,8 +27,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/bacdevobjpropref.h"
 #include "bacnet/access_rule.h"

--- a/src/bacnet/basic/object/access_user.h
+++ b/src/bacnet/basic/object/access_user.h
@@ -27,8 +27,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/bacdevobjpropref.h"
 #include "bacnet/rp.h"

--- a/src/bacnet/basic/object/access_zone.h
+++ b/src/bacnet/basic/object/access_zone.h
@@ -27,8 +27,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/bacdevobjpropref.h"
 #include "bacnet/rp.h"

--- a/src/bacnet/basic/object/ai.h
+++ b/src/bacnet/basic/object/ai.h
@@ -28,8 +28,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/rp.h"
 #include "bacnet/wp.h"
 #if defined(INTRINSIC_REPORTING)

--- a/src/bacnet/basic/object/ao.h
+++ b/src/bacnet/basic/object/ao.h
@@ -36,9 +36,9 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/config.h"
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/rp.h"

--- a/src/bacnet/basic/object/av.h
+++ b/src/bacnet/basic/object/av.h
@@ -28,8 +28,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/wp.h"
 #include "bacnet/rp.h"

--- a/src/bacnet/basic/object/bacfile.h
+++ b/src/bacnet/basic/object/bacfile.h
@@ -36,8 +36,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/bacint.h"
 #include "bacnet/datetime.h"

--- a/src/bacnet/basic/object/bi.h
+++ b/src/bacnet/basic/object/bi.h
@@ -27,8 +27,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/cov.h"
 #include "bacnet/rp.h"
 #include "bacnet/wp.h"

--- a/src/bacnet/basic/object/blo.h
+++ b/src/bacnet/basic/object/blo.h
@@ -11,8 +11,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/rp.h"
 #include "bacnet/wp.h"

--- a/src/bacnet/basic/object/bo.h
+++ b/src/bacnet/basic/object/bo.h
@@ -35,9 +35,9 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/config.h"
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/cov.h"

--- a/src/bacnet/basic/object/bv.h
+++ b/src/bacnet/basic/object/bv.h
@@ -27,8 +27,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/rp.h"
 #include "bacnet/wp.h"

--- a/src/bacnet/basic/object/calendar.h
+++ b/src/bacnet/basic/object/calendar.h
@@ -12,9 +12,9 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/config.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/calendar_entry.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/bacerror.h"

--- a/src/bacnet/basic/object/channel.h
+++ b/src/bacnet/basic/object/channel.h
@@ -36,8 +36,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/rp.h"
 #include "bacnet/wp.h"
 #include "bacnet/basic/object/lo.h"

--- a/src/bacnet/basic/object/color_object.h
+++ b/src/bacnet/basic/object/color_object.h
@@ -20,9 +20,9 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/config.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/rp.h"

--- a/src/bacnet/basic/object/color_temperature.h
+++ b/src/bacnet/basic/object/color_temperature.h
@@ -20,9 +20,9 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/config.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/rp.h"

--- a/src/bacnet/basic/object/command.h
+++ b/src/bacnet/basic/object/command.h
@@ -44,8 +44,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/rp.h"
 #include "bacnet/wp.h"
 

--- a/src/bacnet/basic/object/credential_data_input.h
+++ b/src/bacnet/basic/object/credential_data_input.h
@@ -27,8 +27,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/timestamp.h"
 #include "bacnet/bacdevobjpropref.h"

--- a/src/bacnet/basic/object/csv.h
+++ b/src/bacnet/basic/object/csv.h
@@ -27,8 +27,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/rp.h"
 #include "bacnet/wp.h"

--- a/src/bacnet/basic/object/device.h
+++ b/src/bacnet/basic/object/device.h
@@ -31,8 +31,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/create_object.h"
 #include "bacnet/delete_object.h"

--- a/src/bacnet/basic/object/iv.h
+++ b/src/bacnet/basic/object/iv.h
@@ -35,8 +35,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/wp.h"
 #include "bacnet/rp.h"

--- a/src/bacnet/basic/object/lc.h
+++ b/src/bacnet/basic/object/lc.h
@@ -27,8 +27,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/rp.h"
 #include "bacnet/wp.h"

--- a/src/bacnet/basic/object/lsp.h
+++ b/src/bacnet/basic/object/lsp.h
@@ -27,8 +27,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/rp.h"
 #include "bacnet/wp.h"

--- a/src/bacnet/basic/object/lsz.h
+++ b/src/bacnet/basic/object/lsz.h
@@ -22,8 +22,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/rp.h"
 #include "bacnet/wp.h"

--- a/src/bacnet/basic/object/ms-input.h
+++ b/src/bacnet/basic/object/ms-input.h
@@ -27,8 +27,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/rp.h"
 #include "bacnet/wp.h"

--- a/src/bacnet/basic/object/mso.h
+++ b/src/bacnet/basic/object/mso.h
@@ -35,9 +35,9 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/config.h"
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/cov.h"

--- a/src/bacnet/basic/object/msv.h
+++ b/src/bacnet/basic/object/msv.h
@@ -27,8 +27,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/rp.h"
 #include "bacnet/wp.h"

--- a/src/bacnet/basic/object/nc.h
+++ b/src/bacnet/basic/object/nc.h
@@ -25,6 +25,7 @@
 #ifndef NC_H
 #define NC_H
 
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacdest.h"
 #include "bacnet/event.h"

--- a/src/bacnet/basic/object/netport.h
+++ b/src/bacnet/basic/object/netport.h
@@ -36,8 +36,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/rp.h"

--- a/src/bacnet/basic/object/objects.h
+++ b/src/bacnet/basic/object/objects.h
@@ -27,8 +27,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacstr.h"
 #include "bacnet/bacenum.h"
 

--- a/src/bacnet/basic/object/osv.h
+++ b/src/bacnet/basic/object/osv.h
@@ -27,8 +27,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/wp.h"
 #include "bacnet/rp.h"

--- a/src/bacnet/basic/object/piv.h
+++ b/src/bacnet/basic/object/piv.h
@@ -27,8 +27,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/wp.h"
 #include "bacnet/rp.h"

--- a/src/bacnet/basic/object/schedule.h
+++ b/src/bacnet/basic/object/schedule.h
@@ -28,8 +28,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacapp.h"
 #include "bacnet/datetime.h"
 #include "bacnet/bacerror.h"

--- a/src/bacnet/basic/object/time_value.h
+++ b/src/bacnet/basic/object/time_value.h
@@ -12,9 +12,9 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/config.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/bacerror.h"
 #include "bacnet/rp.h"

--- a/src/bacnet/basic/object/trendlog.h
+++ b/src/bacnet/basic/object/trendlog.h
@@ -27,8 +27,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/cov.h"
 #include "bacnet/datetime.h"
 #include "bacnet/readrange.h"

--- a/src/bacnet/basic/service/h_alarm_ack.h
+++ b/src/bacnet/basic/service/h_alarm_ack.h
@@ -30,8 +30,8 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/alarm_ack.h"

--- a/src/bacnet/basic/service/h_apdu.h
+++ b/src/bacnet/basic/service/h_apdu.h
@@ -30,8 +30,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_arf.h
+++ b/src/bacnet/basic/service/h_arf.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_arf_a.h
+++ b/src/bacnet/basic/service/h_arf_a.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_awf.h
+++ b/src/bacnet/basic/service/h_awf.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_ccov.h
+++ b/src/bacnet/basic/service/h_ccov.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/cov.h"

--- a/src/bacnet/basic/service/h_cov.h
+++ b/src/bacnet/basic/service/h_cov.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_create_object.h
+++ b/src/bacnet/basic/service/h_create_object.h
@@ -12,9 +12,9 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/apdu.h"
 
 #ifdef __cplusplus

--- a/src/bacnet/basic/service/h_dcc.h
+++ b/src/bacnet/basic/service/h_dcc.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_delete_object.h
+++ b/src/bacnet/basic/service/h_delete_object.h
@@ -12,9 +12,9 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/apdu.h"
 
 #ifdef __cplusplus

--- a/src/bacnet/basic/service/h_gas_a.h
+++ b/src/bacnet/basic/service/h_gas_a.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_get_alarm_sum.h
+++ b/src/bacnet/basic/service/h_get_alarm_sum.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/get_alarm_sum.h"

--- a/src/bacnet/basic/service/h_getevent.h
+++ b/src/bacnet/basic/service/h_getevent.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/event.h"

--- a/src/bacnet/basic/service/h_getevent_a.h
+++ b/src/bacnet/basic/service/h_getevent_a.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_iam.h
+++ b/src/bacnet/basic/service/h_iam.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_ihave.h
+++ b/src/bacnet/basic/service/h_ihave.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_list_element.h
+++ b/src/bacnet/basic/service/h_list_element.h
@@ -14,9 +14,9 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/apdu.h"
 
 #ifdef __cplusplus

--- a/src/bacnet/basic/service/h_lso.h
+++ b/src/bacnet/basic/service/h_lso.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_noserv.h
+++ b/src/bacnet/basic/service/h_noserv.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_rd.h
+++ b/src/bacnet/basic/service/h_rd.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_rp.h
+++ b/src/bacnet/basic/service/h_rp.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_rp_a.h
+++ b/src/bacnet/basic/service/h_rp_a.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/rp.h"

--- a/src/bacnet/basic/service/h_rpm.h
+++ b/src/bacnet/basic/service/h_rpm.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_rpm_a.h
+++ b/src/bacnet/basic/service/h_rpm_a.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/rpm.h"

--- a/src/bacnet/basic/service/h_rr.h
+++ b/src/bacnet/basic/service/h_rr.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_rr_a.h
+++ b/src/bacnet/basic/service/h_rr_a.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_ts.h
+++ b/src/bacnet/basic/service/h_ts.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/datetime.h"

--- a/src/bacnet/basic/service/h_ucov.h
+++ b/src/bacnet/basic/service/h_ucov.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/cov.h"

--- a/src/bacnet/basic/service/h_upt.h
+++ b/src/bacnet/basic/service/h_upt.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/ptransfer.h"

--- a/src/bacnet/basic/service/h_whohas.h
+++ b/src/bacnet/basic/service/h_whohas.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_whois.h
+++ b/src/bacnet/basic/service/h_whois.h
@@ -32,8 +32,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_wp.h
+++ b/src/bacnet/basic/service/h_wp.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/h_wpm.h
+++ b/src/bacnet/basic/service/h_wpm.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/s_abort.h
+++ b/src/bacnet/basic/service/s_abort.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/npdu.h"

--- a/src/bacnet/basic/service/s_ack_alarm.h
+++ b/src/bacnet/basic/service/s_ack_alarm.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/alarm_ack.h"

--- a/src/bacnet/basic/service/s_arfs.h
+++ b/src/bacnet/basic/service/s_arfs.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/s_awfs.h
+++ b/src/bacnet/basic/service/s_awfs.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/s_cevent.h
+++ b/src/bacnet/basic/service/s_cevent.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/event.h"

--- a/src/bacnet/basic/service/s_cov.h
+++ b/src/bacnet/basic/service/s_cov.h
@@ -33,9 +33,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/cov.h"

--- a/src/bacnet/basic/service/s_create_object.h
+++ b/src/bacnet/basic/service/s_create_object.h
@@ -14,9 +14,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/s_dcc.h
+++ b/src/bacnet/basic/service/s_dcc.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/s_delete_object.h
+++ b/src/bacnet/basic/service/s_delete_object.h
@@ -14,9 +14,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/s_error.h
+++ b/src/bacnet/basic/service/s_error.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/s_get_alarm_sum.h
+++ b/src/bacnet/basic/service/s_get_alarm_sum.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/s_getevent.h
+++ b/src/bacnet/basic/service/s_getevent.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/s_iam.h
+++ b/src/bacnet/basic/service/s_iam.h
@@ -32,10 +32,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/apdu.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/npdu.h"
 

--- a/src/bacnet/basic/service/s_ihave.h
+++ b/src/bacnet/basic/service/s_ihave.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/s_list_element.h
+++ b/src/bacnet/basic/service/s_list_element.h
@@ -16,9 +16,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/s_lso.h
+++ b/src/bacnet/basic/service/s_lso.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/lso.h"

--- a/src/bacnet/basic/service/s_rd.h
+++ b/src/bacnet/basic/service/s_rd.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/s_readrange.h
+++ b/src/bacnet/basic/service/s_readrange.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/readrange.h"

--- a/src/bacnet/basic/service/s_rp.h
+++ b/src/bacnet/basic/service/s_rp.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/s_rpm.h
+++ b/src/bacnet/basic/service/s_rpm.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/rpm.h"

--- a/src/bacnet/basic/service/s_ts.h
+++ b/src/bacnet/basic/service/s_ts.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/s_uevent.h
+++ b/src/bacnet/basic/service/s_uevent.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/s_upt.h
+++ b/src/bacnet/basic/service/s_upt.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/ptransfer.h"

--- a/src/bacnet/basic/service/s_whohas.h
+++ b/src/bacnet/basic/service/s_whohas.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/s_whois.h
+++ b/src/bacnet/basic/service/s_whois.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/s_wp.h
+++ b/src/bacnet/basic/service/s_wp.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 

--- a/src/bacnet/basic/service/s_wpm.h
+++ b/src/bacnet/basic/service/s_wpm.h
@@ -32,9 +32,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/apdu.h"
 #include "bacnet/wpm.h"

--- a/src/bacnet/basic/services.h
+++ b/src/bacnet/basic/services.h
@@ -25,6 +25,8 @@
 #ifndef BASIC_SERVICES_H
 #define BASIC_SERVICES_H
 
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
+
 /* NPDU layer handlers */
 #include "bacnet/basic/npdu/h_npdu.h"
 #include "bacnet/basic/npdu/h_routed_npdu.h"

--- a/src/bacnet/basic/sys/bigend.h
+++ b/src/bacnet/basic/sys/bigend.h
@@ -24,6 +24,7 @@
 #ifndef BIGEND_H
 #define BIGEND_H
 
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 
 #ifdef __cplusplus

--- a/src/bacnet/basic/sys/color_rgb.h
+++ b/src/bacnet/basic/sys/color_rgb.h
@@ -8,6 +8,7 @@
 #define COLOR_RGB_H
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 
 #ifdef __cplusplus

--- a/src/bacnet/basic/sys/days.h
+++ b/src/bacnet/basic/sys/days.h
@@ -8,6 +8,7 @@
 #define DAYS_H
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 
 #ifdef __cplusplus

--- a/src/bacnet/basic/sys/debug.h
+++ b/src/bacnet/basic/sys/debug.h
@@ -27,8 +27,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 
 #ifndef DEBUG_ENABLED
 #define DEBUG_ENABLED 0

--- a/src/bacnet/basic/sys/fifo.h
+++ b/src/bacnet/basic/sys/fifo.h
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 
 /**

--- a/src/bacnet/basic/sys/filename.h
+++ b/src/bacnet/basic/sys/filename.h
@@ -24,6 +24,7 @@
 #ifndef FILENAME_H
 #define FILENAME_H
 
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 
 #ifdef __cplusplus

--- a/src/bacnet/basic/sys/key.h
+++ b/src/bacnet/basic/sys/key.h
@@ -25,6 +25,7 @@
 #define KEY_H
 
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 
 /* This file has the macros that encode and decode the */
 /* keys for the keylist when used with BACnet Object Id's */

--- a/src/bacnet/basic/sys/keylist.h
+++ b/src/bacnet/basic/sys/keylist.h
@@ -24,6 +24,7 @@
 #ifndef KEYLIST_H
 #define KEYLIST_H
 
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/basic/sys/platform.h"
 #include "bacnet/basic/sys/key.h"

--- a/src/bacnet/basic/sys/linear.h
+++ b/src/bacnet/basic/sys/linear.h
@@ -6,6 +6,8 @@
 #ifndef LINEAR_H
 #define LINEAR_H
 
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/src/bacnet/basic/sys/mstimer.h
+++ b/src/bacnet/basic/sys/mstimer.h
@@ -20,6 +20,7 @@
 #ifndef MSTIMER_H_
 #define MSTIMER_H_
 
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 
 /**

--- a/src/bacnet/basic/sys/platform.h
+++ b/src/bacnet/basic/sys/platform.h
@@ -20,6 +20,7 @@
 
 #include <stddef.h>
 #include <math.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 
 #ifndef islessgreater
 #define islessgreater(x, y) ((x) < (y) || (x) > (y))

--- a/src/bacnet/basic/sys/ringbuf.h
+++ b/src/bacnet/basic/sys/ringbuf.h
@@ -11,6 +11,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 
 /**

--- a/src/bacnet/basic/sys/sbuf.h
+++ b/src/bacnet/basic/sys/sbuf.h
@@ -29,6 +29,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 
 struct static_buffer_t {

--- a/src/bacnet/basic/tsm/tsm.h
+++ b/src/bacnet/basic/tsm/tsm.h
@@ -27,9 +27,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/config.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/npdu.h"
 
 /* note: TSM functionality is optional - only needed if we are

--- a/src/bacnet/basic/ucix/ucix.h
+++ b/src/bacnet/basic/ucix/ucix.h
@@ -19,6 +19,7 @@
 #ifndef _UCI_H__
 #define _UCI_H__
 
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 
 BACNET_STACK_EXPORT

--- a/src/bacnet/bits.h
+++ b/src/bacnet/bits.h
@@ -24,6 +24,8 @@
 #ifndef BITS_H
 #define BITS_H
 
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
+
 /********************************************************************
 * Bit Masks
 *********************************************************************/

--- a/src/bacnet/bytes.h
+++ b/src/bacnet/bytes.h
@@ -27,6 +27,7 @@
 /* Defines the bit/byte/word/long conversions that are used in code */
 
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 
 #ifndef LO_NIB
 #define LO_NIB(b) ((b) & 0xF)

--- a/src/bacnet/calendar_entry.h
+++ b/src/bacnet/calendar_entry.h
@@ -13,6 +13,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bactimevalue.h"
 #include "bacnet/datetime.h"

--- a/src/bacnet/cov.h
+++ b/src/bacnet/cov.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacapp.h"
 

--- a/src/bacnet/create_object.h
+++ b/src/bacnet/create_object.h
@@ -12,10 +12,10 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/bacdcode.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacapp.h"
 
 /**

--- a/src/bacnet/credential_authentication_factor.h
+++ b/src/bacnet/credential_authentication_factor.h
@@ -28,8 +28,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacapp.h"
 #include "bacnet/authentication_factor.h"
 

--- a/src/bacnet/dailyschedule.h
+++ b/src/bacnet/dailyschedule.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bactimevalue.h"
 

--- a/src/bacnet/datalink/arcnet.h
+++ b/src/bacnet/datalink/arcnet.h
@@ -27,8 +27,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/npdu.h"
 
 /* specific defines for ARCNET */

--- a/src/bacnet/datalink/automac.h
+++ b/src/bacnet/datalink/automac.h
@@ -29,6 +29,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 
 /* MS/TP Auto MAC address functionality */
 /* starting number available for AutoMAC */

--- a/src/bacnet/datalink/bacsec.h
+++ b/src/bacnet/datalink/bacsec.h
@@ -39,8 +39,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 
 typedef struct BACnet_Security_Wrapper {

--- a/src/bacnet/datalink/bip.h
+++ b/src/bacnet/datalink/bip.h
@@ -27,8 +27,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/npdu.h"
 #include "bacnet/datalink/bvlc.h"
 

--- a/src/bacnet/datalink/bip6.h
+++ b/src/bacnet/datalink/bip6.h
@@ -16,8 +16,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/npdu.h"
 #include "bacnet/datalink/bvlc6.h"
 

--- a/src/bacnet/datalink/bvlc.h
+++ b/src/bacnet/datalink/bvlc.h
@@ -27,7 +27,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
-#include "bacnet/bacdef.h"
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/npdu.h"
 
 /**

--- a/src/bacnet/datalink/bvlc6.h
+++ b/src/bacnet/datalink/bvlc6.h
@@ -12,8 +12,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/npdu.h"
 
 /**

--- a/src/bacnet/datalink/cobs.h
+++ b/src/bacnet/datalink/cobs.h
@@ -26,6 +26,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 
 /* number of bytes needed for COBS encoded CRC */

--- a/src/bacnet/datalink/crc.h
+++ b/src/bacnet/datalink/crc.h
@@ -26,6 +26,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 
 #ifdef __cplusplus

--- a/src/bacnet/datalink/datalink.h
+++ b/src/bacnet/datalink/datalink.h
@@ -24,9 +24,9 @@
 #ifndef DATALINK_H
 #define DATALINK_H
 
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/config.h"
-#include "bacnet/bacdef.h"
 
 #if defined(BACDL_ETHERNET)
 #include "bacnet/datalink/ethernet.h"

--- a/src/bacnet/datalink/dlenv.h
+++ b/src/bacnet/datalink/dlenv.h
@@ -27,6 +27,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/datalink/bvlc.h"
 
 #include "bacnet/bacnet_stack_exports.h"

--- a/src/bacnet/datalink/dlmstp.h
+++ b/src/bacnet/datalink/dlmstp.h
@@ -27,10 +27,10 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/basic/sys/ringbuf.h"
 #include "bacnet/datalink/mstpdef.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/npdu.h"
 
 /* defines specific to MS/TP */

--- a/src/bacnet/datalink/ethernet.h
+++ b/src/bacnet/datalink/ethernet.h
@@ -27,8 +27,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/npdu.h"
 
 /* specific defines for Ethernet */

--- a/src/bacnet/datalink/mstp.h
+++ b/src/bacnet/datalink/mstp.h
@@ -28,6 +28,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/datalink/mstpdef.h"
 #include "bacnet/config.h"

--- a/src/bacnet/datalink/mstpdef.h
+++ b/src/bacnet/datalink/mstpdef.h
@@ -27,7 +27,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include "bacnet/bacdef.h"
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 
 /*  The value 255 is used to denote broadcast when used as a */
 /* destination address but is not allowed as a value for a station. */

--- a/src/bacnet/datalink/mstptext.h
+++ b/src/bacnet/datalink/mstptext.h
@@ -24,6 +24,7 @@
 #ifndef MSTPTEXT_H
 #define MSTPTEXT_H
 
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 
 #ifdef __cplusplus

--- a/src/bacnet/datetime.h
+++ b/src/bacnet/datetime.h
@@ -15,6 +15,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/basic/sys/platform.h"
 

--- a/src/bacnet/dcc.h
+++ b/src/bacnet/dcc.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/bacstr.h"

--- a/src/bacnet/delete_object.h
+++ b/src/bacnet/delete_object.h
@@ -12,10 +12,10 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/bacdcode.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacapp.h"
 
 /**

--- a/src/bacnet/event.h
+++ b/src/bacnet/event.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/bacapp.h"

--- a/src/bacnet/get_alarm_sum.h
+++ b/src/bacnet/get_alarm_sum.h
@@ -28,6 +28,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacenum.h"
 #include "bacnet/bacapp.h"
 #include "bacnet/timestamp.h"

--- a/src/bacnet/getevent.h
+++ b/src/bacnet/getevent.h
@@ -26,8 +26,8 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/timestamp.h"
 #include "bacnet/event.h"

--- a/src/bacnet/hostnport.h
+++ b/src/bacnet/hostnport.h
@@ -14,6 +14,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/bacstr.h"

--- a/src/bacnet/iam.h
+++ b/src/bacnet/iam.h
@@ -26,8 +26,8 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacaddr.h"
 #include "bacnet/npdu.h"
 

--- a/src/bacnet/ihave.h
+++ b/src/bacnet/ihave.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacstr.h"
 

--- a/src/bacnet/indtext.h
+++ b/src/bacnet/indtext.h
@@ -27,6 +27,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 
 /* index and text pairs */

--- a/src/bacnet/lighting.h
+++ b/src/bacnet/lighting.h
@@ -15,6 +15,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
 

--- a/src/bacnet/list_element.h
+++ b/src/bacnet/list_element.h
@@ -14,10 +14,10 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/bacdcode.h"
-#include "bacnet/bacdef.h"
 
 /**
  *  AddListElement-Request ::= SEQUENCE {

--- a/src/bacnet/lso.h
+++ b/src/bacnet/lso.h
@@ -26,9 +26,9 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacstr.h"
 
 typedef struct {

--- a/src/bacnet/memcopy.h
+++ b/src/bacnet/memcopy.h
@@ -28,6 +28,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bacnet/npdu.h
+++ b/src/bacnet/npdu.h
@@ -26,9 +26,9 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/basic/sys/platform.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 
 /** Hop count default is required by BTL to be maximum */

--- a/src/bacnet/property.h
+++ b/src/bacnet/property.h
@@ -26,8 +26,8 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/rp.h"
 #include "bacnet/proplist.h"

--- a/src/bacnet/proplist.h
+++ b/src/bacnet/proplist.h
@@ -26,8 +26,8 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 #include "bacnet/rp.h"
 

--- a/src/bacnet/ptransfer.h
+++ b/src/bacnet/ptransfer.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 
 typedef struct BACnet_Private_Transfer_Data {

--- a/src/bacnet/rd.h
+++ b/src/bacnet/rd.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
 

--- a/src/bacnet/readrange.h
+++ b/src/bacnet/readrange.h
@@ -24,6 +24,7 @@
 #ifndef READRANGE_H
 #define READRANGE_H
 
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacstr.h"
 #include "bacnet/datetime.h"

--- a/src/bacnet/reject.h
+++ b/src/bacnet/reject.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
 

--- a/src/bacnet/rp.h
+++ b/src/bacnet/rp.h
@@ -26,8 +26,8 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacenum.h"
 
 typedef struct BACnet_Read_Property_Data {

--- a/src/bacnet/rpm.h
+++ b/src/bacnet/rpm.h
@@ -26,9 +26,9 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacenum.h"
-#include "bacnet/bacdef.h"
 #include "bacnet/bacapp.h"
 #include "bacnet/proplist.h"
 #include "bacnet/rp.h"

--- a/src/bacnet/special_event.h
+++ b/src/bacnet/special_event.h
@@ -13,6 +13,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bactimevalue.h"
 #include "bacnet/calendar_entry.h"

--- a/src/bacnet/timestamp.h
+++ b/src/bacnet/timestamp.h
@@ -24,6 +24,7 @@
 #ifndef _TIMESTAMP_H_
 #define _TIMESTAMP_H_
 #include <stdint.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/basic/sys/platform.h"
 #include "bacnet/bacenum.h"

--- a/src/bacnet/timesync.h
+++ b/src/bacnet/timesync.h
@@ -26,8 +26,8 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
-#include "bacnet/bacdef.h"
 
 struct BACnet_Recipient_List;
 typedef struct BACnet_Recipient_List {

--- a/src/bacnet/version.h
+++ b/src/bacnet/version.h
@@ -10,6 +10,8 @@
 #ifndef _BACNET_VERSION_H_
 #define _BACNET_VERSION_H_
 
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
+
 /* This BACnet protocol stack version 0.0.0 - 255.255.255 */
 #ifndef BACNET_VERSION
 #define BACNET_VERSION(x,y,z) (((x)<<16)+((y)<<8)+(z))

--- a/src/bacnet/weeklyschedule.h
+++ b/src/bacnet/weeklyschedule.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/dailyschedule.h"
 #include "bacnet/bactimevalue.h"

--- a/src/bacnet/whohas.h
+++ b/src/bacnet/whohas.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacstr.h"
 

--- a/src/bacnet/whois.h
+++ b/src/bacnet/whois.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 
 #ifdef __cplusplus

--- a/src/bacnet/wp.h
+++ b/src/bacnet/wp.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacdcode.h"
 #include "bacnet/bacapp.h"

--- a/src/bacnet/wpm.h
+++ b/src/bacnet/wpm.h
@@ -27,6 +27,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "bacnet/bacdef.h"  /* Must be before all other bacnet *.h files */
 #include "bacnet/bacnet_stack_exports.h"
 #include "bacnet/bacdcode.h"
 #include "bacnet/bacapp.h"

--- a/test/bacnet/datetime/src/main.c
+++ b/test/bacnet/datetime/src/main.c
@@ -70,7 +70,7 @@ static void datetime_print(const char *title, BACNET_DATE_TIME *bdatetime)
 }
 
 #if defined(CONFIG_ZTEST_NEW_API)
-ZTEST(wp_tests, testBACnetDateTimeWildcard)
+ZTEST(bacnet_datetime, testBACnetDateTimeWildcard)
 #else
 static void testBACnetDateTimeWildcard(void)
 #endif
@@ -88,7 +88,7 @@ static void testBACnetDateTimeWildcard(void)
 }
 
 #if defined(CONFIG_ZTEST_NEW_API)
-ZTEST(wp_tests, testBACnetDateTimeAdd)
+ZTEST(bacnet_datetime, testBACnetDateTimeAdd)
 #else
 static void testBACnetDateTimeAdd(void)
 #endif
@@ -156,7 +156,7 @@ static void testBACnetDateTimeSeconds(void)
 }
 
 #if defined(CONFIG_ZTEST_NEW_API)
-ZTEST(wp_tests, testBACnetDate)
+ZTEST(bacnet_datetime, testBACnetDate)
 #else
 static void testBACnetDate(void)
 #endif
@@ -221,7 +221,7 @@ static void testBACnetDate(void)
 }
 
 #if defined(CONFIG_ZTEST_NEW_API)
-ZTEST(wp_tests, testBACnetTime)
+ZTEST(bacnet_datetime, testBACnetTime)
 #else
 static void testBACnetTime(void)
 #endif
@@ -274,7 +274,7 @@ static void testBACnetTime(void)
 }
 
 #if defined(CONFIG_ZTEST_NEW_API)
-ZTEST(wp_tests, testBACnetDateTime)
+ZTEST(bacnet_datetime, testBACnetDateTime)
 #else
 static void testBACnetDateTime(void)
 #endif
@@ -344,7 +344,7 @@ static void testBACnetDateTime(void)
 }
 
 #if defined(CONFIG_ZTEST_NEW_API)
-ZTEST(wp_tests, testWildcardDateTime)
+ZTEST(bacnet_datetime, testWildcardDateTime)
 #else
 static void testWildcardDateTime(void)
 #endif
@@ -433,7 +433,7 @@ static void testDateEpochConversionCompare(uint16_t year,
 }
 
 #if defined(CONFIG_ZTEST_NEW_API)
-ZTEST(wp_tests, testDateEpochConversion)
+ZTEST(bacnet_datetime, testDateEpochConversion)
 #else
 static void testDateEpochConversion(void)
 #endif
@@ -476,7 +476,7 @@ static void testDateEpoch(void)
 }
 
 #if defined(CONFIG_ZTEST_NEW_API)
-ZTEST(wp_tests, testBACnetDayOfWeek)
+ZTEST(bacnet_datetime, testBACnetDayOfWeek)
 #else
 static void testBACnetDayOfWeek(void)
 #endif
@@ -508,7 +508,7 @@ static void testBACnetDayOfWeek(void)
 }
 
 #if defined(CONFIG_ZTEST_NEW_API)
-ZTEST(wp_tests, testDatetimeCodec)
+ZTEST(bacnet_datetime, testDatetimeCodec)
 #else
 static void testDatetimeCodec(void)
 #endif
@@ -630,7 +630,7 @@ static void testDatetimeConvertUTC(void)
  */
 
 #if defined(CONFIG_ZTEST_NEW_API)
-ZTEST_SUITE(datetime_tests, NULL, NULL, NULL, NULL, NULL);
+ZTEST_SUITE(bacnet_datetime, NULL, NULL, NULL, NULL, NULL);
 #else
 void test_main(void)
 {
@@ -639,7 +639,7 @@ void test_main(void)
      ztest_unit_test(testBACnetDateTimeSeconds),
      ztest_unit_test(testDayOfYear),
 #endif
-    ztest_test_suite(datetime_tests,
+    ztest_test_suite(bacnet_datetime,
         ztest_unit_test(testBACnetDate),
         ztest_unit_test(testBACnetTime),
         ztest_unit_test(testBACnetDateTime),
@@ -653,6 +653,6 @@ void test_main(void)
         ztest_unit_test(testDayOfYear),
         ztest_unit_test(testDatetimeConvertUTC));
 
-    ztest_run_test_suite(datetime_tests);
+    ztest_run_test_suite(bacnet_datetime);
 }
 #endif

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -484,3 +484,7 @@ target_compile_definitions(
   PRINT_ENABLED=1
   )
 
+zephyr_compile_definitions(
+  BACNET_CONFIG_H=1         # Use ports/zephyr/bacnet-config.h
+  )
+

--- a/zephyr/subsys/object/object.h
+++ b/zephyr/subsys/object/object.h
@@ -15,6 +15,7 @@
   #define _CONCAT(x, y) _DO_CONCAT(x, y)
 
 #endif
+#include "bacnet/bacdef.h"  // Must be before all other bacnet/*.h files
 #include "bacnet/basic/sys/keylist.h"
 
 

--- a/zephyr/tests/bacnet/basic/object/command/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/command/CMakeLists.txt
@@ -74,5 +74,6 @@ else()
     ${TEST_OBJECT_INCLUDE})
   target_sources(app PRIVATE
     ${BACNET_TEST_PATH}/src/main.c
+    ${TEST_OBJECT_SRC}/property_test.c
     )
 endif()

--- a/zephyr/tests/bacnet/basic/object/credential_data_input/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/credential_data_input/CMakeLists.txt
@@ -76,5 +76,6 @@ else()
     ${TEST_OBJECT_INCLUDE})
   target_sources(app PRIVATE
     ${BACNET_TEST_PATH}/src/main.c
+    ${TEST_OBJECT_SRC}/property_test.c
     )
 endif()

--- a/zephyr/tests/bacnet/basic/object/netport/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/netport/CMakeLists.txt
@@ -20,14 +20,17 @@ get_filename_component(BACNET_NAME ${BACNET_BASE} NAME)
 # Update include path for this module
 list(APPEND BACNET_INCLUDE ${BACNET_BASE}/src)
 
+set(TEST_OBJECT_SRC ${BACNET_BASE}/test/bacnet/basic/object)
+list(APPEND TEST_OBJECT_INCLUDE ${TEST_OBJECT_SRC})
+
 if(BOARD STREQUAL unit_testing)
   file(RELATIVE_PATH BACNET_INCLUDE $ENV{ZEPHYR_BASE} ${BACNET_BASE}/src)
-  list(APPEND INCLUDE ${BACNET_INCLUDE})
+  file(RELATIVE_PATH TEST_OBJECT_INCLUDE $ENV{ZEPHYR_BASE} ${TEST_OBJECT_SRC})
+  list(APPEND INCLUDE ${BACNET_INCLUDE} ${TEST_OBJECT_INCLUDE})
   list(APPEND SOURCES
     ${BACNET_SRC_PATH}.c
     ${BACNET_TEST_PATH}/src/main.c
-    ${BACNET_TEST_PATH}/../property_test.c
-    ${BACNET_TEST_PATH}/../property_test.h
+    ${TEST_OBJECT_SRC}/property_test.c
     )
 
   get_filename_component(BACNET_OBJECT_SRC ${BACNET_SRC_PATH} PATH)
@@ -68,8 +71,11 @@ else()
   find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
   project(${BACNET_NAME})
 
-  target_include_directories(app PRIVATE ${BACNET_INCLUDE})
+  target_include_directories(app PRIVATE
+    ${BACNET_INCLUDE}
+    ${TEST_OBJECT_INCLUDE})
   target_sources(app PRIVATE
     ${BACNET_TEST_PATH}/src/main.c
+    ${TEST_OBJECT_SRC}/property_test.c
     )
 endif()

--- a/zephyr/tests/bacnet/basic/object/netport/testcase.yaml
+++ b/zephyr/tests/bacnet/basic/object/netport/testcase.yaml
@@ -2,6 +2,7 @@ tests:
   bacnet.basic.object.netport:
     tags: bacnet
     extra_args: EXTRA_CFLAGS='-Wno-error=array-compare'  # for zephyr_v3.0.0 net_if.c
+    skip: true # TODO: Remove once unit test builds/runs under Zephyr CI
   bacnet.basic.object.netport.unit:
     tags: bacnet
     type: unit

--- a/zephyr/tests/bacnet/basic/object/schedule/CMakeLists.txt
+++ b/zephyr/tests/bacnet/basic/object/schedule/CMakeLists.txt
@@ -75,5 +75,6 @@ else()
     ${TEST_OBJECT_INCLUDE})
   target_sources(app PRIVATE
     ${BACNET_TEST_PATH}/src/main.c
+    ${TEST_OBJECT_SRC}/property_test.c
     )
 endif()


### PR DESCRIPTION
* Require bacdeps.h as first bacnet header to include

BACnet headers need to pull in optional configuration and optional ecosystem overrides to allow integrators to control builds.  This commit changes bacnet header files to first include bacnet/bacdep.h to consistently introduce integrator header files.

Verified by:

1. make clean all test

2. ./zephyr/scripts/twister -p unit_testing \ -T bacnet-stack/zephyr/tests/



* Migrate BACNET_UNSIGNED_INTEGER defn to bacdef.h

Verified by:

1. make clean all test

2. ./zephyr/scripts/twister -p unit_testing \ -T bacnet-stack/zephyr/tests/



---------