### PR TITLE
Setting logic behind valid transitions check straight

### DIFF
--- a/src/bacnet/basic/object/nc.c
+++ b/src/bacnet/basic/object/nc.c
@@ -492,20 +492,20 @@ static bool IsRecipientActive(
         case EVENT_STATE_OFFNORMAL:
         case EVENT_STATE_HIGH_LIMIT:
         case EVENT_STATE_LOW_LIMIT:
-            if (bitstring_bit(
+            if (!bitstring_bit(
                     &pBacDest->Transitions, TRANSITION_TO_OFFNORMAL)) {
                 return false;
             }
             break;
 
         case EVENT_STATE_FAULT:
-            if (bitstring_bit(&pBacDest->Transitions, TRANSITION_TO_FAULT)) {
+            if (!bitstring_bit(&pBacDest->Transitions, TRANSITION_TO_FAULT)) {
                 return false;
             }
             break;
 
         case EVENT_STATE_NORMAL:
-            if (bitstring_bit(&pBacDest->Transitions, TRANSITION_TO_NORMAL)) {
+            if (!bitstring_bit(&pBacDest->Transitions, TRANSITION_TO_NORMAL)) {
                 return false;
             }
             break;


### PR DESCRIPTION
n the SHRAE 135-2020 table 12-25:
"Transitions BACnet Event Transition Bits A set of three flags that indicate those transitions
{TO_OFFNORMAL, TO_FAULT, TO_NORMAL} for
which this recipient is suitable.

See #618 .