### PR TITLE
Add check on apdu_len. Timeout if too long.

### DIFF
--- a/src/bacnet/basic/service/h_apdu.c
+++ b/src/bacnet/basic/service/h_apdu.c
@@ -468,7 +468,9 @@ uint16_t apdu_decode_confirmed_service_request(uint8_t *apdu, /* APDU data */
                 return 0;
             }
         }
-        if (apdu_len == (len + 1)) {
+        if (apdu_len > MAX_APDU){
+            return 0;
+        } else if (apdu_len == (len + 1)) {
             /* no request data as seen with Inneasoft BACnet Explorer */
             *service_choice = apdu[len++];
             *service_request = NULL;


### PR DESCRIPTION
BTS has a test on apdu length. The current code responds to telegrams with apdu_len > MAX_APDU.
This patch changes this to timeout.