### PR TITLE
Change first instance of an integer value from 1 to 0

### DIFF
--- a/src/bacnet/basic/object/iv.c
+++ b/src/bacnet/basic/object/iv.c
@@ -134,11 +134,7 @@ unsigned Integer_Value_Count(void)
  */
 uint32_t Integer_Value_Index_To_Instance(unsigned index)
 {
-    uint32_t instance = 1;
-
-    instance += index;
-
-    return instance;
+    return index;
 }
 
 /**
@@ -154,11 +150,8 @@ unsigned Integer_Value_Instance_To_Index(uint32_t object_instance)
 {
     unsigned index = MAX_INTEGER_VALUES;
 
-    if (object_instance) {
-        index = object_instance - 1;
-        if (index > MAX_INTEGER_VALUES) {
-            index = MAX_INTEGER_VALUES;
-        }
+    if (object_instance < MAX_INTEGER_VALUES) {
+        index = object_instance;
     }
 
     return index;


### PR DESCRIPTION
Integer_Values instances start at 1 while other object instances start at 0. Change this to have the same start for all objects.

Is don't see any reason why Integer_Values would start at 1. Is there any ?