### PR TITLE
Make most of functions const correct

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ if (CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "AppleCla
   add_compile_options(-Wswitch-default)
   add_compile_options(-Wunused-variable)
   add_compile_options(-Wcast-qual)
+  add_compile_options(-Wwrite-strings)
 
   # Don't warn about conversion, sign, compares since they are common in
   # embedded
@@ -138,6 +139,7 @@ if (CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "AppleCla
   add_compile_options(-Wno-float-conversion)
   add_compile_options(-Wno-missing-declarations)
   add_compile_options(-Wno-unused-but-set-variable)
+  add_compile_options(-Wno-write-strings)
 elseif(MSVC)
   add_compile_options(/Wall)
 

--- a/apps/abort/main.c
+++ b/apps/abort/main.c
@@ -74,14 +74,14 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s [abort-reason [invoke-id [server]]]\n", filename);
     printf("       [--dnet][--dadr][--mac]\n");
     printf("       [--version][--help]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Send BACnet Abort message to the network.\n");
     printf("--mac A\n"
@@ -123,7 +123,7 @@ int main(int argc, char *argv[])
     bool specific_address = false;
     int argi = 0;
     unsigned int target_args = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     filename = filename_remove_path(argv[0]);
     for (argi = 1; argi < argc; argi++) {

--- a/apps/ack-alarm/main.c
+++ b/apps/ack-alarm/main.c
@@ -141,7 +141,7 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s device-id process-id\n"
            "    event-object-type event-object-instance event-state-acked\n"
@@ -151,7 +151,7 @@ static void print_usage(char *filename)
     printf("       [--version][--help]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Send BACnet AcknowledgedAlarm, message to a device.\n");
     printf("device-id:\n"
@@ -222,7 +222,7 @@ int main(int argc, char *argv[])
     bool specific_address = false;
     int argi = 0;
     unsigned int target_args = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     filename = filename_remove_path(argv[0]);
     for (argi = 1; argi < argc; argi++) {

--- a/apps/add-list-element/main.c
+++ b/apps/add-list-element/main.c
@@ -137,7 +137,7 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s device-instance object-type object-instance "
            "property array-index tag value\n",
@@ -146,7 +146,7 @@ static void print_usage(char *filename)
     printf("       [--version][--help][--verbose]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Add a BACnetLIST element to a property of an object\n"
            "in a BACnet device.\n");
@@ -244,7 +244,7 @@ int main(int argc, char *argv[])
     bool specific_address = false;
     unsigned int target_args = 0;
     int argi = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     filename = filename_remove_path(argv[0]);
     for (argi = 1; argi < argc; argi++) {

--- a/apps/apdu/main.c
+++ b/apps/apdu/main.c
@@ -123,7 +123,7 @@ static void init_service_handlers(void)
 /**
  * @brief Print the usage message
  */
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s", filename);
     printf(" <device-instance> <hex-ASCII>\n");
@@ -135,7 +135,7 @@ static void print_usage(char *filename)
 /**
  * @brief Print the help message
  */
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Send an arbitrary BACnet APDU to a device.\n");
     printf("\n");
@@ -199,7 +199,7 @@ static void print_help(char *filename)
  * @param buffer_len [in] The size of the buffer.
  */
 static void Send_APDU_To_Network(
-    BACNET_ADDRESS *target_address, uint8_t *buffer, size_t buffer_len)
+    BACNET_ADDRESS *target_address, const uint8_t *buffer, size_t buffer_len)
 {
     int pdu_len = 0;
     int bytes_sent = 0;
@@ -288,7 +288,7 @@ int main(int argc, char *argv[])
     bool found = false;
     int argi = 0;
     unsigned int target_args = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
     bool repeat_forever = false;
     long retry_count = 1;
 

--- a/apps/blinkt/device.c
+++ b/apps/blinkt/device.c
@@ -462,7 +462,7 @@ bool Device_Object_Name(
     return status;
 }
 
-bool Device_Set_Object_Name(BACNET_CHARACTER_STRING *object_name)
+bool Device_Set_Object_Name(const BACNET_CHARACTER_STRING *object_name)
 {
     bool status = false; /*return value */
 
@@ -1198,7 +1198,7 @@ int Device_Read_Property_Local(BACNET_READ_PROPERTY_DATA *rpdata)
  * @return The length of the APDU on success, else BACNET_STATUS_ERROR
  */
 static int Read_Property_Common(
-    struct object_functions *pObject, BACNET_READ_PROPERTY_DATA *rpdata)
+    const struct object_functions *pObject, BACNET_READ_PROPERTY_DATA *rpdata)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     BACNET_CHARACTER_STRING char_string;

--- a/apps/blinkt/main.c
+++ b/apps/blinkt/main.c
@@ -343,7 +343,7 @@ int main(int argc, char *argv[])
     unsigned int target_args = 0;
     uint32_t device_id = BACNET_MAX_INSTANCE;
     int argi = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     filename = filename_remove_path(argv[0]);
     for (argi = 1; argi < argc; argi++) {

--- a/apps/create-object/main.c
+++ b/apps/create-object/main.c
@@ -175,7 +175,7 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf(
         "Usage: %s device-instance object-type [object-instance]\n", filename);
@@ -183,7 +183,7 @@ static void print_usage(char *filename)
     printf("       [--version][--help][--verbose]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Create an object in a BACnet device.\n");
     printf("\n");
@@ -232,7 +232,7 @@ int main(int argc, char *argv[])
     bool specific_address = false;
     unsigned int target_args = 0;
     int argi = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     filename = filename_remove_path(argv[0]);
     for (argi = 1; argi < argc; argi++) {

--- a/apps/dcc/main.c
+++ b/apps/dcc/main.c
@@ -116,13 +116,13 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s device-instance state [timeout [password]]\n", filename);
     printf("       [--version][--help]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf(
         "Send BACnet DeviceCommunicationControl service to device.\n"
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
     uint8_t invoke_id = 0;
     bool found = false;
     int argi = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     filename = filename_remove_path(argv[0]);
     for (argi = 1; argi < argc; argi++) {

--- a/apps/delete-object/main.c
+++ b/apps/delete-object/main.c
@@ -136,7 +136,7 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s device-instance object-type object-instance\n",
         filename);
@@ -144,7 +144,7 @@ static void print_usage(char *filename)
     printf("       [--version][--help][--verbose]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Create an object in a BACnet device.\n");
     printf("\n");
@@ -193,7 +193,7 @@ int main(int argc, char *argv[])
     bool specific_address = false;
     unsigned int target_args = 0;
     int argi = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     filename = filename_remove_path(argv[0]);
     for (argi = 1; argi < argc; argi++) {

--- a/apps/epics/main.c
+++ b/apps/epics/main.c
@@ -710,7 +710,7 @@ static void BuildPropRequest(BACNET_READ_ACCESS_DATA *rpm_object)
  *         of the property list.
  */
 static uint8_t Read_Properties(
-    uint32_t device_instance, BACNET_OBJECT_ID *pMyObject)
+    uint32_t device_instance, const BACNET_OBJECT_ID *pMyObject)
 {
     uint8_t invoke_id = 0;
     struct special_property_list_t PropertyListStruct;
@@ -884,7 +884,7 @@ static EPICS_STATES ProcessRPMData(
     return nextState;
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s [-v] [-d] [-p sport] [-t target_mac [-n dnet]]"
            " device-instance\n",
@@ -892,7 +892,7 @@ static void print_usage(char *filename)
     printf("       [--version][--help]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     (void)filename;
     printf("Generates Full EPICS file, including Object and Property List\n");
@@ -921,7 +921,7 @@ static int CheckCommandLineArgs(int argc, char *argv[])
     int i;
     bool bFoundTarget = false;
     int argi = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     filename = filename_remove_path(argv[0]);
     for (argi = 1; argi < argc; argi++) {

--- a/apps/error/main.c
+++ b/apps/error/main.c
@@ -75,7 +75,7 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s [error-class error-code service-number invoke-id]\n",
         filename);
@@ -83,7 +83,7 @@ static void print_usage(char *filename)
     printf("       [--version][--help]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Send BACnet Error message to the network.\n");
     printf("--mac A\n"
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
     bool specific_address = false;
     int argi = 0;
     unsigned int target_args = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     filename = filename_remove_path(argv[0]);
     for (argi = 1; argi < argc; argi++) {

--- a/apps/event/main.c
+++ b/apps/event/main.c
@@ -141,7 +141,7 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s device-id process-id initiating-device-id\n"
            "    event-object-type event-object-instance\n"
@@ -154,7 +154,7 @@ static void print_usage(char *filename)
     printf("       [--version][--help]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Send BACnet ConfirmedEventNotification message to a device.\n");
     printf("device-id:\n"
@@ -246,7 +246,7 @@ int main(int argc, char *argv[])
     bool specific_address = false;
     int argi = 0;
     unsigned int target_args = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
     unsigned found_index = 0;
 
     filename = filename_remove_path(argv[0]);

--- a/apps/getevent/main.c
+++ b/apps/getevent/main.c
@@ -160,7 +160,7 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static int print_help(char *exe_name)
+static int print_help(const char *exe_name)
 {
     printf("Usage:\n"
            "\n"

--- a/apps/iam/main.c
+++ b/apps/iam/main.c
@@ -78,7 +78,7 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s [device-instance vendor-id max-apdu segmentation]\n",
         filename);
@@ -86,7 +86,7 @@ static void print_usage(char *filename)
     printf("       [--version][--help]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Send BACnet I-Am message for a device.\n");
     printf("--mac A\n"
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
     unsigned timeout = 100; /* milliseconds */
     int argi = 0;
     unsigned int target_args = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
     long retry_count = 0;
 
     filename = filename_remove_path(argv[0]);

--- a/apps/iamrouter/main.c
+++ b/apps/iamrouter/main.c
@@ -75,13 +75,13 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s DNET [DNET] [DNET] [...]\n", filename);
     printf("       [--version][--help]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Send BACnet I-Am-Router-To-Network message for \n"
            "one or more networks.\n"
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
 {
     unsigned arg_count = 0;
     int argi = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     filename = filename_remove_path(argv[0]);
     for (argi = 1; argi < argc; argi++) {

--- a/apps/initrouter/main.c
+++ b/apps/initrouter/main.c
@@ -211,13 +211,13 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s address [DNET ID Len Info]\n", filename);
     printf("       [--version][--help]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf(
         "Send BACnet Initialize-Routing-Table message to a network\n"
@@ -286,7 +286,7 @@ int main(int argc, char *argv[])
     time_t current_seconds = 0;
     time_t timeout_seconds = 0;
     int argi = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     filename = filename_remove_path(argv[0]);
     for (argi = 1; argi < argc; argi++) {

--- a/apps/mstpcap/main.c
+++ b/apps/mstpcap/main.c
@@ -121,7 +121,8 @@ struct mstp_statistics {
 static struct mstp_statistics MSTP_Statistics[MAX_MSTP_DEVICES];
 static uint32_t Invalid_Frame_Count;
 
-static uint32_t timeval_diff_ms(struct timeval *old, struct timeval *now)
+static uint32_t timeval_diff_ms(
+    const struct timeval *old, const struct timeval *now)
 {
     uint32_t ms = 0;
 
@@ -132,17 +133,18 @@ static uint32_t timeval_diff_ms(struct timeval *old, struct timeval *now)
     return ms;
 }
 
-static void mstp_monitor_i_am(uint8_t mac, uint8_t *pdu, uint16_t pdu_len)
+static void mstp_monitor_i_am(
+    uint8_t mac, const uint8_t *pdu, uint16_t pdu_len)
 {
     BACNET_ADDRESS src = { 0 };
     BACNET_ADDRESS dest = { 0 };
     BACNET_NPDU_DATA npdu_data = { 0 };
     int apdu_offset = 0;
     uint16_t apdu_len = 0;
-    uint8_t *apdu = NULL;
+    const uint8_t *apdu = NULL;
     uint8_t pdu_type = 0;
     uint8_t service_choice = 0;
-    uint8_t *service_request = NULL;
+    const uint8_t *service_request = NULL;
     uint32_t device_id = 0;
     int len = 0;
 
@@ -171,7 +173,8 @@ static void mstp_monitor_i_am(uint8_t mac, uint8_t *pdu, uint16_t pdu_len)
 }
 
 static void packet_statistics(
-    struct timeval *tv, struct mstp_port_struct_t *mstp_port)
+    const struct timeval *tv,
+    const struct mstp_port_struct_t *mstp_port)
 {
     static struct timeval old_tv = { 0 };
     static uint8_t old_frame = 255;
@@ -423,7 +426,7 @@ uint16_t MSTP_Get_Send(
  */
 void MSTP_Send_Frame(
     struct mstp_port_struct_t *mstp_port,
-    uint8_t * buffer,
+    const uint8_t * buffer,
     uint16_t nbytes)
 {
     (void)mstp_port;
@@ -443,7 +446,7 @@ static char Capture_Filename[64] = "mstp_20090123091200.cap";
 static FILE *File_Handle = NULL; /* stream pointer */
 #if defined(_WIN32)
 static HANDLE Pipe_Handle = INVALID_HANDLE_VALUE; /* pipe handle */
-static void named_pipe_create(char *pipe_name)
+static void named_pipe_create(const char *pipe_name)
 {
     if (!Wireshark_Capture) {
         fprintf(stdout, "mstpcap: Creating Named Pipe \"%s\"\n", pipe_name);
@@ -510,7 +513,7 @@ static size_t data_write_header(
 }
 #else
 static int FD_Pipe = -1;
-static void named_pipe_create(char *name)
+static void named_pipe_create(const char *name)
 {
     int rv = 0;
     rv = mkfifo(name, 0666);
@@ -915,7 +918,7 @@ static void signal_init(void)
 }
 #endif
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s", filename);
     printf(" [--scan <filename>]\n");
@@ -925,7 +928,7 @@ static void print_usage(char *filename)
     printf(" [--version][--help]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("%s --scan <filename>\n"
            "perform statistic analysis on MS/TP capture file.\n",
@@ -986,7 +989,7 @@ int main(int argc, char *argv[])
     uint32_t packet_count = 0;
     uint32_t header_len = 0;
     int argi = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     MSTP_Port.InputBuffer = &RxBuffer[0];
     MSTP_Port.InputBufferSize = sizeof(RxBuffer);

--- a/apps/piface/device.c
+++ b/apps/piface/device.c
@@ -444,7 +444,7 @@ bool Device_Object_Name(
     return status;
 }
 
-bool Device_Set_Object_Name(BACNET_CHARACTER_STRING *object_name)
+bool Device_Set_Object_Name(const BACNET_CHARACTER_STRING *object_name)
 {
     bool status = false; /*return value */
 
@@ -785,7 +785,7 @@ int Device_Object_List_Element_Encode(
  * Object.
  * @return True on success or else False if not found.
  */
-bool Device_Valid_Object_Name(BACNET_CHARACTER_STRING *object_name1,
+bool Device_Valid_Object_Name(const BACNET_CHARACTER_STRING *object_name1,
     BACNET_OBJECT_TYPE *object_type,
     uint32_t *object_instance)
 {
@@ -1180,7 +1180,7 @@ int Device_Read_Property_Local(BACNET_READ_PROPERTY_DATA *rpdata)
  * @return The length of the APDU on success, else BACNET_STATUS_ERROR
  */
 static int Read_Property_Common(
-    struct object_functions *pObject, BACNET_READ_PROPERTY_DATA *rpdata)
+    const struct object_functions *pObject, BACNET_READ_PROPERTY_DATA *rpdata)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     BACNET_CHARACTER_STRING char_string;

--- a/apps/readfile/main.c
+++ b/apps/readfile/main.c
@@ -205,13 +205,13 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s device-instance file-instance local-name\n", filename);
     printf("       [--version][--help]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf(
         "Read a file from a BACnet device and save it locally.\n");
@@ -251,7 +251,7 @@ int main(int argc, char *argv[])
     bool found = false;
     uint16_t my_max_apdu = 0;
     int argi = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     /* print help if requested */
     filename = filename_remove_path(argv[0]);

--- a/apps/readprop/main.c
+++ b/apps/readprop/main.c
@@ -147,7 +147,7 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s device-instance object-type object-instance "
            "property [index]\n",
@@ -156,7 +156,7 @@ static void print_usage(char *filename)
     printf("       [--version][--help]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Read a property from an object in a BACnet device\n"
            "and print the value.\n");
@@ -255,7 +255,7 @@ int main(int argc, char *argv[])
     unsigned object_type = 0;
     unsigned object_property = 0;
     unsigned int target_args = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     filename = filename_remove_path(argv[0]);
     for (argi = 1; argi < argc; argi++) {

--- a/apps/readpropm/main.c
+++ b/apps/readpropm/main.c
@@ -199,7 +199,7 @@ static void cleanup(void)
 }
 
 static void target_address_add(
-    long dnet, BACNET_MAC_ADDRESS *mac, BACNET_MAC_ADDRESS *adr)
+    long dnet, const BACNET_MAC_ADDRESS *mac, const BACNET_MAC_ADDRESS *adr)
 {
     BACNET_ADDRESS dest = { 0 };
 
@@ -234,7 +234,7 @@ static void target_address_add(
     address_add(Target_Device_Object_Instance, MAX_APDU, &dest);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s device-instance object-type object-instance "
            "property[index][,property[index]] [object-type ...]\n",
@@ -243,7 +243,7 @@ static void print_usage(char *filename)
     printf("       [--version][--help]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Read one or more properties from one or more objects\n"
            "in a BACnet device and print the value(s).\n");
@@ -350,7 +350,7 @@ int main(int argc, char *argv[])
     bool specific_address = false;
     unsigned int target_args = 0;
     bool status = false;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     filename = filename_remove_path(argv[0]);
     for (argi = 1; argi < argc; argi++) {

--- a/apps/readrange/main.c
+++ b/apps/readrange/main.c
@@ -121,7 +121,7 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s device-instance object-type object-instance property\n",
         filename);
@@ -129,7 +129,7 @@ static void print_usage(char *filename)
     printf("       [--version][--help]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Read a range of properties from an array or list property\n"
         "in an object in a BACnet device and print the values.\n");
@@ -199,7 +199,7 @@ int main(int argc, char *argv[])
     int year, month, day, wday;
     unsigned object_type = 0;
     unsigned object_property = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     filename = filename_remove_path(argv[0]);
     for (argi = 1; argi < argc; argi++) {

--- a/apps/remove-list-element/main.c
+++ b/apps/remove-list-element/main.c
@@ -137,7 +137,7 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s device-instance object-type object-instance "
            "property array-index tag value\n",
@@ -146,7 +146,7 @@ static void print_usage(char *filename)
     printf("       [--version][--help][--verbose]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Remove an element from a BACnetLIST property of an object\n"
            "in a BACnet device.\n");
@@ -244,7 +244,7 @@ int main(int argc, char *argv[])
     bool specific_address = false;
     unsigned int target_args = 0;
     int argi = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     filename = filename_remove_path(argv[0]);
     for (argi = 1; argi < argc; argi++) {

--- a/apps/router-ipv6/main.c
+++ b/apps/router-ipv6/main.c
@@ -156,7 +156,7 @@ static bool port_find(uint16_t snet, BACNET_ADDRESS *addr)
  * @param snet - router port SNET
  * @param addr - address of port at the net to be added
  */
-static void port_add(uint16_t snet, BACNET_ADDRESS *addr)
+static void port_add(uint16_t snet, const BACNET_ADDRESS *addr)
 {
     DNET *port = NULL;
     DNET *dnet = NULL;
@@ -204,7 +204,7 @@ static void port_add(uint16_t snet, BACNET_ADDRESS *addr)
  * @param net - net to be added
  * @param addr - address of router at the net to be added
  */
-static void dnet_add(uint16_t snet, uint16_t net, BACNET_ADDRESS *addr)
+static void dnet_add(uint16_t snet, uint16_t net, const BACNET_ADDRESS *addr)
 {
     DNET *dnet = NULL;
     DNET *port = NULL;
@@ -398,7 +398,8 @@ static void send_i_am_router_to_network(uint16_t snet, uint16_t net)
  *  Optionally may designate a particular router destination,
  *  especially when ACKing receipt of this message type.
  */
-static void send_initialize_routing_table_ack(uint8_t snet, BACNET_ADDRESS *dst)
+static void send_initialize_routing_table_ack(
+    uint8_t snet, const BACNET_ADDRESS *dst)
 {
     BACNET_ADDRESS dest;
     bool data_expecting_reply = false;
@@ -458,7 +459,10 @@ static void send_initialize_routing_table_ack(uint8_t snet, BACNET_ADDRESS *dst)
  * @param reject_reason [in] One of the BACNET_NETWORK_REJECT_REASONS codes.
  */
 static void send_reject_message_to_network(
-    uint16_t snet, BACNET_ADDRESS *dst, uint8_t reject_reason, uint16_t dnet)
+    uint16_t snet,
+    const BACNET_ADDRESS *dst,
+    uint8_t reject_reason,
+    uint16_t dnet)
 {
     BACNET_ADDRESS dest;
     bool data_expecting_reply = false;
@@ -571,9 +575,9 @@ static void send_who_is_router_to_network(uint16_t snet, uint16_t dnet)
  * @param npdu_len [in] The length of the remaining NPDU message in npdu[].
  */
 static void who_is_router_to_network_handler(uint16_t snet,
-    BACNET_ADDRESS *src,
-    BACNET_NPDU_DATA *npdu_data,
-    uint8_t *npdu,
+    const BACNET_ADDRESS *src,
+    const BACNET_NPDU_DATA *npdu_data,
+    const uint8_t *npdu,
     uint16_t npdu_len)
 {
     DNET *port = NULL;
@@ -752,7 +756,7 @@ static void network_control_handler(uint16_t snet,
  * @param src [in] The BACNET_ADDRESS of the message's original src.
  */
 static void routed_src_address(
-    BACNET_ADDRESS *router_src, uint16_t snet, BACNET_ADDRESS *src)
+    BACNET_ADDRESS *router_src, uint16_t snet, const BACNET_ADDRESS *src)
 {
     unsigned int i = 0;
 

--- a/apps/router-mstp/main.c
+++ b/apps/router-mstp/main.c
@@ -177,7 +177,7 @@ static bool port_find(uint16_t snet, BACNET_ADDRESS *addr)
  * @param snet - router port SNET
  * @param addr - address of port at the net to be added
  */
-static void port_add(uint16_t snet, BACNET_ADDRESS *addr)
+static void port_add(uint16_t snet, const BACNET_ADDRESS *addr)
 {
     DNET *port = NULL;
     DNET *dnet = NULL;
@@ -225,7 +225,7 @@ static void port_add(uint16_t snet, BACNET_ADDRESS *addr)
  * @param net - net to be added
  * @param addr - address of router at the net to be added
  */
-static void dnet_add(uint16_t snet, uint16_t net, BACNET_ADDRESS *addr)
+static void dnet_add(uint16_t snet, uint16_t net, const BACNET_ADDRESS *addr)
 {
     DNET *dnet = NULL;
     DNET *port = NULL;
@@ -419,7 +419,8 @@ static void send_i_am_router_to_network(uint16_t snet, uint16_t net)
  *  Optionally may designate a particular router destination,
  *  especially when ACKing receipt of this message type.
  */
-static void send_initialize_routing_table_ack(uint8_t snet, BACNET_ADDRESS *dst)
+static void send_initialize_routing_table_ack(
+    uint8_t snet, const BACNET_ADDRESS *dst)
 {
     BACNET_ADDRESS dest;
     bool data_expecting_reply = false;
@@ -479,7 +480,10 @@ static void send_initialize_routing_table_ack(uint8_t snet, BACNET_ADDRESS *dst)
  * @param reject_reason [in] One of the BACNET_NETWORK_REJECT_REASONS codes.
  */
 static void send_reject_message_to_network(
-    uint16_t snet, BACNET_ADDRESS *dst, uint8_t reject_reason, uint16_t dnet)
+    uint16_t snet,
+    const BACNET_ADDRESS *dst,
+    uint8_t reject_reason,
+    uint16_t dnet)
 {
     BACNET_ADDRESS dest;
     bool data_expecting_reply = false;
@@ -592,9 +596,9 @@ static void send_who_is_router_to_network(uint16_t snet, uint16_t dnet)
  * @param npdu_len [in] The length of the remaining NPDU message in npdu[].
  */
 static void who_is_router_to_network_handler(uint16_t snet,
-    BACNET_ADDRESS *src,
-    BACNET_NPDU_DATA *npdu_data,
-    uint8_t *npdu,
+    const BACNET_ADDRESS *src,
+    const BACNET_NPDU_DATA *npdu_data,
+    const uint8_t *npdu,
     uint16_t npdu_len)
 {
     DNET *port = NULL;
@@ -775,7 +779,7 @@ static void network_control_handler(uint16_t snet,
  * @param src [in] The BACNET_ADDRESS of the message's original src.
  */
 static void routed_src_address(
-    BACNET_ADDRESS *router_src, uint16_t snet, BACNET_ADDRESS *src)
+    BACNET_ADDRESS *router_src, uint16_t snet, const BACNET_ADDRESS *src)
 {
     unsigned int i = 0;
 

--- a/apps/router/ipmodule.c
+++ b/apps/router/ipmodule.c
@@ -199,7 +199,10 @@ bool dl_ip_init(ROUTER_PORT *port, IP_DATA *ip_data)
 }
 
 int dl_ip_send(
-    IP_DATA *data, BACNET_ADDRESS *dest, uint8_t *pdu, unsigned pdu_len)
+    IP_DATA *data,
+    const BACNET_ADDRESS *dest,
+    const uint8_t *pdu,
+    unsigned pdu_len)
 {
     struct sockaddr_in bip_dest = { 0 };
     int buff_len = 0;

--- a/apps/router/ipmodule.h
+++ b/apps/router/ipmodule.h
@@ -45,8 +45,8 @@ bool dl_ip_init(
 
 int dl_ip_send(
     IP_DATA * data,
-    BACNET_ADDRESS * dest,
-    uint8_t * pdu,
+    const BACNET_ADDRESS * dest,
+    const uint8_t * pdu,
     unsigned pdu_len);
 
 int dl_ip_recv(

--- a/apps/router/main.c
+++ b/apps/router/main.c
@@ -43,7 +43,7 @@ int port_count;
 
 void print_help(void);
 
-bool read_config(char *filepath);
+bool read_config(const char *filepath);
 
 bool parse_cmd(int argc, char *argv[]);
 
@@ -53,7 +53,7 @@ bool init_router(void);
 
 void cleanup(void);
 
-void print_msg(BACMSG *msg);
+void print_msg(const BACMSG *msg);
 
 uint16_t process_msg(BACMSG *msg, MSG_DATA *data, uint8_t **buff);
 
@@ -61,7 +61,7 @@ uint16_t get_next_free_dnet(void);
 
 int kbhit(void);
 
-inline bool is_network_msg(BACMSG *msg);
+inline bool is_network_msg(const BACMSG *msg);
 
 int main(int argc, char *argv[])
 {
@@ -201,7 +201,7 @@ void print_help(void)
         "-s, --stopbits <1|2>\n\tspecify MSTP port stopbits\n");
 }
 
-bool read_config(char *filepath)
+bool read_config(const char *filepath)
 {
     config_t cfg;
     config_setting_t *setting;
@@ -725,11 +725,11 @@ void cleanup(void)
     pthread_mutex_destroy(&msg_lock);
 }
 
-void print_msg(BACMSG *msg)
+void print_msg(const BACMSG *msg)
 {
     if (msg->type == DATA) {
         int i;
-        MSG_DATA *data = (MSG_DATA *)msg->data;
+        const MSG_DATA *data = (const MSG_DATA *)msg->data;
 
         if (data->pdu_len) {
             PRINT(DEBUG, "Message PDU: ");
@@ -821,10 +821,10 @@ int kbhit(void)
     return bytesWaiting;
 }
 
-bool is_network_msg(BACMSG *msg)
+bool is_network_msg(const BACMSG *msg)
 {
     uint8_t control_byte; /* NPDU control byte */
-    MSG_DATA *data = (MSG_DATA *)msg->data;
+    const MSG_DATA *data = (const MSG_DATA *)msg->data;
 
     control_byte = data->pdu[1];
 

--- a/apps/router/network_layer.c
+++ b/apps/router/network_layer.c
@@ -14,7 +14,8 @@
 #include "network_layer.h"
 #include "bacnet/bacint.h"
 
-uint16_t process_network_message(BACMSG *msg, MSG_DATA *data, uint8_t **buff)
+uint16_t process_network_message(
+    const BACMSG *msg, MSG_DATA *data, uint8_t **buff)
 {
     BACNET_NPDU_DATA npdu_data;
     ROUTER_PORT *srcport;

--- a/apps/router/network_layer.h
+++ b/apps/router/network_layer.h
@@ -25,7 +25,7 @@
 #include "portthread.h"
 
 uint16_t process_network_message(
-    BACMSG * msg,
+    const BACMSG * msg,
     MSG_DATA * data,
     uint8_t ** buff);
 

--- a/apps/scov/main.c
+++ b/apps/scov/main.c
@@ -161,14 +161,14 @@ static void cleanup(void)
     }
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s device-id object-type object-instance "
             "process-id <[un]confirmed lifetime|cancel>\n",
         filename);
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Subscribe to a BACnet object for Change-of-Value notifications\n"
         "in a BACnet device and print the Change-of-Value notifications.\n");
@@ -226,7 +226,7 @@ int main(int argc, char *argv[])
     time_t timeout_seconds = 0;
     time_t delta_seconds = 0;
     bool found = false;
-    char *filename = NULL;
+    const char *filename = NULL;
     bool print_usage_terse = false;
     bool print_usage_verbose = false;
     BACNET_SUBSCRIBE_COV_DATA *cov_data = NULL;

--- a/apps/timesync/main.c
+++ b/apps/timesync/main.c
@@ -82,14 +82,14 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s [--dnet][--dadr][--mac]\n", filename);
     printf("       [--date][--time]\n");
     printf("       [--version][--help]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Send BACnet TimeSynchronization request.\n");
     printf("\n");
@@ -157,7 +157,7 @@ int main(int argc, char *argv[])
     BACNET_ADDRESS dest = { 0 };
     bool global_broadcast = true;
     int argi = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     /* decode any command line parameters */
     filename = filename_remove_path(argv[0]);

--- a/apps/ucov/main.c
+++ b/apps/ucov/main.c
@@ -47,7 +47,7 @@ static void Init_Service_Handlers(void)
         SERVICE_CONFIRMED_READ_PROPERTY, handler_read_property);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Sends a BACnet Unconfirmed Change-of-Value Notification\n"
         "to the network.\n");

--- a/apps/uevent/main.c
+++ b/apps/uevent/main.c
@@ -49,7 +49,7 @@ static void Init_Service_Handlers(void)
         SERVICE_CONFIRMED_READ_PROPERTY, handler_read_property);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s pid object-type object-instance \n"
            "    event-object-type event-object-instance \n"
@@ -63,7 +63,7 @@ static void print_usage(char *filename)
     printf("       [--version][--help]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Send BACnet UnconfirmedEventNotification message for a device.\n");
     printf("--mac A\n"
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
     bool specific_address = false;
     int argi = 0;
     unsigned int target_args = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     filename = filename_remove_path(argv[0]);
     for (argi = 1; argi < argc; argi++) {

--- a/apps/uptransfer/main.c
+++ b/apps/uptransfer/main.c
@@ -117,14 +117,14 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s <device-instance|broadcast|dnet=> vendor-id"
         " service-number tag value [tag value...]\n",
         filename);
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Send BACnet UnconfirmedPrivateTransfer message to the network.\n");
     printf("device-instance:\n"
@@ -181,7 +181,7 @@ int main(int argc, char *argv[])
     time_t timeout_seconds = 0;
     time_t delta_seconds = 0;
     bool found = false;
-    char *filename = NULL;
+    const char *filename = NULL;
     char *value_string = NULL;
     bool status = false;
     int args_remaining = 0, tag_value_arg = 0, i = 0;

--- a/apps/whohas/main.c
+++ b/apps/whohas/main.c
@@ -85,14 +85,14 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s [device-instance-min device-instance-min] "
            "<object-type object-instance | object-name> [--help]\r\n",
         filename);
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     print_usage(filename);
     printf("Send BACnet WhoHas request to devices, \r\n"

--- a/apps/whois/main.c
+++ b/apps/whois/main.c
@@ -73,7 +73,7 @@ static struct address_entry *alloc_address_entry(void)
 }
 
 static void address_table_add(
-    uint32_t device_id, unsigned max_apdu, BACNET_ADDRESS *src)
+    uint32_t device_id, unsigned max_apdu, const BACNET_ADDRESS *src)
 {
     struct address_entry *pMatch;
     uint8_t flags = 0;
@@ -185,7 +185,7 @@ static void init_service_handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_macaddr(uint8_t *addr, int len)
+static void print_macaddr(const uint8_t *addr, int len)
 {
     int j = 0;
 
@@ -246,7 +246,7 @@ static void print_address_cache(void)
     }
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s", filename);
     printf(" [device-instance-min [device-instance-max]]\n");
@@ -254,7 +254,7 @@ static void print_usage(char *filename)
     printf("       [--version][--help]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Send BACnet WhoIs service request to a device or multiple\n"
         "devices, and wait for responses. Displays any devices found\n"
@@ -338,7 +338,7 @@ int main(int argc, char *argv[])
     bool global_broadcast = true;
     int argi = 0;
     unsigned int target_args = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
     bool repeat_forever = false;
     long retry_count = 0;
 

--- a/apps/writeprop/main.c
+++ b/apps/writeprop/main.c
@@ -136,14 +136,14 @@ static void Init_Service_Handlers(void)
     apdu_set_reject_handler(MyRejectHandler);
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s device-instance object-type object-instance "
            "property priority index tag value [tag value...]\n",
         filename);
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf(
         "device-instance:\n"

--- a/apps/writepropm/main.c
+++ b/apps/writepropm/main.c
@@ -162,7 +162,7 @@ static void cleanup(void)
     }
 }
 
-static void print_usage(char *filename)
+static void print_usage(const char *filename)
 {
     printf("Usage: %s device-instance object-type object-instance "
            "property[index] priority tag value [property[index] priority tag "
@@ -171,7 +171,7 @@ static void print_usage(char *filename)
     printf("       [--version][--help]\n");
 }
 
-static void print_help(char *filename)
+static void print_help(const char *filename)
 {
     printf("Write one or more properties to one or more objects\n"
         "in a BACnet device.\n");
@@ -278,7 +278,7 @@ int main(int argc, char *argv[])
     unsigned property_array_index = 0;
     int scan_count = 0;
     int argi = 0;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     filename = filename_remove_path(argv[0]);
     for (argi = 1; argi < argc; argi++) {

--- a/ports/arduino_uno/bip-init.c
+++ b/ports/arduino_uno/bip-init.c
@@ -50,7 +50,7 @@ long bip_getaddrbyname(const char *host_name)
  * @param ifname [in] The named interface to use for the network layer.
  *        Eg, for Linux, ifname is eth0, ath0, arc0, and others.
  */
-void bip_set_interface(char *ifname)
+void bip_set_interface(const char *ifname)
 {
     uint8_t local_address[] = { 0, 0, 0, 0 };
     uint8_t broadcast_address[] = { 0, 0, 0, 0 };

--- a/ports/arduino_uno/bip.c
+++ b/ports/arduino_uno/bip.c
@@ -34,7 +34,7 @@ static uint8_t BIP_Broadcast_Address[4] = { 0, 0, 0, 0 };
 /** Converter from uint8_t[4] type address to uint32_t
  *
  */
-uint32_t convertBIP_Address2uint32(uint8_t *bip_address)
+uint32_t convertBIP_Address2uint32(const suint8_t *bip_address)
 {
     return (uint32_t)((bip_address[0] * 2 ^ 24) + (bip_address[1] * 2 ^ 16) +
         (bip_address[2] * 2 ^ 8) + bip_address[3]);
@@ -74,7 +74,7 @@ bool bip_valid(void)
     return (BIP_Socket < MAX_SOCK_NUM);
 }
 
-void bip_set_addr(uint8_t *net_address)
+void bip_set_addr(const uint8_t *net_address)
 { /* in network byte order */
     for (uint8_t i = 0; i < 4; i++)
         BIP_Address[i] = net_address[i];
@@ -86,7 +86,7 @@ uint8_t *bip_get_addr(void)
     return BIP_Address;
 }
 
-void bip_set_broadcast_addr(uint8_t *net_address)
+void bip_set_broadcast_addr(const uint8_t *net_address)
 { /* in network byte order */
     for (uint8_t i = 0; i < 4; i++)
         BIP_Broadcast_Address[i] = net_address[i];
@@ -109,9 +109,8 @@ uint16_t bip_get_port(void)
     return ntohs(BIP_Port);
 }
 
-static int bip_decode_bip_address(BACNET_ADDRESS *bac_addr,
+static int bip_decode_bip_address(const BACNET_ADDRESS *bac_addr,
     uint8_t *address, /* in network format */
-
     uint16_t *port)
 { /* in network format */
     int len = 0;

--- a/ports/arduino_uno/bip.h
+++ b/ports/arduino_uno/bip.h
@@ -28,11 +28,11 @@ extern "C" {
     /* on Linux, ifname is eth0, ath0, arc0, and others.
        on Windows, ifname is the dotted ip address of the interface */
     bool bip_init(char *ifname);
-    void bip_set_interface(char *ifname);
+    void bip_set_interface(const char *ifname);
     void bip_cleanup(void);
 
     /* Convert uint8_t IPv4 to uint32 */
-    uint32_t convertBIP_Address2uint32(uint8_t * bip_address);
+    uint32_t convertBIP_Address2uint32(const uint8_t * bip_address);
     void convertUint32Address_2_uint8Address(uint32_t ip,
         uint8_t * address);
     /* common BACnet/IP functions */
@@ -68,12 +68,12 @@ extern "C" {
     uint16_t bip_get_port(void);
 
     /* use network byte order for setting */
-    void bip_set_addr(uint8_t * net_address);
+    void bip_set_addr(const uint8_t * net_address);
     /* returns network byte order */
     uint8_t *bip_get_addr(void);
 
     /* use network byte order for setting */
-    void bip_set_broadcast_addr(uint8_t * net_address);
+    void bip_set_broadcast_addr(const uint8_t * net_address);
     /* returns network byte order */
     uint8_t *bip_get_broadcast_addr(void);
 

--- a/ports/arduino_uno/bvlc-arduino.c
+++ b/ports/arduino_uno/bvlc-arduino.c
@@ -54,12 +54,9 @@ static int bvlc_encode_bvlc_result(uint8_t *pdu, BACNET_BVLC_RESULT result_code)
  * @return Upon successful completion, returns the number of bytes sent.
  *  Otherwise, -1 shall be returned and errno set to indicate the error.
  */
-static int bvlc_send_mpdu(uint8_t *dest_addr, /* the destination address */
-
-    uint16_t *dest_port, /* the destination port */
-
+static int bvlc_send_mpdu(const uint8_t *dest_addr, /* the destination address */
+    const uint16_t *dest_port, /* the destination port */
     uint8_t *mtu, /* the data */
-
     uint16_t mtu_len)
 { /* amount of data to send  */
     /* assumes that the driver has already been initialized */
@@ -75,9 +72,8 @@ static int bvlc_send_mpdu(uint8_t *dest_addr, /* the destination address */
  * @param dest_addr - destination address
  * @param dest_port - destination port
  */
-static void bvlc_send_result(uint8_t *dest_addr,
-    uint16_t *dest_port, /* the destination address */
-
+static void bvlc_send_result(const uint8_t *dest_addr,
+    const uint16_t *dest_port, /* the destination address */
     BACNET_BVLC_RESULT result_code)
 {
     uint8_t mtu[BIP_MPDU_MAX] = { 0 };

--- a/ports/arduino_uno/h_whois.c
+++ b/ports/arduino_uno/h_whois.c
@@ -64,7 +64,7 @@ void handler_who_is(
     } else if (len != -1) {
         /* is my device id within the limits? */
         target_device = Device_Object_Instance_Number();
-        if (((target_device >= low_limit) && (target_device <= high_limit)) {
+        if ((target_device >= low_limit) && (target_device <= high_limit)) {
             sendIamUnicast(&Handler_Transmit_Buffer[0], src);
         }
     }

--- a/ports/at91sam7s/device.c
+++ b/ports/at91sam7s/device.c
@@ -126,7 +126,8 @@ static struct my_object_functions *Device_Objects_Find_Functions(
 }
 
 static int Read_Property_Common(
-    struct my_object_functions *pObject, BACNET_READ_PROPERTY_DATA *rpdata)
+    const struct my_object_functions *pObject,
+    BACNET_READ_PROPERTY_DATA *rpdata)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     BACNET_CHARACTER_STRING char_string;
@@ -299,7 +300,7 @@ bool Device_Object_Name(
     return status;
 }
 
-bool Device_Set_Object_Name(BACNET_CHARACTER_STRING *object_name)
+bool Device_Set_Object_Name(const BACNET_CHARACTER_STRING *object_name)
 {
     bool status = false; /*return value */
 
@@ -574,7 +575,7 @@ int Device_Object_List_Element_Encode(
     return apdu_len;
 }
 
-bool Device_Valid_Object_Name(BACNET_CHARACTER_STRING *object_name1,
+bool Device_Valid_Object_Name(const BACNET_CHARACTER_STRING *object_name1,
     BACNET_OBJECT_TYPE *object_type,
     uint32_t *object_instance)
 {

--- a/ports/at91sam7s/dlmstp.c
+++ b/ports/at91sam7s/dlmstp.c
@@ -195,10 +195,10 @@ void dlmstp_fill_bacnet_address(BACNET_ADDRESS *src, uint8_t mstp_address)
     }
 }
 
-static bool dlmstp_compare_data_expecting_reply(uint8_t *request_pdu,
+static bool dlmstp_compare_data_expecting_reply(const uint8_t *request_pdu,
     uint16_t request_pdu_len,
     uint8_t src_address,
-    uint8_t *reply_pdu,
+    const uint8_t *reply_pdu,
     uint16_t reply_pdu_len,
     uint8_t dest_address)
 {
@@ -314,7 +314,7 @@ static void MSTP_Send_Frame(
     uint8_t frame_type, /* type of frame to send - see defines */
     uint8_t destination, /* destination address */
     uint8_t source, /* source address */
-    uint8_t *data, /* any data to be sent - may be null */
+    const uint8_t *data, /* any data to be sent - may be null */
     uint16_t data_len)
 { /* number of bytes of data (up to 501) */
     uint8_t crc8 = 0xFF; /* used to calculate the crc value */
@@ -735,7 +735,7 @@ static bool MSTP_Master_Node_FSM(void)
                     frame_type = FRAME_TYPE_BACNET_DATA_NOT_EXPECTING_REPLY;
                 }
                 MSTP_Send_Frame(frame_type, pkt->destination_mac, This_Station,
-                    (uint8_t *)&pkt->buffer[0], pkt->length);
+                    &pkt->buffer[0], pkt->length);
                 FrameCount++;
                 switch (frame_type) {
                     case FRAME_TYPE_BACNET_DATA_EXPECTING_REPLY:
@@ -1081,7 +1081,7 @@ static bool MSTP_Master_Node_FSM(void)
                     frame_type = FRAME_TYPE_BACNET_DATA_NOT_EXPECTING_REPLY;
                 }
                 MSTP_Send_Frame(frame_type, pkt->destination_mac, This_Station,
-                    (uint8_t *)&pkt->buffer[0], pkt->length);
+                    &pkt->buffer[0], pkt->length);
                 Master_State = MSTP_MASTER_STATE_IDLE;
                 /* clear our flag we were holding for comparison */
                 MSTP_Flag.ReceivedValidFrame = false;
@@ -1165,7 +1165,7 @@ static void MSTP_Slave_Node_FSM(void)
                     frame_type = FRAME_TYPE_BACNET_DATA_NOT_EXPECTING_REPLY;
                 }
                 MSTP_Send_Frame(frame_type, pkt->destination_mac, This_Station,
-                    (uint8_t *)&pkt->buffer[0], pkt->length);
+                    &pkt->buffer[0], pkt->length);
                 (void)Ringbuf_Pop(&PDU_Queue, NULL);
             }
             /* clear our flag we were holding for comparison */

--- a/ports/at91sam7s/netport.c
+++ b/ports/at91sam7s/netport.c
@@ -294,7 +294,7 @@ bool Network_Port_MAC_Address(
  * @return  true if object-name was set
  */
 bool Network_Port_MAC_Address_Set(
-    uint32_t object_instance, uint8_t *mac_src, uint8_t mac_len)
+    uint32_t object_instance, const uint8_t *mac_src, uint8_t mac_len)
 {
     if (mac_len == 1) {
         Object_List[0].MAC_Address[0] = mac_src[0];

--- a/ports/at91sam7s/rs485.c
+++ b/ports/at91sam7s/rs485.c
@@ -171,7 +171,7 @@ void RS485_Transmitter_Enable(bool enable)
  * ALGORITHM:   none
  * NOTES:       none
  *****************************************************************************/
-void RS485_Send_Data(uint8_t *buffer, /* data to send */
+void RS485_Send_Data(const uint8_t *buffer, /* data to send */
     uint16_t nbytes)
 { /* number of bytes of data */
     /* LED on send */

--- a/ports/at91sam7s/rs485.h
+++ b/ports/at91sam7s/rs485.h
@@ -22,7 +22,7 @@ extern "C" {
         bool enable);
 
     void RS485_Send_Data(
-        uint8_t * buffer,       /* data to send */
+        const uint8_t * buffer, /* data to send */
         uint16_t nbytes);       /* number of bytes of data */
 
     bool RS485_ReceiveError(

--- a/ports/atmega168/ai.h
+++ b/ports/atmega168/ai.h
@@ -37,13 +37,13 @@ extern "C" {
         uint32_t object_instance);
     bool Analog_Input_Name_Set(
         uint32_t object_instance,
-        char *new_name);
+        const char *new_name);
 
-    char *Analog_Input_Description(
+    const char *Analog_Input_Description(
         uint32_t instance);
     bool Analog_Input_Description_Set(
         uint32_t instance,
-        char *new_name);
+        const char *new_name);
 
     bool Analog_Input_Units_Set(
         uint32_t instance,

--- a/ports/atmega168/dlmstp.c
+++ b/ports/atmega168/dlmstp.c
@@ -226,7 +226,7 @@ static void MSTP_Send_Frame(
     uint8_t frame_type, /* type of frame to send - see defines */
     uint8_t destination, /* destination address */
     uint8_t source, /* source address */
-    uint8_t *pdu, /* any data to be sent - may be null */
+    const uint8_t *pdu, /* any data to be sent - may be null */
     uint16_t pdu_len)
 { /* number of bytes of data (up to 501) */
     uint8_t crc8 = 0xFF; /* used to calculate the crc value */
@@ -635,7 +635,7 @@ static bool MSTP_Master_Node_FSM(void)
             if (TransmitPacketLen) {
                 MSTP_Send_Frame(FRAME_TYPE_BACNET_DATA_NOT_EXPECTING_REPLY,
                     MSTP_BROADCAST_ADDRESS, This_Station,
-                    (uint8_t *)&TransmitPacket[0], TransmitPacketLen);
+                    &TransmitPacket[0], TransmitPacketLen);
                 FrameCount++;
             } else {
                 /* NothingToSend */
@@ -959,7 +959,7 @@ static bool MSTP_Master_Node_FSM(void)
                 /* Note: optimized such that we are never a client */
                 MSTP_Send_Frame(FRAME_TYPE_BACNET_DATA_NOT_EXPECTING_REPLY,
                     TransmitPacketDest, This_Station,
-                    (uint8_t *)&TransmitPacket[0], TransmitPacketLen);
+                    &TransmitPacket[0], TransmitPacketLen);
                 MSTP_Flag.TransmitPacketPending = false;
                 Master_State = MSTP_MASTER_STATE_IDLE;
             } else {

--- a/ports/atmega168/rs485.c
+++ b/ports/atmega168/rs485.c
@@ -144,7 +144,7 @@ void RS485_Turnaround_Delay(void)
  * @param buffer - data to send
  * @param nbytes - number of bytes of data
  */
-void RS485_Send_Data(uint8_t *buffer,
+void RS485_Send_Data(const uint8_t *buffer,
     uint16_t nbytes)
 {
     while (nbytes) {

--- a/ports/atmega168/rs485.h
+++ b/ports/atmega168/rs485.h
@@ -21,7 +21,7 @@ extern "C" {
         bool enable);
 
     void RS485_Send_Data(
-        uint8_t * buffer,       /* data to send */
+        const uint8_t * buffer, /* data to send */
         uint16_t nbytes);       /* number of bytes of data */
 
     bool RS485_ReceiveError(

--- a/ports/bdk-atxx4-mstp/bname.c
+++ b/ports/bdk-atxx4-mstp/bname.c
@@ -18,7 +18,7 @@
 #include "bacnet/basic/object/device.h"
 #include "bname.h"
 
-static bool bacnet_name_isvalid(uint8_t encoding, uint8_t length, char *str)
+static bool bacnet_name_isvalid(uint8_t encoding, uint8_t length, const char *str)
 {
     bool valid = false;
 
@@ -35,7 +35,7 @@ static bool bacnet_name_isvalid(uint8_t encoding, uint8_t length, char *str)
 }
 
 bool bacnet_name_save(
-    uint16_t offset, uint8_t encoding, char *str, uint8_t length)
+    uint16_t offset, uint8_t encoding, const char *str, uint8_t length)
 {
     uint8_t buffer[NV_EEPROM_NAME_SIZE] = { 0 };
     uint8_t i = 0;
@@ -55,11 +55,11 @@ bool bacnet_name_save(
     return false;
 }
 
-bool bacnet_name_set(uint16_t offset, BACNET_CHARACTER_STRING *char_string)
+bool bacnet_name_set(uint16_t offset, const BACNET_CHARACTER_STRING *char_string)
 {
     uint8_t encoding = 0;
     uint8_t length = 0;
-    char *str = NULL;
+    const char *str = NULL;
 
     length = characterstring_length(char_string);
     encoding = characterstring_encoding(char_string);
@@ -70,7 +70,7 @@ bool bacnet_name_set(uint16_t offset, BACNET_CHARACTER_STRING *char_string)
 bool bacnet_name_write_unique(uint16_t offset,
     BACNET_OBJECT_TYPE object_type,
     uint32_t object_instance,
-    BACNET_CHARACTER_STRING *char_string,
+    const BACNET_CHARACTER_STRING *char_string,
     BACNET_ERROR_CLASS *error_class,
     BACNET_ERROR_CODE *error_code)
 {
@@ -120,7 +120,7 @@ bool bacnet_name_write_unique(uint16_t offset,
 
 /* no required minumum length or duplicate checking */
 bool bacnet_name_write(uint16_t offset,
-    BACNET_CHARACTER_STRING *char_string,
+    const BACNET_CHARACTER_STRING *char_string,
     BACNET_ERROR_CLASS *error_class,
     BACNET_ERROR_CODE *error_code)
 {
@@ -149,14 +149,16 @@ bool bacnet_name_write(uint16_t offset,
     return status;
 }
 
-void bacnet_name_init(uint16_t offset, char *default_string)
+void bacnet_name_init(uint16_t offset, const char *default_string)
 {
     (void)bacnet_name_save(
         offset, CHARACTER_UTF8, default_string, strlen(default_string));
 }
 
 void bacnet_name(
-    uint16_t offset, BACNET_CHARACTER_STRING *char_string, char *default_string)
+    uint16_t offset,
+    BACNET_CHARACTER_STRING *char_string,
+    const char *default_string)
 {
     uint8_t encoding = 0;
     uint8_t length = 0;

--- a/ports/bdk-atxx4-mstp/bname.h
+++ b/ports/bdk-atxx4-mstp/bname.h
@@ -17,30 +17,30 @@ extern "C" {
 
     bool bacnet_name_set(
         uint16_t eeprom_offset,
-        BACNET_CHARACTER_STRING * char_string);
+        const BACNET_CHARACTER_STRING * char_string);
     void bacnet_name_init(
         uint16_t eeprom_offset,
-        char *default_string);
+        const char *default_string);
     bool bacnet_name_save(
         uint16_t offset,
         uint8_t encoding,
-        char *str,
+        const char *str,
         uint8_t length);
     void bacnet_name(
         uint16_t eeprom_offset,
         BACNET_CHARACTER_STRING * char_string,
-        char *default_string);
+        const char *default_string);
     bool bacnet_name_write_unique(
         uint16_t offset,
         BACNET_OBJECT_TYPE object_type,
         uint32_t object_instance,
-        BACNET_CHARACTER_STRING * char_string,
+        const BACNET_CHARACTER_STRING * char_string,
         BACNET_ERROR_CLASS * error_class,
         BACNET_ERROR_CODE * error_code);
     /* no required minumum length or duplicate checking */
     bool bacnet_name_write(
         uint16_t offset,
-        BACNET_CHARACTER_STRING * char_string,
+        const BACNET_CHARACTER_STRING * char_string,
         BACNET_ERROR_CLASS * error_class,
         BACNET_ERROR_CODE * error_code);
 

--- a/ports/bdk-atxx4-mstp/device.c
+++ b/ports/bdk-atxx4-mstp/device.c
@@ -551,7 +551,7 @@ int Device_Object_List_Element_Encode(
     return apdu_len;
 }
 
-bool Device_Valid_Object_Name(BACNET_CHARACTER_STRING *object_name1,
+bool Device_Valid_Object_Name(const BACNET_CHARACTER_STRING *object_name1,
     BACNET_OBJECT_TYPE *object_type,
     uint32_t *object_instance)
 {

--- a/ports/bdk-atxx4-mstp/dlmstp.c
+++ b/ports/bdk-atxx4-mstp/dlmstp.c
@@ -196,10 +196,10 @@ void dlmstp_fill_bacnet_address(BACNET_ADDRESS *src, uint8_t mstp_address)
     }
 }
 
-static bool dlmstp_compare_data_expecting_reply(uint8_t *request_pdu,
+static bool dlmstp_compare_data_expecting_reply(const uint8_t *request_pdu,
     uint16_t request_pdu_len,
     uint8_t src_address,
-    uint8_t *reply_pdu,
+    const uint8_t *reply_pdu,
     uint16_t reply_pdu_len,
     uint8_t dest_address)
 {
@@ -314,8 +314,8 @@ static bool dlmstp_compare_data_expecting_reply(uint8_t *request_pdu,
 static void MSTP_Send_Frame(
     uint8_t frame_type, /* type of frame to send - see defines */
     uint8_t destination, /* destination address */
-    uint8_t source, /* source address */
-    uint8_t *data, /* any data to be sent - may be null */
+    uint8_t source,      /* source address */
+    const uint8_t *data, /* any data to be sent - may be null */
     uint16_t data_len)
 { /* number of bytes of data (up to 501) */
     uint8_t crc8 = 0xFF; /* used to calculate the crc value */
@@ -757,7 +757,7 @@ static bool MSTP_Master_Node_FSM(void)
                     frame_type = FRAME_TYPE_BACNET_DATA_NOT_EXPECTING_REPLY;
                 }
                 MSTP_Send_Frame(frame_type, pkt->destination_mac, This_Station,
-                    (uint8_t *)&pkt->buffer[0], pkt->length);
+                    &pkt->buffer[0], pkt->length);
                 FrameCount++;
                 switch (frame_type) {
                     case FRAME_TYPE_BACNET_DATA_EXPECTING_REPLY:
@@ -1111,7 +1111,7 @@ static bool MSTP_Master_Node_FSM(void)
                     frame_type = FRAME_TYPE_BACNET_DATA_NOT_EXPECTING_REPLY;
                 }
                 MSTP_Send_Frame(frame_type, pkt->destination_mac, This_Station,
-                    (uint8_t *)&pkt->buffer[0], pkt->length);
+                    &pkt->buffer[0], pkt->length);
                 Master_State = MSTP_MASTER_STATE_IDLE;
                 /* clear our flag we were holding for comparison */
                 MSTP_Flag.ReceivedValidFrame = false;
@@ -1195,7 +1195,7 @@ static void MSTP_Slave_Node_FSM(void)
                     frame_type = FRAME_TYPE_BACNET_DATA_NOT_EXPECTING_REPLY;
                 }
                 MSTP_Send_Frame(frame_type, pkt->destination_mac, This_Station,
-                    (uint8_t *)&pkt->buffer[0], pkt->length);
+                    &pkt->buffer[0], pkt->length);
                 (void)Ringbuf_Pop(&PDU_Queue, NULL);
             }
             /* clear our flag we were holding for comparison */

--- a/ports/bdk-atxx4-mstp/eeprom.c
+++ b/ports/bdk-atxx4-mstp/eeprom.c
@@ -30,7 +30,7 @@ int eeprom_bytes_read(
 }
 
 int eeprom_bytes_write(uint16_t eeaddr, /* EEPROM starting memory address */
-    uint8_t *buf, /* data to send */
+    const uint8_t *buf, /* data to send */
     int len)
 { /* number of bytes of data */
     int count = 0;

--- a/ports/bdk-atxx4-mstp/eeprom.h
+++ b/ports/bdk-atxx4-mstp/eeprom.h
@@ -21,7 +21,7 @@ extern "C" {
         int nbytes);    /* number of bytes of data to read */
     int eeprom_bytes_write(
         uint16_t ee_address,    /* EEPROM starting memory address */
-        uint8_t * buffer,       /* data to send */
+        const uint8_t * buffer, /* data to send */
         int nbytes);    /* number of bytes of data */
 
 #ifdef __cplusplus

--- a/ports/bdk-atxx4-mstp/netport.c
+++ b/ports/bdk-atxx4-mstp/netport.c
@@ -295,7 +295,7 @@ bool Network_Port_MAC_Address(
  * @return  true if object-name was set
  */
 bool Network_Port_MAC_Address_Set(
-    uint32_t object_instance, uint8_t *mac_src, uint8_t mac_len)
+    uint32_t object_instance, const uint8_t *mac_src, uint8_t mac_len)
 {
     if (mac_len == 1) {
         Object_List[0].MAC_Address[0] = mac_src[0];

--- a/ports/bdk-atxx4-mstp/rs485.c
+++ b/ports/bdk-atxx4-mstp/rs485.c
@@ -175,7 +175,7 @@ bool rs485_receive_error(void)
  * RETURN:      none
  * NOTES:       none
  *****************************************************************************/
-void rs485_bytes_send(uint8_t *buffer, /* data to send */
+void rs485_bytes_send(const uint8_t *buffer, /* data to send */
     uint16_t nbytes)
 { /* number of bytes of data */
     led_on(LED_5);

--- a/ports/bdk-atxx4-mstp/rs485.h
+++ b/ports/bdk-atxx4-mstp/rs485.h
@@ -23,7 +23,7 @@ extern "C" {
     bool rs485_receive_error(
         void);
     void rs485_bytes_send(
-        uint8_t * buffer,       /* data to send */
+        const uint8_t * buffer,       /* data to send */
         uint16_t nbytes);       /* number of bytes of data */
     uint32_t rs485_baud_rate(
         void);

--- a/ports/bsd/bip-init.c
+++ b/ports/bsd/bip-init.c
@@ -162,7 +162,7 @@ void bip_get_broadcast_address(BACNET_ADDRESS *dest)
  *
  * @param addr - network IPv4 address
  */
-bool bip_set_addr(BACNET_IP_ADDRESS *addr)
+bool bip_set_addr(const BACNET_IP_ADDRESS *addr)
 {
     (void)addr;
     /* not something we do within this driver */
@@ -189,7 +189,7 @@ bool bip_get_addr(BACNET_IP_ADDRESS *addr)
  * @param addr - network IPv4 address
  * @return true if the address was set
  */
-bool bip_set_broadcast_addr(BACNET_IP_ADDRESS *addr)
+bool bip_set_broadcast_addr(const BACNET_IP_ADDRESS *addr)
 {
     (void)addr;
     /* not something we do within this driver */
@@ -257,7 +257,8 @@ uint8_t bip_get_subnet_prefix(void)
  * @return Upon successful completion, returns the number of bytes sent.
  *  Otherwise, -1 shall be returned and errno set to indicate the error.
  */
-int bip_send_mpdu(BACNET_IP_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
+int bip_send_mpdu(
+    const BACNET_IP_ADDRESS *dest, const uint8_t *mtu, uint16_t mtu_len)
 {
     struct sockaddr_in bip_dest = { 0 };
 
@@ -276,7 +277,7 @@ int bip_send_mpdu(BACNET_IP_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
     /* Send the packet */
     debug_print_ipv4(
         "Sending MPDU->", &bip_dest.sin_addr, bip_dest.sin_port, mtu_len);
-    return sendto(BIP_Socket, (char *)mtu, mtu_len, 0,
+    return sendto(BIP_Socket, (const char *)mtu, mtu_len, 0,
         (struct sockaddr *)&bip_dest, sizeof(struct sockaddr));
 }
 
@@ -472,7 +473,8 @@ static char *ifname_default(void)
  * @param addr [out] The netmask addr, broadcast addr, ip addr.
  * @param request [in] addr broadaddr netmask
  */
-static int get_local_address(char *ifname, struct in_addr *addr, char *request)
+static int get_local_address(
+    const char *ifname, struct in_addr *addr, const char *request)
 {
     char rv = '\0'; /* return value */
 
@@ -543,7 +545,7 @@ int bip_set_broadcast_binding(
  * @param ifname [in] The named interface to use for the network layer.
  *        Eg, for MAC OS X, ifname is en0, en1, and others.
  */
-void bip_set_interface(char *ifname)
+void bip_set_interface(const char *ifname)
 {
     struct in_addr local_address;
     struct in_addr broadcast_address;
@@ -602,7 +604,7 @@ void bip_set_interface(char *ifname)
     }
 }
 
-static int createSocket(struct sockaddr_in *sin)
+static int createSocket(const struct sockaddr_in *sin)
 {
     int status = 0; /* return from socket lib calls */
     int sockopt = 0;

--- a/ports/bsd/bip6.c
+++ b/ports/bsd/bip6.c
@@ -181,7 +181,7 @@ void bip6_get_my_address(BACNET_ADDRESS *addr)
  *
  * @param addr - network IPv6 address
  */
-bool bip6_set_addr(BACNET_IP6_ADDRESS *addr)
+bool bip6_set_addr(const BACNET_IP6_ADDRESS *addr)
 {
     return bvlc6_address_copy(&BIP6_Addr, addr);
 }
@@ -201,7 +201,7 @@ bool bip6_get_addr(BACNET_IP6_ADDRESS *addr)
  *
  * @param addr - network IPv6 address
  */
-bool bip6_set_broadcast_addr(BACNET_IP6_ADDRESS *addr)
+bool bip6_set_broadcast_addr(const BACNET_IP6_ADDRESS *addr)
 {
     return bvlc6_address_copy(&BIP6_Broadcast_Addr, addr);
 }
@@ -227,7 +227,8 @@ bool bip6_get_broadcast_addr(BACNET_IP6_ADDRESS *addr)
  * @return Upon successful completion, returns the number of bytes sent.
  *  Otherwise, -1 shall be returned and errno set to indicate the error.
  */
-int bip6_send_mpdu(BACNET_IP6_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
+int bip6_send_mpdu(
+    const BACNET_IP6_ADDRESS *dest, const uint8_t *mtu, uint16_t mtu_len)
 {
     struct sockaddr_in6 bvlc_dest = { 0 };
     uint16_t addr16[8];
@@ -252,7 +253,7 @@ int bip6_send_mpdu(BACNET_IP6_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
     bvlc_dest.sin6_scope_id = BIP6_Socket_Scope_Id;
     debug_print_ipv6("Sending MPDU->", &bvlc_dest.sin6_addr);
     /* Send the packet */
-    return sendto(BIP6_Socket, (char *)mtu, mtu_len, 0,
+    return sendto(BIP6_Socket, (const char *)mtu, mtu_len, 0,
         (struct sockaddr *)&bvlc_dest, sizeof(bvlc_dest));
 }
 

--- a/ports/bsd/datetime-init.c
+++ b/ports/bsd/datetime-init.c
@@ -27,8 +27,7 @@
  * @param utc - True for UTC sync, False for Local time
  * @return True if time is set
  */
-void datetime_timesync(
-    BACNET_DATE *bdate, BACNET_TIME *btime, bool utc)
+void datetime_timesync(BACNET_DATE *bdate, BACNET_TIME *btime, bool utc)
 {
     (void)bdate;
     (void)btime;

--- a/ports/bsd/rs485.c
+++ b/ports/bsd/rs485.c
@@ -396,7 +396,7 @@ bool RS485_Set_Baud_Rate(uint32_t baud)
  *****************************************************************************/
 void RS485_Send_Frame(
     struct mstp_port_struct_t *mstp_port, /* port specific data */
-    uint8_t *buffer, /* frame to send (up to 501 bytes of data) */
+    const uint8_t *buffer, /* frame to send (up to 501 bytes of data) */
     uint16_t nbytes)
 { /* number of bytes of data (up to 501) */
     uint32_t turnaround_time = Tturnaround * 1000;

--- a/ports/bsd/rs485.h
+++ b/ports/bsd/rs485.h
@@ -30,8 +30,8 @@ void RS485_Initialize(void);
 BACNET_STACK_EXPORT
 void RS485_Send_Frame(
     struct mstp_port_struct_t *mstp_port, /* port specific data */
-    uint8_t *buffer, /* frame to send (up to 501 bytes of data) */
-    uint16_t nbytes); /* number of bytes of data (up to 501) */
+    const uint8_t *buffer,  /* frame to send (up to 501 bytes of data) */
+    uint16_t nbytes);       /* number of bytes of data (up to 501) */
 
 BACNET_STACK_EXPORT
 void RS485_Check_UART_Data(

--- a/ports/esp32/src/ai.h
+++ b/ports/esp32/src/ai.h
@@ -73,13 +73,13 @@ extern "C" {
         BACNET_CHARACTER_STRING * object_name);
     bool Analog_Input_Name_Set(
         uint32_t object_instance,
-        char *new_name);
+        const char *new_name);
 
-    char *Analog_Input_Description(
+    const char *Analog_Input_Description(
         uint32_t instance);
     bool Analog_Input_Description_Set(
         uint32_t instance,
-        char *new_name);
+        const char *new_name);
 
     bool Analog_Input_Units_Set(
         uint32_t instance,

--- a/ports/esp32/src/bip_init.c
+++ b/ports/esp32/src/bip_init.c
@@ -15,7 +15,7 @@ long bip_get_addr_by_name(const char *host_name)
     return 0;
 }
 
-void bip_set_interface(char *ifname)
+void bip_set_interface(const char *ifname)
 {
 }
 

--- a/ports/esp32/src/bo.h
+++ b/ports/esp32/src/bo.h
@@ -45,13 +45,13 @@ extern "C" {
         uint32_t object_instance,
         char *new_name);
 
-    char *Binary_Output_Description(
+    const char *Binary_Output_Description(
         uint32_t instance);
     bool Binary_Output_Description_Set(
         uint32_t instance,
-        char *new_name);
+        const char *new_name);
 
-    char *Binary_Output_Inactive_Text(
+    const char *Binary_Output_Inactive_Text(
         uint32_t instance);
     bool Binary_Output_Inactive_Text_Set(
         uint32_t instance,

--- a/ports/esp32/src/device.c
+++ b/ports/esp32/src/device.c
@@ -381,7 +381,7 @@ bool Device_Object_Name(
     return status;
 }
 
-bool Device_Set_Object_Name(BACNET_CHARACTER_STRING *object_name)
+bool Device_Set_Object_Name(const BACNET_CHARACTER_STRING *object_name)
 {
     bool status = false; /*return value */
 
@@ -689,7 +689,7 @@ bool Device_Object_List_Identifier(
  * Object.
  * @return True on success or else False if not found.
  */
-bool Device_Valid_Object_Name(BACNET_CHARACTER_STRING *object_name1,
+bool Device_Valid_Object_Name(const BACNET_CHARACTER_STRING *object_name1,
     BACNET_OBJECT_TYPE *object_type,
     uint32_t *object_instance)
 {

--- a/ports/esp32/src/device.h
+++ b/ports/esp32/src/device.h
@@ -274,7 +274,7 @@ extern "C" {
         uint32_t object_instance,
         BACNET_CHARACTER_STRING * object_name);
     bool Device_Set_Object_Name(
-        BACNET_CHARACTER_STRING * object_name);
+        const BACNET_CHARACTER_STRING * object_name);
     /* Copy a child object name, given its ID. */
     bool Device_Object_Name_Copy(
         BACNET_OBJECT_TYPE object_type,
@@ -340,7 +340,7 @@ extern "C" {
         void);
 
     bool Device_Valid_Object_Name(
-        BACNET_CHARACTER_STRING * object_name,
+        const BACNET_CHARACTER_STRING * object_name,
         BACNET_OBJECT_TYPE *object_type,
         uint32_t * object_instance);
     bool Device_Valid_Object_Id(
@@ -375,7 +375,7 @@ extern "C" {
 
     uint16_t Add_Routed_Device(
         uint32_t Object_Instance,
-        BACNET_CHARACTER_STRING * Object_Name,
+        const BACNET_CHARACTER_STRING * Object_Name,
         const char *Description);
     DEVICE_OBJECT_DATA *Get_Routed_Device_Object(
         int idx);
@@ -388,14 +388,14 @@ extern "C" {
     bool Routed_Device_Address_Lookup(
         int idx,
         uint8_t address_len,
-        uint8_t * mac_adress);
+        const uint8_t * mac_adress);
     bool Routed_Device_GetNext(
-        BACNET_ADDRESS * dest,
-        int *DNET_list,
+        const BACNET_ADDRESS * dest,
+        const int *DNET_list,
         int *cursor);
     bool Routed_Device_Is_Valid_Network(
         uint16_t dest_net,
-        int *DNET_list);
+        const int *DNET_list);
 
     uint32_t Routed_Device_Index_To_Instance(
         unsigned index);

--- a/ports/linux/arcnet.c
+++ b/ports/linux/arcnet.c
@@ -69,7 +69,7 @@ void arcnet_cleanup(void)
     return;
 }
 
-static int arcnet_bind(char *interface_name)
+static int arcnet_bind(const char *interface_name)
 {
     int sock_fd = -1; /* return value */
     struct ifreq ifr;

--- a/ports/linux/bacport.h
+++ b/ports/linux/bacport.h
@@ -100,7 +100,7 @@ extern int bip_get_local_netmask(
 
 BACNET_STACK_EXPORT
 extern int bip_get_local_address_ioctl(
-    char *ifname,
+    const char *ifname,
     struct in_addr *addr,
     int request);
 

--- a/ports/linux/bip-init.c
+++ b/ports/linux/bip-init.c
@@ -178,7 +178,7 @@ void bip_get_broadcast_address(BACNET_ADDRESS *dest)
  *
  * @param addr - network IPv4 address
  */
-bool bip_set_addr(BACNET_IP_ADDRESS *addr)
+bool bip_set_addr(const BACNET_IP_ADDRESS *addr)
 {
     /* not something we do within this driver */
     (void)addr;
@@ -205,7 +205,7 @@ bool bip_get_addr(BACNET_IP_ADDRESS *addr)
  * @param addr - network IPv4 address
  * @return true if the address was set
  */
-bool bip_set_broadcast_addr(BACNET_IP_ADDRESS *addr)
+bool bip_set_broadcast_addr(const BACNET_IP_ADDRESS *addr)
 {
     /* not something we do within this driver */
     (void)addr;
@@ -273,7 +273,8 @@ uint8_t bip_get_subnet_prefix(void)
  * @return Upon successful completion, returns the number of bytes sent.
  *  Otherwise, -1 shall be returned and errno set to indicate the error.
  */
-int bip_send_mpdu(BACNET_IP_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
+int bip_send_mpdu(
+    const BACNET_IP_ADDRESS *dest, const uint8_t *mtu, uint16_t mtu_len)
 {
     struct sockaddr_in bip_dest = { 0 };
 
@@ -292,7 +293,7 @@ int bip_send_mpdu(BACNET_IP_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
     /* Send the packet */
     debug_print_ipv4(
         "Sending MPDU->", &bip_dest.sin_addr, bip_dest.sin_port, mtu_len);
-    return sendto(BIP_Socket, (char *)mtu, mtu_len, 0,
+    return sendto(BIP_Socket, (const char *)mtu, mtu_len, 0,
         (struct sockaddr *)&bip_dest, sizeof(struct sockaddr));
 }
 
@@ -465,7 +466,8 @@ bool bip_get_addr_by_name(const char *host_name, BACNET_IP_ADDRESS *addr)
  * @param request - the ioctl() request
  * @return 0 on success, else the error from the ioctl() call.
  */
-static int get_local_ifr_ioctl(char *ifname, struct ifreq *ifr, int request)
+static int get_local_ifr_ioctl(
+    const char *ifname, struct ifreq *ifr, int request)
 {
     int fd;
     int rv; /* return value */
@@ -491,7 +493,8 @@ static int get_local_ifr_ioctl(char *ifname, struct ifreq *ifr, int request)
  * @param request - the ioctl() request
  * @return 0 on success, else the error from the ioctl() call.
  */
-int bip_get_local_address_ioctl(char *ifname, struct in_addr *addr, int request)
+int bip_get_local_address_ioctl(
+    const char *ifname, struct in_addr *addr, int request)
 {
     struct ifreq ifr = { 0 };
     struct sockaddr_in *tcpip_address;
@@ -746,7 +749,7 @@ int bip_set_broadcast_binding(
  * @param ifname [in] The named interface to use for the network layer.
  *        Eg, for Linux, ifname is eth0, ath0, arc0, and others.
  */
-void bip_set_interface(char *ifname)
+void bip_set_interface(const char *ifname)
 {
     struct in_addr local_address;
     struct in_addr netmask;
@@ -804,7 +807,7 @@ void bip_set_interface(char *ifname)
     }
 }
 
-static int createSocket(struct sockaddr_in *sin)
+static int createSocket(const struct sockaddr_in *sin)
 {
     int status = 0; /* return from socket lib calls */
     int sockopt = 0;

--- a/ports/linux/bip6.c
+++ b/ports/linux/bip6.c
@@ -188,7 +188,7 @@ void bip6_get_my_address(BACNET_ADDRESS *addr)
  *
  * @param addr - network IPv6 address
  */
-bool bip6_set_addr(BACNET_IP6_ADDRESS *addr)
+bool bip6_set_addr(const BACNET_IP6_ADDRESS *addr)
 {
     return bvlc6_address_copy(&BIP6_Addr, addr);
 }
@@ -208,7 +208,7 @@ bool bip6_get_addr(BACNET_IP6_ADDRESS *addr)
  *
  * @param addr - network IPv6 address
  */
-bool bip6_set_broadcast_addr(BACNET_IP6_ADDRESS *addr)
+bool bip6_set_broadcast_addr(const BACNET_IP6_ADDRESS *addr)
 {
     return bvlc6_address_copy(&BIP6_Broadcast_Addr, addr);
 }
@@ -234,7 +234,8 @@ bool bip6_get_broadcast_addr(BACNET_IP6_ADDRESS *addr)
  * @return Upon successful completion, returns the number of bytes sent.
  *  Otherwise, -1 shall be returned and errno set to indicate the error.
  */
-int bip6_send_mpdu(BACNET_IP6_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
+int bip6_send_mpdu(
+    const BACNET_IP6_ADDRESS *dest, const uint8_t *mtu, uint16_t mtu_len)
 {
     struct sockaddr_in6 bvlc_dest = { 0 };
     uint16_t addr16[8];
@@ -259,7 +260,7 @@ int bip6_send_mpdu(BACNET_IP6_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
     bvlc_dest.sin6_scope_id = BIP6_Socket_Scope_Id;
     debug_print_ipv6("Sending MPDU->", &bvlc_dest.sin6_addr);
     /* Send the packet */
-    return sendto(BIP6_Socket, (char *)mtu, mtu_len, 0,
+    return sendto(BIP6_Socket, (const char *)mtu, mtu_len, 0,
         (struct sockaddr *)&bvlc_dest, sizeof(bvlc_dest));
 }
 

--- a/ports/linux/dlmstp.c
+++ b/ports/linux/dlmstp.c
@@ -398,16 +398,18 @@ uint16_t MSTP_Get_Send(struct mstp_port_struct_t *mstp_port, unsigned timeout)
  * @param nbytes - number of bytes of data to send
  */
 void MSTP_Send_Frame(
-    struct mstp_port_struct_t *mstp_port, uint8_t *buffer, uint16_t nbytes)
+    struct mstp_port_struct_t *mstp_port,
+    const uint8_t *buffer,
+    uint16_t nbytes)
 {
     RS485_Send_Frame(mstp_port, buffer, nbytes);
 }
 
 static bool dlmstp_compare_data_expecting_reply(
-    uint8_t *request_pdu,
+    const uint8_t *request_pdu,
     uint16_t request_pdu_len,
     uint8_t src_address,
-    uint8_t *reply_pdu,
+    const uint8_t *reply_pdu,
     uint16_t reply_pdu_len,
     uint8_t dest_address)
 {

--- a/ports/linux/dlmstp_linux.c
+++ b/ports/linux/dlmstp_linux.c
@@ -379,16 +379,18 @@ uint16_t MSTP_Get_Send(struct mstp_port_struct_t *mstp_port, unsigned timeout)
  * @param nbytes - number of bytes of data to send
  */
 void MSTP_Send_Frame(
-    struct mstp_port_struct_t *mstp_port, uint8_t *buffer, uint16_t nbytes)
+    struct mstp_port_struct_t *mstp_port,
+    const uint8_t *buffer,
+    uint16_t nbytes)
 {
     RS485_Send_Frame(mstp_port, buffer, nbytes);
 }
 
 static bool dlmstp_compare_data_expecting_reply(
-    uint8_t *request_pdu,
+    const uint8_t *request_pdu,
     uint16_t request_pdu_len,
     uint8_t src_address,
-    uint8_t *reply_pdu,
+    const uint8_t *reply_pdu,
     uint16_t reply_pdu_len,
     uint8_t dest_address)
 {

--- a/ports/linux/ethernet.c
+++ b/ports/linux/ethernet.c
@@ -64,7 +64,7 @@ int setNonblocking(
 #endif
 
 /* opens an 802.2 socket to receive and send packets */
-static int ethernet_bind(struct sockaddr *eth_addr, char *interface_name)
+static int ethernet_bind(struct sockaddr *eth_addr, const char *interface_name)
 {
     int sock_fd = -1; /* return value */
 #if 0
@@ -339,7 +339,7 @@ uint16_t ethernet_receive(BACNET_ADDRESS *src, /* source address */
     return pdu_len;
 }
 
-void ethernet_set_my_address(BACNET_ADDRESS *my_address)
+void ethernet_set_my_address(const BACNET_ADDRESS *my_address)
 {
     int i = 0;
 
@@ -387,7 +387,7 @@ void ethernet_get_broadcast_address(BACNET_ADDRESS *dest)
     return;
 }
 
-void ethernet_debug_address(const char *info, BACNET_ADDRESS *dest)
+void ethernet_debug_address(const char *info, const BACNET_ADDRESS *dest)
 {
     int i = 0; /* counter */
 

--- a/ports/linux/mstpsnap.c
+++ b/ports/linux/mstpsnap.c
@@ -84,7 +84,7 @@ uint16_t MSTP_Get_Send(
  */
 void MSTP_Send_Frame(
     struct mstp_port_struct_t *mstp_port,
-    uint8_t * buffer,
+    const uint8_t * buffer,
     uint16_t nbytes)
 {
     (void)mstp_port;
@@ -141,7 +141,7 @@ static int network_init(const char *name, int protocol)
 }
 
 static void snap_received_packet(
-    struct mstp_port_struct_t *mstp_port, int sockfd)
+    const struct mstp_port_struct_t *mstp_port, int sockfd)
 {
     uint16_t mtu_len = 0; /* number of octets of packet saved in file */
     unsigned i = 0; /* counter */

--- a/ports/linux/rs485.c
+++ b/ports/linux/rs485.c
@@ -355,14 +355,14 @@ bool RS485_Set_Baud_Rate(uint32_t baud)
  *****************************************************************************/
 void RS485_Send_Frame(
     struct mstp_port_struct_t *mstp_port, /* port specific data */
-    uint8_t *buffer, /* frame to send (up to 501 bytes of data) */
+    const uint8_t *buffer, /* frame to send (up to 501 bytes of data) */
     uint16_t nbytes)
 { /* number of bytes of data (up to 501) */
     uint32_t turnaround_time = Tturnaround * 1000;
     uint32_t baud;
     ssize_t written = 0;
     int greska;
-    SHARED_MSTP_DATA *poSharedData = NULL;
+    const SHARED_MSTP_DATA *poSharedData = NULL;
 
     if (mstp_port) {
         poSharedData = (SHARED_MSTP_DATA *)mstp_port->UserData;

--- a/ports/linux/rs485.h
+++ b/ports/linux/rs485.h
@@ -29,7 +29,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     void RS485_Send_Frame(
         struct mstp_port_struct_t *mstp_port,  /* port specific data */
-        uint8_t * buffer,       /* frame to send (up to 501 bytes of data) */
+        const uint8_t * buffer, /* frame to send (up to 501 bytes of data) */
         uint16_t nbytes);       /* number of bytes of data (up to 501) */
 
     BACNET_STACK_EXPORT

--- a/ports/lwip/bip.c
+++ b/ports/lwip/bip.c
@@ -67,7 +67,7 @@ uint32_t bip_stats_drop(void)
  * @param addr - network IPv4 address
  * @return true if the address is set
  */
-bool bip_set_addr(BACNET_IP_ADDRESS *addr)
+bool bip_set_addr(const BACNET_IP_ADDRESS *addr)
 {
     return bvlc_address_copy(&BIP_Address, addr);
 }
@@ -87,7 +87,7 @@ bool bip_get_addr(BACNET_IP_ADDRESS *addr)
  * @param network IPv4 broadcast address
  * @return true if the broadcast address is retrieved
  */
-bool bip_set_broadcast_addr(BACNET_IP_ADDRESS *addr)
+bool bip_set_broadcast_addr(const BACNET_IP_ADDRESS *addr)
 {
     return bvlc_address_copy(&BIP_Broadcast_Address, addr);
 }
@@ -137,7 +137,7 @@ uint16_t bip_get_port(void)
  * @param address - IPv4 address from LwIP
  * @param mac - IP address from BACnet/IP
  */
-static void bip_mac_to_addr(ip4_addr_t *address, uint8_t *mac)
+static void bip_mac_to_addr(ip4_addr_t *address, const uint8_t *mac)
 {
     if (mac && address) {
         address->addr = ((u32_t)((((uint32_t)mac[0]) << 24) & 0xff000000));
@@ -153,7 +153,7 @@ static void bip_mac_to_addr(ip4_addr_t *address, uint8_t *mac)
  * @param address - IPv4 address from LwIP
  * @param port - IPv4 UDP port number
  */
-static int bip_decode_bip_address(BACNET_IP_ADDRESS *baddr,
+static int bip_decode_bip_address(const BACNET_IP_ADDRESS *baddr,
     ip_addr_t *address,
     uint16_t *port)
 {
@@ -215,7 +215,7 @@ static int bip_encode_bip_address(BACNET_IP_ADDRESS *baddr,
  * @return number of bytes sent, or 0 on failure.
  */
 int bip_send_mpdu(
-    BACNET_IP_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
+    const BACNET_IP_ADDRESS *dest, const uint8_t *mtu, uint16_t mtu_len)
 {
     struct pbuf *pkt = NULL;
     /* addr and port in host format */

--- a/ports/pic18f6720/mstp.c
+++ b/ports/pic18f6720/mstp.c
@@ -118,7 +118,7 @@
             x++;                     \
     }
 
-bool MSTP_Line_Active(volatile struct mstp_port_struct_t *mstp_port)
+bool MSTP_Line_Active(const volatile struct mstp_port_struct_t *mstp_port)
 {
     return (mstp_port->EventCount > Nmin_octets);
 }
@@ -128,7 +128,7 @@ unsigned MSTP_Create_Frame(uint8_t *buffer, /* where frame is loaded */
     uint8_t frame_type, /* type of frame to send - see defines */
     uint8_t destination, /* destination address */
     uint8_t source, /* source address */
-    uint8_t *data, /* any data to be sent - may be null */
+    const uint8_t *data, /* any data to be sent - may be null */
     unsigned data_len)
 { /* number of bytes of data (up to 501) */
     uint8_t crc8 = 0xFF; /* used to calculate the crc value */
@@ -181,7 +181,7 @@ void MSTP_Create_And_Send_Frame(
     uint8_t frame_type, /* type of frame to send - see defines */
     uint8_t destination, /* destination address */
     uint8_t source, /* source address */
-    uint8_t *data, /* any data to be sent - may be null */
+    const uint8_t *data, /* any data to be sent - may be null */
     unsigned data_len)
 { /* number of bytes of data (up to 501) */
     uint8_t buffer[DLMSTP_MPDU_MAX] = { 0 }; /* buffer for sending */

--- a/ports/pic18f6720/mstp.h
+++ b/ports/pic18f6720/mstp.h
@@ -142,7 +142,7 @@ extern "C" {
 
     /* returns true if line is active */
     bool MSTP_Line_Active(
-        volatile struct mstp_port_struct_t *mstp_port);
+        const volatile struct mstp_port_struct_t *mstp_port);
 
     unsigned MSTP_Create_Frame(
         uint8_t * buffer,       /* where frame is loaded */
@@ -150,7 +150,7 @@ extern "C" {
         uint8_t frame_type,     /* type of frame to send - see defines */
         uint8_t destination,    /* destination address */
         uint8_t source, /* source address */
-        uint8_t * data, /* any data to be sent - may be null */
+        const uint8_t * data, /* any data to be sent - may be null */
         unsigned data_len);     /* number of bytes of data (up to 501) */
 
 

--- a/ports/pic18f6720/rs485.c
+++ b/ports/pic18f6720/rs485.c
@@ -42,7 +42,7 @@ volatile uint8_t RS485_Tx_Buffer[NEXT_POWER_OF_2(DLMSTP_MPDU_MAX)];
  *****************************************************************************/
 void RS485_Send_Frame(
     volatile struct mstp_port_struct_t *mstp_port, /* port specific data */
-    uint8_t *buffer, /* frame to send (up to 501 bytes of data) */
+    const uint8_t *buffer, /* frame to send (up to 501 bytes of data) */
     uint16_t nbytes)
 { /* number of bytes of data (up to 501) */
     uint16_t i = 0; /* loop counter */

--- a/ports/pic18f6720/rs485.h
+++ b/ports/pic18f6720/rs485.h
@@ -28,7 +28,7 @@ extern "C" {
 
     void RS485_Send_Frame(
         volatile struct mstp_port_struct_t *mstp_port,  /* port specific data */
-        uint8_t * buffer,       /* frame to send (up to 501 bytes of data) */
+        const uint8_t * buffer, /* frame to send (up to 501 bytes of data) */
         uint16_t nbytes);       /* number of bytes of data (up to 501) */
 
     /* returns true if there is more data waiting */

--- a/ports/pic18f97j60/mstp.c
+++ b/ports/pic18f97j60/mstp.c
@@ -118,17 +118,17 @@
             x++;                     \
     }
 
-bool MSTP_Line_Active(volatile struct mstp_port_struct_t *mstp_port)
+bool MSTP_Line_Active(const volatile struct mstp_port_struct_t *mstp_port)
 {
     return (mstp_port->EventCount > Nmin_octets);
 }
 
 unsigned MSTP_Create_Frame(uint8_t *buffer, /* where frame is loaded */
     unsigned buffer_len, /* amount of space available */
-    uint8_t frame_type, /* type of frame to send - see defines */
+    uint8_t frame_type,  /* type of frame to send - see defines */
     uint8_t destination, /* destination address */
-    uint8_t source, /* source address */
-    uint8_t *data, /* any data to be sent - may be null */
+    uint8_t source,      /* source address */
+    const uint8_t *data, /* any data to be sent - may be null */
     unsigned data_len)
 { /* number of bytes of data (up to 501) */
     uint8_t crc8 = 0xFF; /* used to calculate the crc value */
@@ -181,7 +181,7 @@ void MSTP_Create_And_Send_Frame(
     uint8_t frame_type, /* type of frame to send - see defines */
     uint8_t destination, /* destination address */
     uint8_t source, /* source address */
-    uint8_t *data, /* any data to be sent - may be null */
+    const uint8_t *data, /* any data to be sent - may be null */
     unsigned data_len)
 { /* number of bytes of data (up to 501) */
     uint8_t buffer[DLMSTP_MPDU_MAX] = { 0 }; /* buffer for sending */

--- a/ports/pic18f97j60/mstp.h
+++ b/ports/pic18f97j60/mstp.h
@@ -142,15 +142,15 @@ extern "C" {
 
     /* returns true if line is active */
     bool MSTP_Line_Active(
-        volatile struct mstp_port_struct_t *mstp_port);
+        const volatile struct mstp_port_struct_t *mstp_port);
 
     unsigned MSTP_Create_Frame(
         uint8_t * buffer,       /* where frame is loaded */
         unsigned buffer_len,    /* amount of space available */
         uint8_t frame_type,     /* type of frame to send - see defines */
         uint8_t destination,    /* destination address */
-        uint8_t source, /* source address */
-        uint8_t * data, /* any data to be sent - may be null */
+        uint8_t source,         /* source address */
+        const uint8_t * data,   /* any data to be sent - may be null */
         unsigned data_len);     /* number of bytes of data (up to 501) */
 
 

--- a/ports/pic18f97j60/rs485.c
+++ b/ports/pic18f97j60/rs485.c
@@ -42,7 +42,7 @@ volatile uint8_t RS485_Tx_Buffer[NEXT_POWER_OF_2(DLMSTP_MPDU_MAX)];
  *****************************************************************************/
 void RS485_Send_Frame(
     volatile struct mstp_port_struct_t *mstp_port, /* port specific data */
-    uint8_t *buffer, /* frame to send (up to 501 bytes of data) */
+    const uint8_t *buffer, /* frame to send (up to 501 bytes of data) */
     uint16_t nbytes)
 { /* number of bytes of data (up to 501) */
     uint16_t i = 0; /* loop counter */

--- a/ports/pic18f97j60/rs485.h
+++ b/ports/pic18f97j60/rs485.h
@@ -28,8 +28,8 @@ extern "C" {
 
     void RS485_Send_Frame(
         volatile struct mstp_port_struct_t *mstp_port,  /* port specific data */
-        uint8_t * buffer,       /* frame to send (up to 501 bytes of data) */
-        uint16_t nbytes);       /* number of bytes of data (up to 501) */
+        const uint8_t * buffer,     /* frame to send (up to 501 bytes of data) */
+        uint16_t nbytes);           /* number of bytes of data (up to 501) */
 
     /* returns true if there is more data waiting */
     bool RS485_Check_UART_Data(

--- a/ports/rx62n/device.c
+++ b/ports/rx62n/device.c
@@ -107,11 +107,12 @@ static struct my_object_functions *Device_Objects_Find_Functions(
 }
 
 static int Read_Property_Common(
-    struct my_object_functions *pObject, BACNET_READ_PROPERTY_DATA *rpdata)
+    const struct my_object_functions *pObject,
+    BACNET_READ_PROPERTY_DATA *rpdata)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     BACNET_CHARACTER_STRING char_string;
-    char *pString = "";
+    const char *pString = "";
     uint8_t *apdu = NULL;
 #if (BACNET_PROTOCOL_REVISION >= 14)
     struct special_property_list_t property_list;

--- a/ports/rx62n/ethernet.c
+++ b/ports/rx62n/ethernet.c
@@ -174,7 +174,7 @@ uint16_t ethernet_receive(BACNET_ADDRESS *src, /* source address */
     return pdu_len;
 }
 
-void ethernet_set_my_address(BACNET_ADDRESS *my_address)
+void ethernet_set_my_address(const BACNET_ADDRESS *my_address)
 {
     int i = 0;
 

--- a/ports/stm32f10x/device.c
+++ b/ports/stm32f10x/device.c
@@ -103,7 +103,8 @@ static struct my_object_functions *Device_Objects_Find_Functions(
 }
 
 static int Read_Property_Common(
-    struct my_object_functions *pObject, BACNET_READ_PROPERTY_DATA *rpdata)
+    const struct my_object_functions *pObject,
+    BACNET_READ_PROPERTY_DATA *rpdata)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     BACNET_CHARACTER_STRING char_string;
@@ -308,7 +309,7 @@ bool Device_Object_Name(
     return status;
 }
 
-bool Device_Set_Object_Name(BACNET_CHARACTER_STRING *object_name)
+bool Device_Set_Object_Name(const BACNET_CHARACTER_STRING *object_name)
 {
     bool status = false; /*return value */
 
@@ -588,7 +589,7 @@ int Device_Object_List_Element_Encode(
     return apdu_len;
 }
 
-bool Device_Valid_Object_Name(BACNET_CHARACTER_STRING *object_name1,
+bool Device_Valid_Object_Name(const BACNET_CHARACTER_STRING *object_name1,
     BACNET_OBJECT_TYPE *object_type,
     uint32_t *object_instance)
 {

--- a/ports/stm32f10x/netport.c
+++ b/ports/stm32f10x/netport.c
@@ -294,7 +294,7 @@ bool Network_Port_MAC_Address(
  * @return  true if object-name was set
  */
 bool Network_Port_MAC_Address_Set(
-    uint32_t object_instance, uint8_t *mac_src, uint8_t mac_len)
+    uint32_t object_instance, const uint8_t *mac_src, uint8_t mac_len)
 {
     if (mac_len == 1) {
         Object_List[0].MAC_Address[0] = mac_src[0];

--- a/ports/stm32f10x/rs485.c
+++ b/ports/stm32f10x/rs485.c
@@ -152,7 +152,7 @@ bool rs485_frame_sent(void)
  * @param nbytes - number of bytes to transmit
  * @return true if added to queue
  */
-void rs485_bytes_send(uint8_t *buffer, /* data to send */
+void rs485_bytes_send(const uint8_t *buffer, /* data to send */
     uint16_t nbytes)
 { /* number of bytes of data */
     uint8_t tx_byte;

--- a/ports/stm32f10x/rs485.h
+++ b/ports/stm32f10x/rs485.h
@@ -30,7 +30,7 @@ extern "C" {
     bool rs485_receive_error(
         void);
     void rs485_bytes_send(
-        uint8_t * buffer,
+        const uint8_t * buffer,
         uint16_t nbytes);
 
     uint32_t rs485_baud_rate(

--- a/ports/stm32f4xx/device.c
+++ b/ports/stm32f4xx/device.c
@@ -345,7 +345,7 @@ bool Device_Object_Name(
     return status;
 }
 
-bool Device_Set_Object_Name(BACNET_CHARACTER_STRING *object_name)
+bool Device_Set_Object_Name(const BACNET_CHARACTER_STRING *object_name)
 {
     bool status = false; /*return value */
 
@@ -478,7 +478,7 @@ void Device_UUID_Init(void)
  * @param new_uuid [in] The new UUID to set
  * @param length [in] The length of the new UUID
  */
-void Device_UUID_Set(uint8_t *new_uuid, size_t length)
+void Device_UUID_Set(const uint8_t *new_uuid, size_t length)
 {
     if (new_uuid && (length == sizeof(Device_UUID))) {
         memcpy(Device_UUID, new_uuid, sizeof(Device_UUID));
@@ -603,7 +603,7 @@ int Device_Object_List_Element_Encode(
  * Object.
  * @return True on success or else False if not found.
  */
-bool Device_Valid_Object_Name(BACNET_CHARACTER_STRING *object_name1,
+bool Device_Valid_Object_Name(const BACNET_CHARACTER_STRING *object_name1,
     BACNET_OBJECT_TYPE *object_type,
     uint32_t *object_instance)
 {
@@ -842,7 +842,8 @@ int Device_Read_Property_Local(BACNET_READ_PROPERTY_DATA *rpdata)
  * @return The length of the APDU on success, else BACNET_STATUS_ERROR
  */
 static int Read_Property_Common(
-    struct my_object_functions *pObject, BACNET_READ_PROPERTY_DATA *rpdata)
+    const struct my_object_functions *pObject,
+    BACNET_READ_PROPERTY_DATA *rpdata)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     BACNET_CHARACTER_STRING char_string;

--- a/ports/stm32f4xx/netport.c
+++ b/ports/stm32f4xx/netport.c
@@ -299,7 +299,7 @@ bool Network_Port_MAC_Address(
  * @return  true if object-name was set
  */
 bool Network_Port_MAC_Address_Set(
-    uint32_t object_instance, uint8_t *mac_src, uint8_t mac_len)
+    uint32_t object_instance, const uint8_t *mac_src, uint8_t mac_len)
 {
     if (mac_len == 1) {
         Object_List[0].MAC_Address[0] = mac_src[0];

--- a/ports/stm32f4xx/rs485.c
+++ b/ports/stm32f4xx/rs485.c
@@ -209,7 +209,7 @@ bool rs485_byte_available(uint8_t *data_register)
  * @param nbytes - number of bytes to transmit
  * @return true if added to queue
  */
-void rs485_bytes_send(uint8_t *buffer, uint16_t nbytes)
+void rs485_bytes_send(const uint8_t *buffer, uint16_t nbytes)
 {
     if (buffer && (nbytes > 0)) {
         if (FIFO_Add(&Transmit_Queue, buffer, nbytes)) {

--- a/ports/stm32f4xx/rs485.h
+++ b/ports/stm32f4xx/rs485.h
@@ -20,7 +20,7 @@ bool rs485_rts_enabled(void);
 bool rs485_byte_available(uint8_t *data_register);
 bool rs485_receive_error(void);
 
-void rs485_bytes_send(uint8_t *buffer, uint16_t nbytes);
+void rs485_bytes_send(const uint8_t *buffer, uint16_t nbytes);
 
 uint32_t rs485_baud_rate(void);
 bool rs485_baud_rate_set(uint32_t baud);

--- a/ports/win32/bip-init.c
+++ b/ports/win32/bip-init.c
@@ -317,7 +317,7 @@ void bip_get_broadcast_address(BACNET_ADDRESS *dest)
  *
  * @param addr - network IPv4 address
  */
-bool bip_set_addr(BACNET_IP_ADDRESS *addr)
+bool bip_set_addr(const BACNET_IP_ADDRESS *addr)
 {
     (void)addr;
     /* not something we do here within this application */
@@ -344,7 +344,7 @@ bool bip_get_addr(BACNET_IP_ADDRESS *addr)
  * @param addr - network IPv4 address
  * @return true if the address was set
  */
-bool bip_set_broadcast_addr(BACNET_IP_ADDRESS *addr)
+bool bip_set_broadcast_addr(const BACNET_IP_ADDRESS *addr)
 {
     (void)addr;
     /* not something we do within this application */
@@ -412,7 +412,8 @@ uint8_t bip_get_subnet_prefix(void)
  * @return Upon successful completion, returns the number of bytes sent.
  *  Otherwise, -1 shall be returned and errno set to indicate the error.
  */
-int bip_send_mpdu(BACNET_IP_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
+int bip_send_mpdu(
+    const BACNET_IP_ADDRESS *dest, const uint8_t *mtu, uint16_t mtu_len)
 {
     struct sockaddr_in bip_dest = { 0 };
     int rv = 0;
@@ -432,7 +433,7 @@ int bip_send_mpdu(BACNET_IP_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
     /* Send the packet */
     debug_print_ipv4(
         "Sending MPDU->", &bip_dest.sin_addr, bip_dest.sin_port, mtu_len);
-    rv = sendto(BIP_Socket, (char *)mtu, mtu_len, 0,
+    rv = sendto(BIP_Socket, (const char *)mtu, mtu_len, 0,
         (struct sockaddr *)&bip_dest, sizeof(struct sockaddr));
     if (rv == SOCKET_ERROR) {
         print_last_error("sendto");
@@ -737,7 +738,7 @@ static void set_broadcast_address(uint32_t net_address)
  * @param ifname [in] The named interface to use for the network layer.
  *        Eg, for Windows, ifname is the dotted ip address of the interface
  */
-void bip_set_interface(char *ifname)
+void bip_set_interface(const char *ifname)
 {
     /* setup local address */
     if (BIP_Address.s_addr == 0) {
@@ -754,7 +755,7 @@ void bip_set_interface(char *ifname)
     }
 }
 
-static SOCKET createSocket(struct sockaddr_in *sin)
+static SOCKET createSocket(const struct sockaddr_in *sin)
 {
     int rv = 0; /* return from socket lib calls */
     int value = 1;

--- a/ports/win32/bip6.c
+++ b/ports/win32/bip6.c
@@ -290,7 +290,7 @@ void bip6_get_my_address(BACNET_ADDRESS *addr)
  *
  * @param addr - network IPv6 address
  */
-bool bip6_set_addr(BACNET_IP6_ADDRESS *addr)
+bool bip6_set_addr(const BACNET_IP6_ADDRESS *addr)
 {
     return bvlc6_address_copy(&BIP6_Addr, addr);
 }
@@ -312,7 +312,7 @@ bool bip6_get_addr(BACNET_IP6_ADDRESS *addr)
  *
  * @return true if the BACnet/IPv6 address matches our own address
  */
-bool bip6_address_match_self(BACNET_IP6_ADDRESS *addr)
+bool bip6_address_match_self(const BACNET_IP6_ADDRESS *addr)
 {
     return !bvlc6_address_different(addr, &BIP6_Addr);
 }
@@ -322,7 +322,7 @@ bool bip6_address_match_self(BACNET_IP6_ADDRESS *addr)
  *
  * @param addr - network IPv6 address
  */
-bool bip6_set_broadcast_addr(BACNET_IP6_ADDRESS *addr)
+bool bip6_set_broadcast_addr(const BACNET_IP6_ADDRESS *addr)
 {
     return bvlc6_address_copy(&BIP6_Broadcast_Addr, addr);
 }
@@ -348,7 +348,7 @@ bool bip6_get_broadcast_addr(BACNET_IP6_ADDRESS *addr)
  * @return Upon successful completion, returns the number of bytes sent.
  *  Otherwise, -1 shall be returned and errno set to indicate the error.
  */
-int bip6_send_mpdu(BACNET_IP6_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
+int bip6_send_mpdu(const BACNET_IP6_ADDRESS *dest, const uint8_t *mtu, uint16_t mtu_len)
 {
     struct sockaddr_in6 bvlc_dest = { 0 };
     uint16_t addr16[8];
@@ -375,8 +375,8 @@ int bip6_send_mpdu(BACNET_IP6_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
     debug_print_ipv6("Sending MPDU->", &bvlc_dest.sin6_addr);
     /* Send the packet */
     return sendto(
-        BIP6_Socket, (char *)mtu, mtu_len, 0, (struct sockaddr *)&bvlc_dest,
-        sizeof(bvlc_dest));
+        BIP6_Socket, (const char *)mtu, mtu_len, 0,
+        (const struct sockaddr *)&bvlc_dest, sizeof(bvlc_dest));
 }
 
 /**
@@ -392,9 +392,9 @@ int bip6_send_mpdu(BACNET_IP6_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
  *  Otherwise, -1 shall be returned and errno set to indicate the error.
  */
 int bip6_send_pdu(
-    BACNET_ADDRESS *dest,
-    BACNET_NPDU_DATA *npdu_data,
-    uint8_t *pdu,
+    const BACNET_ADDRESS *dest,
+    const BACNET_NPDU_DATA *npdu_data,
+    const uint8_t *pdu,
     unsigned pdu_len)
 {
     return bvlc6_send_pdu(dest, npdu_data, pdu, pdu_len);

--- a/ports/win32/datetime-init.c
+++ b/ports/win32/datetime-init.c
@@ -101,8 +101,7 @@ int gettimeofday(struct timeval *tp, void *tzp)
  * @param utc - True for UTC sync, False for Local time
  * @return True if time is set
  */
-void datetime_timesync(
-    BACNET_DATE *bdate, BACNET_TIME *btime, bool utc)
+void datetime_timesync(BACNET_DATE *bdate, BACNET_TIME *btime, bool utc)
 {
     (void)bdate;
     (void)btime;

--- a/ports/win32/dlmstp-mm.c
+++ b/ports/win32/dlmstp-mm.c
@@ -291,18 +291,18 @@ uint16_t MSTP_Get_Send(
  */
 void MSTP_Send_Frame(
     struct mstp_port_struct_t *mstp_port,
-    uint8_t * buffer,
+    const uint8_t * buffer,
     uint16_t nbytes)
 {
     RS485_Send_Frame(mstp_port, buffer, nbytes);
 }
 
-bool dlmstp_compare_data_expecting_reply(uint8_t *request_pdu,
+bool dlmstp_compare_data_expecting_reply(const uint8_t *request_pdu,
     uint16_t request_pdu_len,
     uint8_t src_address,
-    uint8_t *reply_pdu,
+    const uint8_t *reply_pdu,
     uint16_t reply_pdu_len,
-    BACNET_ADDRESS *dest_address)
+    const BACNET_ADDRESS *dest_address)
 {
     uint16_t offset;
     /* One way to check the message is to compare NPDU

--- a/ports/win32/dlmstp.c
+++ b/ports/win32/dlmstp.c
@@ -277,18 +277,18 @@ uint16_t MSTP_Get_Send(
  */
 void MSTP_Send_Frame(
     struct mstp_port_struct_t *mstp_port,
-    uint8_t * buffer,
+    const uint8_t * buffer,
     uint16_t nbytes)
 {
     RS485_Send_Frame(mstp_port, buffer, nbytes);
 }
 
-static bool dlmstp_compare_data_expecting_reply(uint8_t *request_pdu,
+static bool dlmstp_compare_data_expecting_reply(const uint8_t *request_pdu,
     uint16_t request_pdu_len,
     uint8_t src_address,
-    uint8_t *reply_pdu,
+    const uint8_t *reply_pdu,
     uint16_t reply_pdu_len,
-    BACNET_ADDRESS *dest_address)
+    const BACNET_ADDRESS *dest_address)
 {
     uint16_t offset;
     /* One way to check the message is to compare NPDU

--- a/ports/win32/ethernet.c
+++ b/ports/win32/ethernet.c
@@ -352,7 +352,7 @@ uint16_t ethernet_receive(
     return pdu_len;
 }
 
-void ethernet_set_my_address(BACNET_ADDRESS *my_address)
+void ethernet_set_my_address(const BACNET_ADDRESS *my_address)
 {
     int i = 0;
 
@@ -400,7 +400,7 @@ void ethernet_get_broadcast_address(BACNET_ADDRESS *dest)
     return;
 }
 
-void ethernet_debug_address(const char *info, BACNET_ADDRESS *dest)
+void ethernet_debug_address(const char *info, const BACNET_ADDRESS *dest)
 {
     int i = 0; /* counter */
     char msg[200];

--- a/ports/win32/rs485.c
+++ b/ports/win32/rs485.c
@@ -397,7 +397,7 @@ bool RS485_Set_Baud_Rate(uint32_t baud)
 /* Transmits a Frame on the wire */
 void RS485_Send_Frame(
     struct mstp_port_struct_t *mstp_port, /* port specific data */
-    uint8_t *buffer, /* frame to send (up to 501 bytes of data) */
+    const uint8_t *buffer,  /* frame to send (up to 501 bytes of data) */
     uint16_t nbytes)
 { /* number of bytes of data (up to 501) */
     DWORD dwWritten = 0;

--- a/ports/win32/rs485.h
+++ b/ports/win32/rs485.h
@@ -30,8 +30,8 @@ extern "C" {
     BACNET_STACK_EXPORT
     void RS485_Send_Frame(
         struct mstp_port_struct_t *mstp_port,  /* port specific data */
-        uint8_t * buffer,       /* frame to send (up to 501 bytes of data) */
-        uint16_t nbytes);       /* number of bytes of data (up to 501) */
+        const uint8_t * buffer,     /* frame to send (up to 501 bytes of data) */
+        uint16_t nbytes);           /* number of bytes of data (up to 501) */
 
     BACNET_STACK_EXPORT
     void RS485_Check_UART_Data(

--- a/ports/xplained/bname.c
+++ b/ports/xplained/bname.c
@@ -21,7 +21,7 @@
  * RETURN: true if valid
  * NOTES: none
  **************************************************************************/
-static bool bacnet_name_isvalid(uint8_t encoding, uint8_t length, char *str)
+static bool bacnet_name_isvalid(uint8_t encoding, uint8_t length, const char *str)
 {
     bool valid = false;
 
@@ -82,7 +82,7 @@ int bacnet_name_copy(uint16_t offset, uint8_t *dest, uint8_t dest_len)
 uint8_t bacnet_name_encode(uint8_t *buffer,
     uint8_t buffer_len,
     uint8_t encoding,
-    char *str,
+    const char *str,
     uint8_t str_len)
 {
     unsigned len = 0;
@@ -110,7 +110,7 @@ uint8_t bacnet_name_encode(uint8_t *buffer,
  * NOTES: none
  **************************************************************************/
 bool bacnet_name_save(
-    uint16_t offset, uint8_t encoding, char *str, uint8_t str_len)
+    uint16_t offset, uint8_t encoding, const char *str, uint8_t str_len)
 {
     uint8_t buffer[NVM_NAME_SIZE] = { 0 };
     uint8_t length = 0;
@@ -127,11 +127,11 @@ bool bacnet_name_save(
     return false;
 }
 
-bool bacnet_name_set(uint16_t offset, BACNET_CHARACTER_STRING *char_string)
+bool bacnet_name_set(uint16_t offset, const BACNET_CHARACTER_STRING *char_string)
 {
     uint8_t encoding = 0;
     uint8_t length = 0;
-    char *str = NULL;
+    const char *str = NULL;
 
     length = characterstring_length(char_string);
     encoding = characterstring_encoding(char_string);
@@ -142,7 +142,7 @@ bool bacnet_name_set(uint16_t offset, BACNET_CHARACTER_STRING *char_string)
 bool bacnet_name_write_unique(uint16_t offset,
     int object_type,
     uint32_t object_instance,
-    BACNET_CHARACTER_STRING *char_string,
+    const BACNET_CHARACTER_STRING *char_string,
     BACNET_ERROR_CLASS *error_class,
     BACNET_ERROR_CODE *error_code)
 {
@@ -192,7 +192,7 @@ bool bacnet_name_write_unique(uint16_t offset,
 
 /* no required minumum length or duplicate checking */
 bool bacnet_name_write(uint16_t offset,
-    BACNET_CHARACTER_STRING *char_string,
+    const BACNET_CHARACTER_STRING *char_string,
     BACNET_ERROR_CLASS *error_class,
     BACNET_ERROR_CODE *error_code)
 {
@@ -221,14 +221,16 @@ bool bacnet_name_write(uint16_t offset,
     return status;
 }
 
-void bacnet_name_init(uint16_t offset, char *default_string)
+void bacnet_name_init(uint16_t offset, const char *default_string)
 {
     (void)bacnet_name_save(
         offset, CHARACTER_UTF8, default_string, strlen(default_string));
 }
 
 void bacnet_name(
-    uint16_t offset, BACNET_CHARACTER_STRING *char_string, char *default_string)
+    uint16_t offset,
+    BACNET_CHARACTER_STRING *char_string,
+    const char *default_string)
 {
     uint8_t encoding = 0;
     uint8_t length = 0;

--- a/ports/xplained/bname.h
+++ b/ports/xplained/bname.h
@@ -21,36 +21,36 @@ extern "C" {
         uint8_t dest_len);
     bool bacnet_name_set(
         uint16_t eeprom_offset,
-        BACNET_CHARACTER_STRING * char_string);
+        const BACNET_CHARACTER_STRING * char_string);
     void bacnet_name_init(
         uint16_t eeprom_offset,
-        char *default_string);
+        const char *default_string);
     uint8_t bacnet_name_encode(
         uint8_t *buffer,
         uint8_t buffer_len,
         uint8_t encoding,
-        char *str,
+        const char *str,
         uint8_t str_len);
     bool bacnet_name_save(
         uint16_t offset,
         uint8_t encoding,
-        char *str,
+        const char *str,
         uint8_t str_len);
     void bacnet_name(
         uint16_t eeprom_offset,
         BACNET_CHARACTER_STRING * char_string,
-        char *default_string);
+        const char *default_string);
     bool bacnet_name_write_unique(
         uint16_t offset,
         int object_type,
         uint32_t object_instance,
-        BACNET_CHARACTER_STRING * char_string,
+        const BACNET_CHARACTER_STRING * char_string,
         BACNET_ERROR_CLASS * error_class,
         BACNET_ERROR_CODE * error_code);
     /* no required minumum length or duplicate checking */
     bool bacnet_name_write(
         uint16_t offset,
-        BACNET_CHARACTER_STRING * char_string,
+        const BACNET_CHARACTER_STRING * char_string,
         BACNET_ERROR_CLASS * error_class,
         BACNET_ERROR_CODE * error_code);
 

--- a/ports/xplained/device.c
+++ b/ports/xplained/device.c
@@ -526,7 +526,7 @@ int Device_Object_List_Element_Encode(
     return apdu_len;
 }
 
-bool Device_Valid_Object_Name(BACNET_CHARACTER_STRING *object_name1,
+bool Device_Valid_Object_Name(const BACNET_CHARACTER_STRING *object_name1,
     BACNET_OBJECT_TYPE *object_type,
     uint32_t *object_instance)
 {

--- a/ports/xplained/netport.c
+++ b/ports/xplained/netport.c
@@ -288,7 +288,7 @@ bool Network_Port_MAC_Address(
  * @return  true if object-name was set
  */
 bool Network_Port_MAC_Address_Set(
-    uint32_t object_instance, uint8_t *mac_src, uint8_t mac_len)
+    uint32_t object_instance, const uint8_t *mac_src, uint8_t mac_len)
 {
     if (mac_len == 1) {
         Object_List[0].MAC_Address[0] = mac_src[0];

--- a/ports/xplained/rs485.c
+++ b/ports/xplained/rs485.c
@@ -147,7 +147,7 @@ bool rs485_receive_error(void)
  * @param buffer - array of one or more bytes to transmit
  * @param nbytes - number of bytes to transmit
  */
-void rs485_bytes_send(uint8_t *buffer, uint16_t nbytes)
+void rs485_bytes_send(const uint8_t *buffer, uint16_t nbytes)
 {
     bool status = false;
     bool start_required = false;

--- a/ports/xplained/rs485.h
+++ b/ports/xplained/rs485.h
@@ -20,7 +20,7 @@ bool rs485_rts_enabled(void);
 bool rs485_byte_available(uint8_t *data_register);
 bool rs485_receive_error(void);
 
-void rs485_bytes_send(uint8_t *buffer, uint16_t nbytes);
+void rs485_bytes_send(const uint8_t *buffer, uint16_t nbytes);
 
 uint32_t rs485_baud_rate(void);
 bool rs485_baud_rate_set(uint32_t baud);

--- a/ports/zephyr/bacnet/datalink/ethernet.h
+++ b/ports/zephyr/bacnet/datalink/ethernet.h
@@ -71,7 +71,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     void bacnet_ethernet_set_my_address(
-        BACNET_ADDRESS * my_address);
+        const BACNET_ADDRESS * my_address);
     BACNET_STACK_EXPORT
     void bacnet_ethernet_get_my_address(
         BACNET_ADDRESS * my_address);

--- a/ports/zephyr/bip-init.c
+++ b/ports/zephyr/bip-init.c
@@ -150,7 +150,7 @@ void bip_get_broadcast_address(BACNET_ADDRESS *dest)
  * @param addr - network IPv4 address
  * @return true if the address was set
  */
-bool bip_set_addr(BACNET_IP_ADDRESS *addr)
+bool bip_set_addr(const BACNET_IP_ADDRESS *addr)
 {
     if (addr) {
         memcpy(&BIP_Address.s_addr, &addr->address[0], IP_ADDRESS_MAX);
@@ -180,7 +180,7 @@ bool bip_get_addr(BACNET_IP_ADDRESS *addr)
  * @param addr - network IPv4 address
  * @return true if the address was set
  */
-bool bip_set_broadcast_addr(BACNET_IP_ADDRESS *addr)
+bool bip_set_broadcast_addr(const BACNET_IP_ADDRESS *addr)
 {
     if (addr) {
         memcpy(&BIP_Broadcast_Addr.s_addr, &addr->address[0], IP_ADDRESS_MAX);
@@ -249,7 +249,8 @@ uint8_t bip_get_subnet_prefix(void)
  * @return Upon successful completion, returns the number of bytes sent.
  *  Otherwise, -1 shall be returned and errno set to indicate the error.
  */
-int bip_send_mpdu(BACNET_IP_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
+int bip_send_mpdu(
+    const BACNET_IP_ADDRESS *dest, const uint8_t *mtu, uint16_t mtu_len)
 {
     struct sockaddr_in bip_dest = { 0 };
 
@@ -267,7 +268,7 @@ int bip_send_mpdu(BACNET_IP_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
     /* Send the packet */
     debug_print_ipv4(
         "Sending MPDU->", &bip_dest.sin_addr, bip_dest.sin_port, mtu_len);
-    return zsock_sendto(BIP_Socket, (char *)mtu, mtu_len, 0,
+    return zsock_sendto(BIP_Socket, (const char *)mtu, mtu_len, 0,
         (struct sockaddr *)&bip_dest, sizeof(struct sockaddr));
 }
 
@@ -404,7 +405,7 @@ int bip_send_pdu(BACNET_ADDRESS *dest,
  * @param ifname [in] The named interface to use for the network layer.
  *        Eg, for Linux, ifname is eth0, ath0, arc0, and others.
  */
-void bip_set_interface(char *ifname)
+void bip_set_interface(const char *ifname)
 {
     struct net_if *iface = 0;
     int index = -1;
@@ -492,7 +493,7 @@ void bip_set_interface(char *ifname)
     }
 }
 
-static int createSocket(struct sockaddr_in *sin)
+static int createSocket(const struct sockaddr_in *sin)
 {
     int sock_fd = -1;
     const int sockopt = 1;

--- a/ports/zephyr/bip6-init.c
+++ b/ports/zephyr/bip6-init.c
@@ -51,7 +51,7 @@ static char ipv6_addr_str[] = "";
  * @param a - IPv6 address
  * @return Pointer to global string
  */
-static char *inet6_ntoa(struct in6_addr *a)
+static char *inet6_ntoa(const struct in6_addr *a)
 {
 #if CONFIG_BACNETSTACK_LOG_LEVEL
     uint8_t x = 0;
@@ -226,7 +226,7 @@ void bip6_get_my_address(BACNET_ADDRESS *addr)
  *
  * @param addr - network IPv6 address
  */
-bool bip6_set_addr(BACNET_IP6_ADDRESS *addr)
+bool bip6_set_addr(const BACNET_IP6_ADDRESS *addr)
 {
     return bvlc6_address_copy(&BIP6_Addr, addr);
 }
@@ -246,7 +246,7 @@ bool bip6_get_addr(BACNET_IP6_ADDRESS *addr)
  *
  * @param addr - network IPv6 address
  */
-bool bip6_set_broadcast_addr(BACNET_IP6_ADDRESS *addr)
+bool bip6_set_broadcast_addr(const BACNET_IP6_ADDRESS *addr)
 {
     return bvlc6_address_copy(&BIP6_Broadcast_Addr, addr);
 }
@@ -272,7 +272,8 @@ bool bip6_get_broadcast_addr(BACNET_IP6_ADDRESS *addr)
  * @return Upon successful completion, returns the number of bytes sent.
  *  Otherwise, -1 shall be returned and errno set to indicate the error.
  */
-int bip6_send_mpdu(BACNET_IP6_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
+int bip6_send_mpdu(
+    const BACNET_IP6_ADDRESS *dest, const uint8_t *mtu, uint16_t mtu_len)
 {
     struct sockaddr_in6 bvlc_dest = { 0 };
     uint16_t addr16[8];
@@ -302,8 +303,8 @@ int bip6_send_mpdu(BACNET_IP6_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
     LOG_DBG("BIP6: Sending MPDU to %s", ipv6_addr_str);
     /* Send the packet */
     return zsock_sendto(
-        BIP6_Socket, (char *)mtu, mtu_len, 0, (struct sockaddr *)&bvlc_dest,
-        sizeof(bvlc_dest));
+        BIP6_Socket, (const char *)mtu, mtu_len, 0,
+        (struct sockaddr *)&bvlc_dest, sizeof(bvlc_dest));
 }
 
 /**
@@ -333,7 +334,8 @@ int bip6_send_pdu(
  * @param n - size of the buffer
  * @param addr - BACnet/IPv6 address
  */
-static int bvlc6_snprintf_addr(char *s, size_t n, BACNET_IP6_ADDRESS *addr)
+static int bvlc6_snprintf_addr(
+    char *s, size_t n, const BACNET_IP6_ADDRESS *addr)
 {
     uint16_t addr16[8];
 

--- a/ports/zephyr/rs485.h
+++ b/ports/zephyr/rs485.h
@@ -32,8 +32,8 @@ extern "C" {
     BACNET_STACK_EXPORT
     void RS485_Send_Frame(
         volatile struct mstp_port_struct_t *mstp_port,  /* port specific data */
-        uint8_t * buffer,       /* frame to send (up to 501 bytes of data) */
-        uint16_t nbytes);       /* number of bytes of data (up to 501) */
+        const uint8_t * buffer,     /* frame to send (up to 501 bytes of data) */
+        uint16_t nbytes);           /* number of bytes of data (up to 501) */
 
     BACNET_STACK_EXPORT
     void RS485_Check_UART_Data(

--- a/src/bacnet/abort.c
+++ b/src/bacnet/abort.c
@@ -214,7 +214,7 @@ int abort_encode_apdu(
  * @return Total length of the apdu, typically 2 on success, zero otherwise.
  */
 int abort_decode_service_request(
-    uint8_t *apdu, unsigned apdu_len, uint8_t *invoke_id, uint8_t *abort_reason)
+    const uint8_t *apdu, unsigned apdu_len, uint8_t *invoke_id, uint8_t *abort_reason)
 {
     int len = 0;
 

--- a/src/bacnet/abort.h
+++ b/src/bacnet/abort.h
@@ -37,7 +37,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     int abort_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         uint8_t * invoke_id,
         uint8_t * abort_reason);

--- a/src/bacnet/access_rule.c
+++ b/src/bacnet/access_rule.c
@@ -10,7 +10,7 @@
 #include "bacnet/access_rule.h"
 #include "bacnet/bacdcode.h"
 
-int bacapp_encode_access_rule(uint8_t *apdu, BACNET_ACCESS_RULE *rule)
+int bacapp_encode_access_rule(uint8_t *apdu, const BACNET_ACCESS_RULE *rule)
 {
     int len;
     int apdu_len = 0;
@@ -49,7 +49,7 @@ int bacapp_encode_access_rule(uint8_t *apdu, BACNET_ACCESS_RULE *rule)
 }
 
 int bacapp_encode_context_access_rule(
-    uint8_t *apdu, uint8_t tag_number, BACNET_ACCESS_RULE *rule)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_ACCESS_RULE *rule)
 {
     int len;
     int apdu_len = 0;
@@ -66,7 +66,7 @@ int bacapp_encode_context_access_rule(
     return apdu_len;
 }
 
-int bacapp_decode_access_rule(uint8_t *apdu, BACNET_ACCESS_RULE *rule)
+int bacapp_decode_access_rule(const uint8_t *apdu, BACNET_ACCESS_RULE *rule)
 {
     int len;
     int apdu_len = 0;
@@ -148,7 +148,7 @@ int bacapp_decode_access_rule(uint8_t *apdu, BACNET_ACCESS_RULE *rule)
 }
 
 int bacapp_decode_context_access_rule(
-    uint8_t *apdu, uint8_t tag_number, BACNET_ACCESS_RULE *rule)
+    const uint8_t *apdu, uint8_t tag_number, BACNET_ACCESS_RULE *rule)
 {
     int len = 0;
     int section_length;

--- a/src/bacnet/access_rule.h
+++ b/src/bacnet/access_rule.h
@@ -44,19 +44,19 @@ extern "C" {
     BACNET_STACK_EXPORT
     int bacapp_encode_access_rule(
         uint8_t * apdu,
-        BACNET_ACCESS_RULE * rule);
+        const BACNET_ACCESS_RULE * rule);
     BACNET_STACK_EXPORT
     int bacapp_encode_context_access_rule(
         uint8_t * apdu,
         uint8_t tag_number,
-        BACNET_ACCESS_RULE * rule);
+        const BACNET_ACCESS_RULE * rule);
     BACNET_STACK_EXPORT
     int bacapp_decode_access_rule(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         BACNET_ACCESS_RULE * rule);
     BACNET_STACK_EXPORT
     int bacapp_decode_context_access_rule(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint8_t tag_number,
         BACNET_ACCESS_RULE * rule);
 

--- a/src/bacnet/alarm_ack.c
+++ b/src/bacnet/alarm_ack.c
@@ -20,7 +20,7 @@
  * @return number of bytes encoded
  */
 int alarm_ack_encode_apdu(
-    uint8_t *apdu, uint8_t invoke_id, BACNET_ALARM_ACK_DATA *data)
+    uint8_t *apdu, uint8_t invoke_id, const BACNET_ALARM_ACK_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -54,7 +54,7 @@ int alarm_ack_encode_apdu(
  * @param data  Pointer to the service data used for encoding values
  * @return number of bytes encoded
  */
-int alarm_ack_encode_service_request(uint8_t *apdu, BACNET_ALARM_ACK_DATA *data)
+int alarm_ack_encode_service_request(uint8_t *apdu, const BACNET_ALARM_ACK_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -104,7 +104,7 @@ int alarm_ack_encode_service_request(uint8_t *apdu, BACNET_ALARM_ACK_DATA *data)
 size_t bacnet_acknowledge_alarm_info_request_encode(
     uint8_t *apdu,
     size_t apdu_size,
-    BACNET_ALARM_ACK_DATA *data)
+    const BACNET_ALARM_ACK_DATA *data)
 {
     size_t apdu_len = 0; /* total length of the apdu, return value */
 
@@ -128,7 +128,7 @@ size_t bacnet_acknowledge_alarm_info_request_encode(
  * @return number of bytes decoded, or BACNET_STATUS_ERROR on error.
  */
 int alarm_ack_decode_service_request(
-    uint8_t *apdu, unsigned apdu_size, BACNET_ALARM_ACK_DATA *data)
+    const uint8_t *apdu, unsigned apdu_size, BACNET_ALARM_ACK_DATA *data)
 {
     int len = 0;
     int apdu_len = 0;

--- a/src/bacnet/alarm_ack.h
+++ b/src/bacnet/alarm_ack.h
@@ -42,22 +42,22 @@ extern "C" {
     int alarm_ack_encode_apdu(
         uint8_t * apdu,
         uint8_t invoke_id,
-        BACNET_ALARM_ACK_DATA * data);
+        const BACNET_ALARM_ACK_DATA * data);
 
     BACNET_STACK_EXPORT
     int alarm_ack_encode_service_request(
         uint8_t * apdu,
-        BACNET_ALARM_ACK_DATA * data);
+        const BACNET_ALARM_ACK_DATA * data);
 
     BACNET_STACK_EXPORT
     size_t bacnet_acknowledge_alarm_info_request_encode(
         uint8_t *apdu,
         size_t apdu_size,
-        BACNET_ALARM_ACK_DATA *data);
+        const BACNET_ALARM_ACK_DATA *data);
 
     BACNET_STACK_EXPORT
     int alarm_ack_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_ALARM_ACK_DATA * data);
 

--- a/src/bacnet/arf.c
+++ b/src/bacnet/arf.c
@@ -33,7 +33,7 @@
  * @param data  Pointer to the service data used for encoding values
  * @return number of bytes encoded
  */
-int arf_service_encode_apdu(uint8_t *apdu, BACNET_ATOMIC_READ_FILE_DATA *data)
+int arf_service_encode_apdu(uint8_t *apdu, const BACNET_ATOMIC_READ_FILE_DATA *data)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
     int len = 0;
@@ -102,7 +102,7 @@ int arf_service_encode_apdu(uint8_t *apdu, BACNET_ATOMIC_READ_FILE_DATA *data)
  * @return number of bytes encoded, or zero if unable to encode or too large
  */
 size_t atomicreadfile_service_request_encode(
-    uint8_t *apdu, size_t apdu_size, BACNET_ATOMIC_READ_FILE_DATA *data)
+    uint8_t *apdu, size_t apdu_size, const BACNET_ATOMIC_READ_FILE_DATA *data)
 {
     size_t apdu_len = 0; /* total length of the apdu, return value */
 
@@ -124,7 +124,7 @@ size_t atomicreadfile_service_request_encode(
  * @return number of bytes encoded
  */
 int arf_encode_apdu(
-    uint8_t *apdu, uint8_t invoke_id, BACNET_ATOMIC_READ_FILE_DATA *data)
+    uint8_t *apdu, uint8_t invoke_id, const BACNET_ATOMIC_READ_FILE_DATA *data)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
     int len = 0;
@@ -171,7 +171,7 @@ int arf_encode_apdu(
  * @return number of bytes decoded or BACNET_STATUS_ERROR on error.
  */
 int arf_decode_service_request(
-    uint8_t *apdu, unsigned apdu_size, BACNET_ATOMIC_READ_FILE_DATA *data)
+    const uint8_t *apdu, unsigned apdu_size, BACNET_ATOMIC_READ_FILE_DATA *data)
 {
     int tag_len = 0;
     int apdu_len = 0;
@@ -269,7 +269,7 @@ int arf_decode_service_request(
  *  or NULL for length
  * @return number of bytes decoded, or BACNET_STATUS_ERROR on error
  */
-int arf_decode_apdu(uint8_t *apdu,
+int arf_decode_apdu(const uint8_t *apdu,
     unsigned apdu_size,
     uint8_t *invoke_id,
     BACNET_ATOMIC_READ_FILE_DATA *data)
@@ -327,7 +327,7 @@ int arf_decode_apdu(uint8_t *apdu,
  * @return number of bytes encoded
  */
 int arf_ack_service_encode_apdu(
-    uint8_t *apdu, BACNET_ATOMIC_READ_FILE_DATA *data)
+    uint8_t *apdu, const BACNET_ATOMIC_READ_FILE_DATA *data)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
     int len = 0;
@@ -403,7 +403,7 @@ int arf_ack_service_encode_apdu(
  * @return number of bytes encoded
  */
 int arf_ack_encode_apdu(
-    uint8_t *apdu, uint8_t invoke_id, BACNET_ATOMIC_READ_FILE_DATA *data)
+    uint8_t *apdu, uint8_t invoke_id, const BACNET_ATOMIC_READ_FILE_DATA *data)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
     int len = 0;
@@ -449,7 +449,7 @@ int arf_ack_encode_apdu(
  * @return Bytes encoded or BACNET_STATUS_ERROR on error.
  */
 int arf_ack_decode_service_request(
-    uint8_t *apdu, unsigned apdu_size, BACNET_ATOMIC_READ_FILE_DATA *data)
+    const uint8_t *apdu, unsigned apdu_size, BACNET_ATOMIC_READ_FILE_DATA *data)
 {
     int apdu_len = 0;
     int len = 0;
@@ -560,7 +560,7 @@ int arf_ack_decode_service_request(
  *  or NULL for length
  * @return number of bytes decoded, or BACNET_STATUS_ERROR on error
  */
-int arf_ack_decode_apdu(uint8_t *apdu,
+int arf_ack_decode_apdu(const uint8_t *apdu,
     unsigned apdu_size,
     uint8_t *invoke_id,
     BACNET_ATOMIC_READ_FILE_DATA *data)

--- a/src/bacnet/arf.h
+++ b/src/bacnet/arf.h
@@ -49,27 +49,27 @@ extern "C" {
     int arf_encode_apdu(
         uint8_t * apdu,
         uint8_t invoke_id,
-        BACNET_ATOMIC_READ_FILE_DATA * data);
+        const BACNET_ATOMIC_READ_FILE_DATA * data);
     BACNET_STACK_EXPORT
     int arf_service_encode_apdu(
         uint8_t *apdu,
-        BACNET_ATOMIC_READ_FILE_DATA *data);
+        const BACNET_ATOMIC_READ_FILE_DATA *data);
     BACNET_STACK_EXPORT
     size_t atomicreadfile_service_request_encode(
         uint8_t *apdu,
         size_t apdu_size,
-        BACNET_ATOMIC_READ_FILE_DATA *data);
+        const BACNET_ATOMIC_READ_FILE_DATA *data);
 
 /* decode the service request only */
     BACNET_STACK_EXPORT
     int arf_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_ATOMIC_READ_FILE_DATA * data);
 
     BACNET_STACK_EXPORT
     int arf_decode_apdu(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         uint8_t * invoke_id,
         BACNET_ATOMIC_READ_FILE_DATA * data);
@@ -81,22 +81,22 @@ extern "C" {
     int arf_ack_encode_apdu(
         uint8_t * apdu,
         uint8_t invoke_id,
-        BACNET_ATOMIC_READ_FILE_DATA * data);
+        const BACNET_ATOMIC_READ_FILE_DATA * data);
     BACNET_STACK_EXPORT
     int arf_ack_service_encode_apdu(
         uint8_t *apdu,
-        BACNET_ATOMIC_READ_FILE_DATA *data);
+        const BACNET_ATOMIC_READ_FILE_DATA *data);
 
 /* decode the service request only */
     BACNET_STACK_EXPORT
     int arf_ack_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_ATOMIC_READ_FILE_DATA * data);
 
     BACNET_STACK_EXPORT
     int arf_ack_decode_apdu(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         uint8_t * invoke_id,
         BACNET_ATOMIC_READ_FILE_DATA * data);

--- a/src/bacnet/assigned_access_rights.c
+++ b/src/bacnet/assigned_access_rights.c
@@ -10,7 +10,7 @@
 #include "bacnet/bacdcode.h"
 
 int bacapp_encode_assigned_access_rights(
-    uint8_t *apdu, BACNET_ASSIGNED_ACCESS_RIGHTS *aar)
+    uint8_t *apdu, const BACNET_ASSIGNED_ACCESS_RIGHTS *aar)
 {
     int len;
     int apdu_len = 0;
@@ -34,7 +34,7 @@ int bacapp_encode_assigned_access_rights(
 }
 
 int bacapp_encode_context_assigned_access_rights(
-    uint8_t *apdu, uint8_t tag, BACNET_ASSIGNED_ACCESS_RIGHTS *aar)
+    uint8_t *apdu, uint8_t tag, const BACNET_ASSIGNED_ACCESS_RIGHTS *aar)
 {
     int len;
     int apdu_len = 0;
@@ -52,7 +52,7 @@ int bacapp_encode_context_assigned_access_rights(
 }
 
 int bacapp_decode_assigned_access_rights(
-    uint8_t *apdu, BACNET_ASSIGNED_ACCESS_RIGHTS *aar)
+    const uint8_t *apdu, BACNET_ASSIGNED_ACCESS_RIGHTS *aar)
 {
     int len;
     int apdu_len = 0;
@@ -84,7 +84,7 @@ int bacapp_decode_assigned_access_rights(
 }
 
 int bacapp_decode_context_assigned_access_rights(
-    uint8_t *apdu, uint8_t tag, BACNET_ASSIGNED_ACCESS_RIGHTS *aar)
+    const uint8_t *apdu, uint8_t tag, BACNET_ASSIGNED_ACCESS_RIGHTS *aar)
 {
     int len = 0;
     int section_length;

--- a/src/bacnet/assigned_access_rights.h
+++ b/src/bacnet/assigned_access_rights.h
@@ -28,19 +28,19 @@ extern "C" {
     BACNET_STACK_EXPORT
     int bacapp_encode_assigned_access_rights(
         uint8_t * apdu,
-        BACNET_ASSIGNED_ACCESS_RIGHTS * aar);
+        const BACNET_ASSIGNED_ACCESS_RIGHTS * aar);
     BACNET_STACK_EXPORT
     int bacapp_encode_context_assigned_access_rights(
         uint8_t * apdu,
         uint8_t tag,
-        BACNET_ASSIGNED_ACCESS_RIGHTS * aar);
+        const BACNET_ASSIGNED_ACCESS_RIGHTS * aar);
     BACNET_STACK_EXPORT
     int bacapp_decode_assigned_access_rights(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         BACNET_ASSIGNED_ACCESS_RIGHTS * aar);
     BACNET_STACK_EXPORT
     int bacapp_decode_context_assigned_access_rights(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint8_t tag,
         BACNET_ASSIGNED_ACCESS_RIGHTS * aar);
 

--- a/src/bacnet/authentication_factor.c
+++ b/src/bacnet/authentication_factor.c
@@ -16,7 +16,7 @@
  * @return number of bytes encoded, or zero if unable to encode
  */
 int bacapp_encode_authentication_factor(
-    uint8_t *apdu, BACNET_AUTHENTICATION_FACTOR *af)
+    uint8_t *apdu, const BACNET_AUTHENTICATION_FACTOR *af)
 {
     int len;
     int apdu_len = 0;
@@ -56,7 +56,7 @@ int bacapp_encode_authentication_factor(
  * @return number of bytes encoded, or zero if unable to encode
  */
 int bacapp_encode_context_authentication_factor(
-    uint8_t *apdu, uint8_t tag, BACNET_AUTHENTICATION_FACTOR *af)
+    uint8_t *apdu, uint8_t tag, const BACNET_AUTHENTICATION_FACTOR *af)
 {
     int len;
     int apdu_len = 0;
@@ -84,7 +84,7 @@ int bacapp_encode_context_authentication_factor(
  * @return Bytes decoded or BACNET_STATUS_REJECT on error.
  */
 int bacapp_decode_authentication_factor(
-    uint8_t *apdu, BACNET_AUTHENTICATION_FACTOR *af)
+    const uint8_t *apdu, BACNET_AUTHENTICATION_FACTOR *af)
 {
     int len;
     int apdu_len = 0;
@@ -140,7 +140,7 @@ int bacapp_decode_authentication_factor(
  * @return Bytes decoded or BACNET_STATUS_REJECT on error.
  */
 int bacapp_decode_context_authentication_factor(
-    uint8_t *apdu, uint8_t tag, BACNET_AUTHENTICATION_FACTOR *af)
+    const uint8_t *apdu, uint8_t tag, BACNET_AUTHENTICATION_FACTOR *af)
 {
     int len = 0;
     int section_length;

--- a/src/bacnet/authentication_factor.h
+++ b/src/bacnet/authentication_factor.h
@@ -28,19 +28,19 @@ extern "C" {
     BACNET_STACK_EXPORT
     int bacapp_encode_authentication_factor(
         uint8_t * apdu,
-        BACNET_AUTHENTICATION_FACTOR * af);
+        const BACNET_AUTHENTICATION_FACTOR * af);
     BACNET_STACK_EXPORT
     int bacapp_encode_context_authentication_factor(
         uint8_t * apdu,
         uint8_t tag,
-        BACNET_AUTHENTICATION_FACTOR * af);
+        const BACNET_AUTHENTICATION_FACTOR * af);
     BACNET_STACK_EXPORT
     int bacapp_decode_authentication_factor(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         BACNET_AUTHENTICATION_FACTOR * af);
     BACNET_STACK_EXPORT
     int bacapp_decode_context_authentication_factor(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint8_t tag,
         BACNET_AUTHENTICATION_FACTOR * af);
 

--- a/src/bacnet/authentication_factor_format.c
+++ b/src/bacnet/authentication_factor_format.c
@@ -10,7 +10,7 @@
 #include "bacnet/authentication_factor_format.h"
 
 int bacapp_encode_authentication_factor_format(
-    uint8_t *apdu, BACNET_AUTHENTICATION_FACTOR_FORMAT *aff)
+    uint8_t *apdu, const BACNET_AUTHENTICATION_FACTOR_FORMAT *aff)
 {
     int len;
     int apdu_len = 0;
@@ -41,7 +41,7 @@ int bacapp_encode_authentication_factor_format(
 }
 
 int bacapp_encode_context_authentication_factor_format(
-    uint8_t *apdu, uint8_t tag, BACNET_AUTHENTICATION_FACTOR_FORMAT *aff)
+    uint8_t *apdu, uint8_t tag, const BACNET_AUTHENTICATION_FACTOR_FORMAT *aff)
 {
     int len;
     int apdu_len = 0;
@@ -59,7 +59,7 @@ int bacapp_encode_context_authentication_factor_format(
 }
 
 int bacapp_decode_authentication_factor_format(
-    uint8_t *apdu, BACNET_AUTHENTICATION_FACTOR_FORMAT *aff)
+    const uint8_t *apdu, BACNET_AUTHENTICATION_FACTOR_FORMAT *aff)
 {
     int len;
     int apdu_len = 0;
@@ -113,7 +113,7 @@ int bacapp_decode_authentication_factor_format(
 }
 
 int bacapp_decode_context_authentication_factor_format(
-    uint8_t *apdu, uint8_t tag, BACNET_AUTHENTICATION_FACTOR_FORMAT *aff)
+    const uint8_t *apdu, uint8_t tag, BACNET_AUTHENTICATION_FACTOR_FORMAT *aff)
 {
     int len = 0;
     int section_length;

--- a/src/bacnet/authentication_factor_format.h
+++ b/src/bacnet/authentication_factor_format.h
@@ -25,19 +25,19 @@ extern "C" {
     BACNET_STACK_EXPORT
     int bacapp_encode_authentication_factor_format(
         uint8_t * apdu,
-        BACNET_AUTHENTICATION_FACTOR_FORMAT * aff);
+        const BACNET_AUTHENTICATION_FACTOR_FORMAT * aff);
     BACNET_STACK_EXPORT
     int bacapp_encode_context_authentication_factor_format(
         uint8_t * apdu,
         uint8_t tag_number,
-        BACNET_AUTHENTICATION_FACTOR_FORMAT * aff);
+        const BACNET_AUTHENTICATION_FACTOR_FORMAT * aff);
     BACNET_STACK_EXPORT
     int bacapp_decode_authentication_factor_format(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         BACNET_AUTHENTICATION_FACTOR_FORMAT * aff);
     BACNET_STACK_EXPORT
     int bacapp_decode_context_authentication_factor_format(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint8_t tag_number,
         BACNET_AUTHENTICATION_FACTOR_FORMAT * aff);
 

--- a/src/bacnet/awf.c
+++ b/src/bacnet/awf.c
@@ -34,7 +34,7 @@
  * @param data  Pointer to the service data used for encoding values
  * @return number of bytes encoded
  */
-int awf_service_encode_apdu(uint8_t *apdu, BACNET_ATOMIC_WRITE_FILE_DATA *data)
+int awf_service_encode_apdu(uint8_t *apdu, const BACNET_ATOMIC_WRITE_FILE_DATA *data)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
     int len = 0;
@@ -110,7 +110,7 @@ int awf_service_encode_apdu(uint8_t *apdu, BACNET_ATOMIC_WRITE_FILE_DATA *data)
  * @return number of bytes encoded, or zero if unable to encode or too large
  */
 int atomicwritefile_service_request_encode(
-    uint8_t *apdu, size_t apdu_size, BACNET_ATOMIC_WRITE_FILE_DATA *data)
+    uint8_t *apdu, size_t apdu_size, const BACNET_ATOMIC_WRITE_FILE_DATA *data)
 {
     size_t apdu_len = 0; /* total length of the apdu, return value */
 
@@ -132,7 +132,7 @@ int atomicwritefile_service_request_encode(
  * @return number of bytes encoded
  */
 int awf_encode_apdu(
-    uint8_t *apdu, uint8_t invoke_id, BACNET_ATOMIC_WRITE_FILE_DATA *data)
+    uint8_t *apdu, uint8_t invoke_id, const BACNET_ATOMIC_WRITE_FILE_DATA *data)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
     int len = 0;
@@ -180,7 +180,7 @@ int awf_encode_apdu(
  * @return number of bytes decoded or BACNET_STATUS_ERROR on error.
  */
 int awf_decode_service_request(
-    uint8_t *apdu, unsigned apdu_size, BACNET_ATOMIC_WRITE_FILE_DATA *data)
+    const uint8_t *apdu, unsigned apdu_size, BACNET_ATOMIC_WRITE_FILE_DATA *data)
 {
     /* return value */
     int apdu_len = 0;
@@ -299,7 +299,7 @@ int awf_decode_service_request(
  *  or NULL for length
  * @return number of bytes decoded, or BACNET_STATUS_ERROR on error
  */
-int awf_decode_apdu(uint8_t *apdu,
+int awf_decode_apdu(const uint8_t *apdu,
     unsigned apdu_size,
     uint8_t *invoke_id,
     BACNET_ATOMIC_WRITE_FILE_DATA *data)
@@ -346,7 +346,7 @@ int awf_decode_apdu(uint8_t *apdu,
  * @return number of bytes encoded
  */
 int awf_ack_service_encode_apdu(
-    uint8_t *apdu, BACNET_ATOMIC_WRITE_FILE_DATA *data)
+    uint8_t *apdu, const BACNET_ATOMIC_WRITE_FILE_DATA *data)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
 
@@ -374,7 +374,7 @@ int awf_ack_service_encode_apdu(
  * @return number of bytes encoded
  */
 int awf_ack_encode_apdu(
-    uint8_t *apdu, uint8_t invoke_id, BACNET_ATOMIC_WRITE_FILE_DATA *data)
+    uint8_t *apdu, uint8_t invoke_id, const BACNET_ATOMIC_WRITE_FILE_DATA *data)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
     int len = 0;
@@ -410,7 +410,7 @@ int awf_ack_encode_apdu(
  * @return number of bytes encoded or BACNET_STATUS_ERROR on error.
  */
 int awf_ack_decode_service_request(
-    uint8_t *apdu, unsigned apdu_size, BACNET_ATOMIC_WRITE_FILE_DATA *data)
+    const uint8_t *apdu, unsigned apdu_size, BACNET_ATOMIC_WRITE_FILE_DATA *data)
 {
     int len = 0, apdu_len = 0;
     int32_t signed_integer;
@@ -463,7 +463,7 @@ int awf_ack_decode_service_request(
  *  or NULL for length
  * @return number of bytes decoded, or BACNET_STATUS_ERROR on error
  */
-int awf_ack_decode_apdu(uint8_t *apdu,
+int awf_ack_decode_apdu(const uint8_t *apdu,
     unsigned apdu_size,
     uint8_t *invoke_id,
     BACNET_ATOMIC_WRITE_FILE_DATA *data)

--- a/src/bacnet/awf.h
+++ b/src/bacnet/awf.h
@@ -42,27 +42,27 @@ extern "C" {
     BACNET_STACK_EXPORT
     int awf_service_encode_apdu(
         uint8_t *apdu,
-        BACNET_ATOMIC_WRITE_FILE_DATA *data);
+        const BACNET_ATOMIC_WRITE_FILE_DATA *data);
     BACNET_STACK_EXPORT
     int atomicwritefile_service_request_encode(
         uint8_t *apdu,
         size_t apdu_size,
-        BACNET_ATOMIC_WRITE_FILE_DATA *data);
+        const BACNET_ATOMIC_WRITE_FILE_DATA *data);
 
     BACNET_STACK_EXPORT
     int awf_encode_apdu(
         uint8_t * apdu,
         uint8_t invoke_id,
-        BACNET_ATOMIC_WRITE_FILE_DATA * data);
+        const BACNET_ATOMIC_WRITE_FILE_DATA * data);
 
     BACNET_STACK_EXPORT
     int awf_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_size,
         BACNET_ATOMIC_WRITE_FILE_DATA * data);
     BACNET_STACK_EXPORT
     int awf_decode_apdu(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_size,
         uint8_t * invoke_id,
         BACNET_ATOMIC_WRITE_FILE_DATA * data);
@@ -70,21 +70,21 @@ extern "C" {
     BACNET_STACK_EXPORT
     int awf_ack_service_encode_apdu(
         uint8_t *apdu,
-        BACNET_ATOMIC_WRITE_FILE_DATA *data);
+        const BACNET_ATOMIC_WRITE_FILE_DATA *data);
     BACNET_STACK_EXPORT
     int awf_ack_encode_apdu(
         uint8_t * apdu,
         uint8_t invoke_id,
-        BACNET_ATOMIC_WRITE_FILE_DATA * data);
+        const BACNET_ATOMIC_WRITE_FILE_DATA * data);
 
     BACNET_STACK_EXPORT
     int awf_ack_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_size,
         BACNET_ATOMIC_WRITE_FILE_DATA * data);
     BACNET_STACK_EXPORT
     int awf_ack_decode_apdu(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_size,
         uint8_t * invoke_id,
         BACNET_ATOMIC_WRITE_FILE_DATA * data);

--- a/src/bacnet/bacaction.c
+++ b/src/bacnet/bacaction.c
@@ -22,7 +22,7 @@
  * @return number of bytes encoded
  */
 int bacnet_action_property_value_encode(
-    uint8_t *apdu, BACNET_ACTION_PROPERTY_VALUE *value)
+    uint8_t *apdu, const BACNET_ACTION_PROPERTY_VALUE *value)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
 
@@ -85,7 +85,7 @@ int bacnet_action_property_value_encode(
  * @return number of bytes encoded
  */
 int bacnet_action_property_value_decode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_ACTION_PROPERTY_VALUE *value)
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_ACTION_PROPERTY_VALUE *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -159,7 +159,8 @@ int bacnet_action_property_value_decode(
  * @return true if the two structures are the same
  */
 bool bacnet_action_property_value_same(
-    BACNET_ACTION_PROPERTY_VALUE *value1, BACNET_ACTION_PROPERTY_VALUE *value2)
+    const BACNET_ACTION_PROPERTY_VALUE *value1,
+    const BACNET_ACTION_PROPERTY_VALUE *value2)
 {
     bool status = false; /*return value */
 
@@ -255,7 +256,7 @@ bool bacnet_action_property_value_same(
  * @param entry [in] The BACNET_ACTION_LIST structure to encode
  * @return The length of the encoded data, or BACNET_STATUS_REJECT on error
  */
-int bacnet_action_command_encode(uint8_t *apdu, BACNET_ACTION_LIST *entry)
+int bacnet_action_command_encode(uint8_t *apdu, const BACNET_ACTION_LIST *entry)
 {
     int len = 0;
     int apdu_len = 0;
@@ -349,7 +350,7 @@ int bacnet_action_command_encode(uint8_t *apdu, BACNET_ACTION_LIST *entry)
  * @return The length of the decoded data, or BACNET_STATUS_ERROR on error
  */
 int bacnet_action_command_decode(
-    uint8_t *apdu, size_t apdu_size, BACNET_ACTION_LIST *entry)
+    const uint8_t *apdu, size_t apdu_size, BACNET_ACTION_LIST *entry)
 {
     int len = 0;
     int apdu_len = 0;
@@ -525,7 +526,7 @@ int bacnet_action_command_decode(
  * @return True if the two structures are the same, else False
  */
 bool bacnet_action_command_same(
-    BACNET_ACTION_LIST *entry1, BACNET_ACTION_LIST *entry2)
+    const BACNET_ACTION_LIST *entry1, const BACNET_ACTION_LIST *entry2)
 {
     if (!entry1 || !entry2) {
         return false;

--- a/src/bacnet/bacaction.h
+++ b/src/bacnet/bacaction.h
@@ -83,24 +83,28 @@ extern "C" {
 
 BACNET_STACK_EXPORT
 int bacnet_action_property_value_encode(
-    uint8_t *apdu, BACNET_ACTION_PROPERTY_VALUE *value);
+    uint8_t *apdu, const BACNET_ACTION_PROPERTY_VALUE *value);
 BACNET_STACK_EXPORT
 int bacnet_action_property_value_decode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_ACTION_PROPERTY_VALUE *value);
+    const uint8_t *apdu,
+    uint32_t apdu_size,
+    BACNET_ACTION_PROPERTY_VALUE *value);
 BACNET_STACK_EXPORT
 bool bacnet_action_property_value_same(
-    BACNET_ACTION_PROPERTY_VALUE *value1, BACNET_ACTION_PROPERTY_VALUE *value2);
+    const BACNET_ACTION_PROPERTY_VALUE *value1,
+    const BACNET_ACTION_PROPERTY_VALUE *value2);
 
 BACNET_STACK_EXPORT
-int bacnet_action_command_encode(uint8_t *apdu, BACNET_ACTION_LIST *entry);
+int bacnet_action_command_encode(
+    uint8_t *apdu, const BACNET_ACTION_LIST *entry);
 
 BACNET_STACK_EXPORT
 int bacnet_action_command_decode(
-    uint8_t *apdu, size_t apdu_size, BACNET_ACTION_LIST *entry);
+    const uint8_t *apdu, size_t apdu_size, BACNET_ACTION_LIST *entry);
 
 BACNET_STACK_EXPORT
 bool bacnet_action_command_same(
-    BACNET_ACTION_LIST *entry1, BACNET_ACTION_LIST *entry2);
+    const BACNET_ACTION_LIST *entry1, const BACNET_ACTION_LIST *entry2);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/bacaddr.c
+++ b/src/bacnet/bacaddr.c
@@ -23,7 +23,7 @@
  * @param dest - #BACNET_ADDRESS to be copied into
  * @param src -  #BACNET_ADDRESS to be copied from
  */
-void bacnet_address_copy(BACNET_ADDRESS *dest, BACNET_ADDRESS *src)
+void bacnet_address_copy(BACNET_ADDRESS *dest, const BACNET_ADDRESS *src)
 {
     int i = 0;
 
@@ -46,7 +46,7 @@ void bacnet_address_copy(BACNET_ADDRESS *dest, BACNET_ADDRESS *src)
  * @param src -  #BACNET_ADDRESS to be compared
  * @return true if the same values
  */
-bool bacnet_address_same(BACNET_ADDRESS *dest, BACNET_ADDRESS *src)
+bool bacnet_address_same(const BACNET_ADDRESS *dest, const BACNET_ADDRESS *src)
 {
     uint8_t i = 0; /* loop counter */
 
@@ -96,9 +96,9 @@ bool bacnet_address_same(BACNET_ADDRESS *dest, BACNET_ADDRESS *src)
  * @return true if configured
  */
 bool bacnet_address_init(BACNET_ADDRESS *dest,
-    BACNET_MAC_ADDRESS *mac,
+    const BACNET_MAC_ADDRESS *mac,
     uint16_t dnet,
-    BACNET_MAC_ADDRESS *adr)
+    const BACNET_MAC_ADDRESS *adr)
 {
     uint8_t i = 0; /* loop counter */
 
@@ -146,7 +146,8 @@ bool bacnet_address_init(BACNET_ADDRESS *dest,
  * @param src -  #BACNET_MAC_ADDRESS to be compared
  * @return true if the same values
  */
-bool bacnet_address_mac_same(BACNET_MAC_ADDRESS *dest, BACNET_MAC_ADDRESS *src)
+bool bacnet_address_mac_same(
+    const BACNET_MAC_ADDRESS *dest, const BACNET_MAC_ADDRESS *src)
 {
     uint8_t i = 0; /* loop counter */
 
@@ -173,7 +174,8 @@ bool bacnet_address_mac_same(BACNET_MAC_ADDRESS *dest, BACNET_MAC_ADDRESS *src)
  * @param adr [in] address to initialize, null if empty
  * @param len [in] length of address in bytes
  */
-void bacnet_address_mac_init(BACNET_MAC_ADDRESS *mac, uint8_t *adr, uint8_t len)
+void bacnet_address_mac_init(
+    BACNET_MAC_ADDRESS *mac, const uint8_t *adr, uint8_t len)
 {
     uint8_t i = 0;
 
@@ -251,7 +253,7 @@ bool bacnet_address_mac_from_ascii(BACNET_MAC_ADDRESS *mac, const char *arg)
  * @return the number of apdu bytes consumed, or #BACNET_STATUS_ERROR (-1)
  */
 int bacnet_address_decode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_ADDRESS *value)
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_ADDRESS *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -304,7 +306,7 @@ int bacnet_address_decode(
  * @param value - parameter to store the value after decoding
  * @return length of the APDU buffer decoded, or BACNET_STATUS_ERROR
  */
-int bacnet_address_context_decode(uint8_t *apdu,
+int bacnet_address_context_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     uint8_t tag_number,
     BACNET_ADDRESS *value)
@@ -339,7 +341,7 @@ int bacnet_address_context_decode(uint8_t *apdu,
  *
  * @return number of apdu bytes created
  */
-int encode_bacnet_address(uint8_t *apdu, BACNET_ADDRESS *destination)
+int encode_bacnet_address(uint8_t *apdu, const BACNET_ADDRESS *destination)
 {
     int apdu_len = 0;
     BACNET_OCTET_STRING mac_addr;
@@ -368,7 +370,7 @@ int encode_bacnet_address(uint8_t *apdu, BACNET_ADDRESS *destination)
  * @return length of the APDU buffer decoded, or BACNET_STATUS_ERROR
  * @deprecated use bacnet_address_decode() instead
  */
-int decode_bacnet_address(uint8_t *apdu, BACNET_ADDRESS *value)
+int decode_bacnet_address(const uint8_t *apdu, BACNET_ADDRESS *value)
 {
     return bacnet_address_decode(apdu, MAX_APDU, value);
 }
@@ -380,7 +382,7 @@ int decode_bacnet_address(uint8_t *apdu, BACNET_ADDRESS *value)
  * @return number of apdu bytes created
  */
 int encode_context_bacnet_address(
-    uint8_t *apdu, uint8_t tag_number, BACNET_ADDRESS *destination)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_ADDRESS *destination)
 {
     int len = 0;
     uint8_t *apdu_offset = NULL;
@@ -406,7 +408,7 @@ int encode_context_bacnet_address(
  * @deprecated use bacnet_address_context_decode() instead
  */
 int decode_context_bacnet_address(
-    uint8_t *apdu, uint8_t tag_number, BACNET_ADDRESS *value)
+    const uint8_t *apdu, uint8_t tag_number, BACNET_ADDRESS *value)
 {
     return bacnet_address_context_decode(apdu, MAX_APDU, tag_number, value);
 }

--- a/src/bacnet/bacaddr.h
+++ b/src/bacnet/bacaddr.h
@@ -19,45 +19,47 @@ extern "C" {
 #endif /* __cplusplus */
 
 BACNET_STACK_EXPORT
-void bacnet_address_copy(BACNET_ADDRESS *dest, BACNET_ADDRESS *src);
+void bacnet_address_copy(BACNET_ADDRESS *dest, const BACNET_ADDRESS *src);
 BACNET_STACK_EXPORT
-bool bacnet_address_same(BACNET_ADDRESS *dest, BACNET_ADDRESS *src);
+bool bacnet_address_same(
+    const BACNET_ADDRESS *dest, const BACNET_ADDRESS *src);
 BACNET_STACK_EXPORT
 bool bacnet_address_init(BACNET_ADDRESS *dest,
-    BACNET_MAC_ADDRESS *mac,
+    const BACNET_MAC_ADDRESS *mac,
     uint16_t dnet,
-    BACNET_MAC_ADDRESS *adr);
+    const BACNET_MAC_ADDRESS *adr);
 
 BACNET_STACK_EXPORT
-bool bacnet_address_mac_same(BACNET_MAC_ADDRESS *dest, BACNET_MAC_ADDRESS *src);
+bool bacnet_address_mac_same(
+    const BACNET_MAC_ADDRESS *dest, const BACNET_MAC_ADDRESS *src);
 BACNET_STACK_EXPORT
 void bacnet_address_mac_init(
-    BACNET_MAC_ADDRESS *mac, uint8_t *adr, uint8_t len);
+    BACNET_MAC_ADDRESS *mac, const uint8_t *adr, uint8_t len);
 BACNET_STACK_EXPORT
 bool bacnet_address_mac_from_ascii(BACNET_MAC_ADDRESS *mac, const char *arg);
 
 BACNET_STACK_EXPORT
 int bacnet_address_decode(
-    uint8_t *apdu, uint32_t adpu_size, BACNET_ADDRESS *value);
+    const uint8_t *apdu, uint32_t adpu_size, BACNET_ADDRESS *value);
 BACNET_STACK_EXPORT
-int bacnet_address_context_decode(uint8_t *apdu,
+int bacnet_address_context_decode(const uint8_t *apdu,
     uint32_t adpu_size,
     uint8_t tag_number,
     BACNET_ADDRESS *value);
 
 BACNET_STACK_EXPORT
-int encode_bacnet_address(uint8_t *apdu, BACNET_ADDRESS *destination);
+int encode_bacnet_address(uint8_t *apdu, const BACNET_ADDRESS *destination);
 BACNET_STACK_EXPORT
 int encode_context_bacnet_address(
-    uint8_t *apdu, uint8_t tag_number, BACNET_ADDRESS *destination);
+    uint8_t *apdu, uint8_t tag_number, const BACNET_ADDRESS *destination);
 
 BACNET_STACK_DEPRECATED("Use bacnet_address_decode() instead")
 BACNET_STACK_EXPORT
-int decode_bacnet_address(uint8_t *apdu, BACNET_ADDRESS *destination);
+int decode_bacnet_address(const uint8_t *apdu, BACNET_ADDRESS *destination);
 BACNET_STACK_DEPRECATED("Use bacnet_address_context_decode() instead")
 BACNET_STACK_EXPORT
 int decode_context_bacnet_address(
-    uint8_t *apdu, uint8_t tag_number, BACNET_ADDRESS *destination);
+    const uint8_t *apdu, uint8_t tag_number, BACNET_ADDRESS *destination);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/bacapp.c
+++ b/src/bacnet/bacapp.c
@@ -47,7 +47,7 @@
  * @param value - value to encode
  * @return number of bytes encoded
  */
-static int bacnet_scale_encode(uint8_t *apdu, BACNET_SCALE *value)
+static int bacnet_scale_encode(uint8_t *apdu, const BACNET_SCALE *value)
 {
     int apdu_len = 0;
 
@@ -79,7 +79,7 @@ static int bacnet_scale_encode(uint8_t *apdu, BACNET_SCALE *value)
  * @return number of bytes decoded, or BACNET_STATUS_ERROR on error
  */
 static int
-bacnet_scale_decode(uint8_t *apdu, size_t apdu_size, BACNET_SCALE *value)
+bacnet_scale_decode(const uint8_t *apdu, size_t apdu_size, BACNET_SCALE *value)
 {
     int apdu_len = 0;
     BACNET_TAG tag = { 0 };
@@ -119,7 +119,7 @@ bacnet_scale_decode(uint8_t *apdu, size_t apdu_size, BACNET_SCALE *value)
 #endif
 
 #if defined(BACAPP_SCALE)
-static bool bacnet_scale_same(BACNET_SCALE *value1, BACNET_SCALE *value2)
+static bool bacnet_scale_same(const BACNET_SCALE *value1, const BACNET_SCALE *value2)
 {
     bool status = false;
 
@@ -158,7 +158,7 @@ static bool bacnet_scale_same(BACNET_SCALE *value1, BACNET_SCALE *value2)
  * @param value - value to encode
  * @return number of bytes encoded
  */
-static int bacnet_shed_level_encode(uint8_t *apdu, BACNET_SHED_LEVEL *value)
+static int bacnet_shed_level_encode(uint8_t *apdu, const BACNET_SHED_LEVEL *value)
 {
     int apdu_len = 0;
 
@@ -202,7 +202,7 @@ static int bacnet_shed_level_encode(uint8_t *apdu, BACNET_SHED_LEVEL *value)
  * @return number of bytes decoded, or BACNET_STATUS_ERROR on error
  */
 static int
-bacnet_shed_level_decode(uint8_t *apdu, size_t apdu_size, BACNET_SHED_LEVEL *value)
+bacnet_shed_level_decode(const uint8_t *apdu, size_t apdu_size, BACNET_SHED_LEVEL *value)
 {
     int apdu_len = 0;
     BACNET_TAG tag = { 0 };
@@ -254,7 +254,7 @@ bacnet_shed_level_decode(uint8_t *apdu, size_t apdu_size, BACNET_SHED_LEVEL *val
 
 #if defined(BACAPP_SHED_LEVEL)
 static bool
-bacnet_shed_level_same(BACNET_SHED_LEVEL *value1, BACNET_SHED_LEVEL *value2)
+bacnet_shed_level_same(const BACNET_SHED_LEVEL *value1, const BACNET_SHED_LEVEL *value2)
 {
     bool status = false;
 
@@ -297,7 +297,7 @@ bacnet_shed_level_same(BACNET_SHED_LEVEL *value1, BACNET_SHED_LEVEL *value2)
  * @return number of bytes encoded
  */
 int bacapp_encode_application_data(
-    uint8_t *apdu, BACNET_APPLICATION_DATA_VALUE *value)
+    uint8_t *apdu, const BACNET_APPLICATION_DATA_VALUE *value)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
 
@@ -527,7 +527,7 @@ int bacapp_encode_application_data(
  * in the decoding, or BACNET_STATUS_ERROR/ABORT/REJECT if malformed.
  */
 int bacapp_data_decode(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     uint32_t apdu_size,
     uint8_t tag_data_type,
     uint32_t len_value_type,
@@ -645,7 +645,7 @@ int bacapp_data_decode(
  * @deprecated Use bacapp_data_decode() instead.
  */
 int bacapp_decode_data(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     uint8_t tag_data_type,
     uint32_t len_value_type,
     BACNET_APPLICATION_DATA_VALUE *value)
@@ -665,7 +665,7 @@ int bacapp_decode_data(
  * BACNET_STATUS_ERROR
  */
 int bacapp_decode_application_data(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_APPLICATION_DATA_VALUE *value)
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_APPLICATION_DATA_VALUE *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -711,12 +711,12 @@ int bacapp_decode_application_data(
 */
 
 bool bacapp_decode_application_data_safe(
-    uint8_t *new_apdu,
+    const uint8_t *new_apdu,
     uint32_t new_apdu_len,
     BACNET_APPLICATION_DATA_VALUE *value)
 {
     /* The static variables that store the apdu buffer between function calls */
-    static uint8_t *apdu = NULL;
+    static const uint8_t *apdu = NULL;
     static uint32_t apdu_len_remaining = 0;
     static uint32_t apdu_len = 0;
     int len = 0;
@@ -770,7 +770,7 @@ bool bacapp_decode_application_data_safe(
  * @deprecated Use bacnet_application_data_length() instead.
  */
 int bacapp_decode_data_len(
-    uint8_t *apdu, uint8_t tag_number, uint32_t len_value_type)
+    const uint8_t *apdu, uint8_t tag_number, uint32_t len_value_type)
 {
     (void)apdu;
     return bacnet_application_data_length(tag_number, len_value_type);
@@ -783,7 +783,7 @@ int bacapp_decode_data_len(
  * @return  number of bytes decoded, or zero if errors occur
  * @deprecated Use bacnet_enclosed_data_length() instead.
  */
-int bacapp_decode_application_data_len(uint8_t *apdu, unsigned apdu_size)
+int bacapp_decode_application_data_len(const uint8_t *apdu, unsigned apdu_size)
 {
     int len = 0;
     int tag_len = 0;
@@ -814,7 +814,7 @@ int bacapp_decode_application_data_len(uint8_t *apdu, unsigned apdu_size)
 int bacapp_encode_context_data_value(
     uint8_t *apdu,
     uint8_t context_tag_number,
-    BACNET_APPLICATION_DATA_VALUE *value)
+    const BACNET_APPLICATION_DATA_VALUE *value)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
     int len;
@@ -993,7 +993,7 @@ int bacapp_encode_context_data(
  * @deprecated Use bacapp_decode_known_property() instead.
  */
 int bacapp_decode_context_data(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     unsigned apdu_size,
     BACNET_APPLICATION_DATA_VALUE *value,
     BACNET_PROPERTY_ID property)
@@ -1016,7 +1016,7 @@ int bacapp_decode_context_data(
  * @deprecated Use bacapp_decode_known_property() instead.
  */
 int bacapp_decode_generic_property(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     int apdu_size,
     BACNET_APPLICATION_DATA_VALUE *value,
     BACNET_PROPERTY_ID prop)
@@ -1063,7 +1063,7 @@ int bacapp_decode_generic_property(
  * @return  number of bytes decoded, or #BACNET_STATUS_ERROR
  */
 static int decode_priority_array_value(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     unsigned apdu_size,
     BACNET_APPLICATION_DATA_VALUE *value,
     BACNET_OBJECT_TYPE object_type)
@@ -1308,7 +1308,7 @@ int bacapp_known_property_tag(
  * @return  number of bytes decoded (0..N), or #BACNET_STATUS_ERROR
  */
 int bacapp_decode_application_tag_value(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     size_t apdu_size,
     BACNET_APPLICATION_TAG tag,
     BACNET_APPLICATION_DATA_VALUE *value)
@@ -1607,7 +1607,7 @@ int bacapp_decode_application_tag_value(
  * @note number of bytes can be 0 for empty lists, etc.
  */
 int bacapp_decode_known_property(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     int apdu_size,
     BACNET_APPLICATION_DATA_VALUE *value,
     BACNET_OBJECT_TYPE object_type,
@@ -1653,7 +1653,7 @@ int bacapp_decode_known_property(
  * @deprecated use bacnet_enclosed_data_length() instead
  */
 int bacapp_decode_context_data_len(
-    uint8_t *apdu, unsigned apdu_len_max, BACNET_PROPERTY_ID property)
+    const uint8_t *apdu, unsigned apdu_len_max, BACNET_PROPERTY_ID property)
 {
     int apdu_len = 0, len = 0;
     BACNET_TAG tag = { 0 };
@@ -1675,7 +1675,7 @@ int bacapp_decode_context_data_len(
  * @param value  Pointer to the application value structure
  * @return Length of the encoded data in bytes
  */
-int bacapp_encode_data(uint8_t *apdu, BACNET_APPLICATION_DATA_VALUE *value)
+int bacapp_encode_data(uint8_t *apdu, const BACNET_APPLICATION_DATA_VALUE *value)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
 
@@ -1831,7 +1831,7 @@ bool bacapp_copy(
  * @deprecated Use bacnet_enclosed_data_length() instead.
  */
 int bacapp_data_len(
-    uint8_t *apdu, unsigned apdu_size, BACNET_PROPERTY_ID property)
+    const uint8_t *apdu, unsigned apdu_size, BACNET_PROPERTY_ID property)
 {
     (void)property;
     return bacnet_enclosed_data_length(apdu, apdu_size);
@@ -1894,7 +1894,7 @@ int bacapp_snprintf_shift(int len, char **buf, size_t *buf_size)
  * @return number of characters written to the string
  */
 static int bacapp_snprintf_shed_level(
-    char *str, size_t str_len, BACNET_SHED_LEVEL *value)
+    char *str, size_t str_len, const BACNET_SHED_LEVEL *value)
 {
     int length = 0;
 
@@ -2149,7 +2149,8 @@ static int bacapp_snprintf_enumerated(
  *     The omission of day of week implies that the day is unspecified:
  *     (24-January-1998);
  */
-static int bacapp_snprintf_date(char *str, size_t str_len, BACNET_DATE *bdate)
+static int bacapp_snprintf_date(
+    char *str, size_t str_len, const BACNET_DATE *bdate)
 {
     int ret_val = 0;
     int slen = 0;
@@ -2188,7 +2189,8 @@ static int bacapp_snprintf_date(char *str, size_t str_len, BACNET_DATE *bdate)
  *     in the format hh:mm:ss.xx: 2:05:44.00, 16:54:59.99.
  *     Any "wild card" field is shown by an asterisk (X'2A'): 16:54:*.*;
  */
-static int bacapp_snprintf_time(char *str, size_t str_len, BACNET_TIME *btime)
+static int bacapp_snprintf_time(
+    char *str, size_t str_len, const BACNET_TIME *btime)
 {
     int ret_val = 0;
     int slen = 0;
@@ -2232,7 +2234,7 @@ static int bacapp_snprintf_time(char *str, size_t str_len, BACNET_TIME *btime)
  * @return number of characters written
  */
 static int bacapp_snprintf_object_id(
-    char *str, size_t str_len, BACNET_OBJECT_ID *object_id)
+    char *str, size_t str_len, const BACNET_OBJECT_ID *object_id)
 {
     int ret_val = 0;
     int slen = 0;
@@ -2266,8 +2268,8 @@ static int bacapp_snprintf_object_id(
  * @param value - value to print
  * @return number of characters written
  */
-static int
-bacapp_snprintf_datetime(char *str, size_t str_len, BACNET_DATE_TIME *value)
+static int bacapp_snprintf_datetime(
+    char *str, size_t str_len, const BACNET_DATE_TIME *value)
 {
     int ret_val = 0;
     int slen = 0;
@@ -2294,8 +2296,8 @@ bacapp_snprintf_datetime(char *str, size_t str_len, BACNET_DATE_TIME *value)
  * @param value - value to print
  * @return number of characters written
  */
-static int
-bacapp_snprintf_daterange(char *str, size_t str_len, BACNET_DATE_RANGE *value)
+static int bacapp_snprintf_daterange(
+    char *str, size_t str_len, const BACNET_DATE_RANGE *value)
 {
     int ret_val = 0;
     int slen = 0;
@@ -2328,8 +2330,8 @@ bacapp_snprintf_daterange(char *str, size_t str_len, BACNET_DATE_RANGE *value)
  *     The omission of day of week implies that the day is unspecified:
  *     (24-January-1998);
  */
-static int
-bacapp_snprintf_weeknday(char *str, size_t str_len, BACNET_WEEKNDAY *value)
+static int bacapp_snprintf_weeknday(
+    char *str, size_t str_len, const BACNET_WEEKNDAY *value)
 {
     int ret_val = 0;
     int slen = 0;
@@ -2381,7 +2383,9 @@ bacapp_snprintf_weeknday(char *str, size_t str_len, BACNET_WEEKNDAY *value)
  * @return number of characters written
  */
 static int bacapp_snprintf_device_object_property_reference(
-    char *str, size_t str_len, BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value)
+    char *str,
+    size_t str_len,
+    const BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value)
 {
     int slen;
     int ret_val = 0;
@@ -2427,7 +2431,7 @@ static int bacapp_snprintf_device_object_property_reference(
  * @return number of characters written
  */
 static int bacapp_snprintf_device_object_reference(
-    char *str, size_t str_len, BACNET_DEVICE_OBJECT_REFERENCE *value)
+    char *str, size_t str_len, const BACNET_DEVICE_OBJECT_REFERENCE *value)
 {
     int slen;
     int ret_val = 0;
@@ -2460,7 +2464,7 @@ static int bacapp_snprintf_device_object_reference(
  * @return number of characters written
  */
 static int bacapp_snprintf_object_property_reference(
-    char *str, size_t str_len, BACNET_OBJECT_PROPERTY_REFERENCE *value)
+    char *str, size_t str_len, const BACNET_OBJECT_PROPERTY_REFERENCE *value)
 {
     int slen;
     int ret_val = 0;
@@ -2504,7 +2508,7 @@ static int bacapp_snprintf_object_property_reference(
 static int bacapp_snprintf_weeklyschedule(
     char *str,
     size_t str_len,
-    BACNET_WEEKLY_SCHEDULE *ws,
+    const BACNET_WEEKLY_SCHEDULE *ws,
     BACNET_ARRAY_INDEX arrayIndex)
 {
     int slen;
@@ -2520,7 +2524,7 @@ static int bacapp_snprintf_weeklyschedule(
     /* Find what inner type it uses */
     int inner_tag = -1;
     for (wi = 0; wi < loopend; wi++) {
-        BACNET_DAILY_SCHEDULE *ds = &ws->weeklySchedule[wi];
+        const BACNET_DAILY_SCHEDULE *ds = &ws->weeklySchedule[wi];
         for (ti = 0; ti < ds->TV_Count; ti++) {
             int tag = ds->Time_Values[ti].Value.tag;
             if (inner_tag == -1) {
@@ -2541,7 +2545,7 @@ static int bacapp_snprintf_weeklyschedule(
     }
     ret_val += bacapp_snprintf_shift(slen, &str, &str_len);
     for (wi = 0; wi < loopend; wi++) {
-        BACNET_DAILY_SCHEDULE *ds = &ws->weeklySchedule[wi];
+        const BACNET_DAILY_SCHEDULE *ds = &ws->weeklySchedule[wi];
         if (arrayIndex == BACNET_ARRAY_ALL) {
             slen = bacapp_snprintf(str, str_len, "%s: [", weekdaynames[wi]);
         } else {
@@ -2590,31 +2594,32 @@ static int bacapp_snprintf_weeklyschedule(
  * @return number of characters written
  */
 static int bacapp_snprintf_host_n_port(
-    char *str, size_t str_len, BACNET_HOST_N_PORT *value)
+    char *str, size_t str_len, const BACNET_HOST_N_PORT *value)
 {
     int slen, len, i;
-    char *char_str;
+    const char *char_str;
     int ret_val = 0;
 
     slen = bacapp_snprintf(str, str_len, "{");
     ret_val += bacapp_snprintf_shift(slen, &str, &str_len);
     if (value->host_ip_address) {
-        uint8_t *octet_str;
-        octet_str = octetstring_value(&value->host.ip_address);
+        const uint8_t *octet_str;
+        octet_str = octetstring_value(
+            (BACNET_OCTET_STRING *)&value->host.ip_address);
         slen = bacapp_snprintf(
             str, str_len, "%u.%u.%u.%u:%u", (unsigned)octet_str[0],
             (unsigned)octet_str[1], (unsigned)octet_str[2],
             (unsigned)octet_str[3], (unsigned)value->port);
         ret_val += slen;
     } else if (value->host_name) {
-        BACNET_CHARACTER_STRING *name;
+        const BACNET_CHARACTER_STRING *name;
         name = &value->host.name;
         len = characterstring_length(name);
         char_str = characterstring_value(name);
         slen = bacapp_snprintf(str, str_len, "\"");
         ret_val += bacapp_snprintf_shift(slen, &str, &str_len);
         for (i = 0; i < len; i++) {
-            if (isprint(*((unsigned char *)char_str))) {
+            if (isprint(*((const unsigned char *)char_str))) {
                 slen = bacapp_snprintf(str, str_len, "%c", *char_str);
             } else {
                 slen = bacapp_snprintf(str, str_len, "%c", '.');
@@ -2641,7 +2646,7 @@ static int bacapp_snprintf_host_n_port(
  * @return number of characters written
  */
 static int bacapp_snprintf_calendar_entry(
-    char *str, size_t str_len, BACNET_CALENDAR_ENTRY *value)
+    char *str, size_t str_len, const BACNET_CALENDAR_ENTRY *value)
 {
     int slen;
     int ret_val = 0;
@@ -2683,7 +2688,7 @@ static int bacapp_snprintf_calendar_entry(
  * @return number of characters written
  */
 static int bacapp_snprintf_primitive_data_value(
-    char *str, size_t str_len, BACNET_PRIMITIVE_DATA_VALUE *value)
+    char *str, size_t str_len, const BACNET_PRIMITIVE_DATA_VALUE *value)
 {
     int ret_val = 0;
 
@@ -2747,7 +2752,7 @@ static int bacapp_snprintf_primitive_data_value(
  * @return number of characters written
  */
 static int bacapp_snprintf_daily_schedule(
-    char *str, size_t str_len, BACNET_DAILY_SCHEDULE *value)
+    char *str, size_t str_len, const BACNET_DAILY_SCHEDULE *value)
 {
     int slen;
     int ret_val = 0;
@@ -2785,7 +2790,7 @@ static int bacapp_snprintf_daily_schedule(
  * @return number of characters written
  */
 static int bacapp_snprintf_special_event(
-    char *str, size_t str_len, BACNET_SPECIAL_EVENT *value)
+    char *str, size_t str_len, const BACNET_SPECIAL_EVENT *value)
 {
     int slen;
     int ret_val = 0;
@@ -2825,7 +2830,7 @@ static int bacapp_snprintf_special_event(
  * @return number of characters written
  */
 static int bacapp_snprintf_action_property_value(
-    char *str, size_t str_len, BACNET_ACTION_PROPERTY_VALUE *value)
+    char *str, size_t str_len, const BACNET_ACTION_PROPERTY_VALUE *value)
 {
     int ret_val = 0;
 
@@ -2889,7 +2894,7 @@ static int bacapp_snprintf_action_property_value(
  * @return number of characters written
  */
 static int bacapp_snprintf_action_command(
-    char *str, size_t str_len, BACNET_ACTION_LIST *value)
+    char *str, size_t str_len, const BACNET_ACTION_LIST *value)
 {
     int slen;
     int ret_val = 0;
@@ -2960,11 +2965,11 @@ static int bacapp_snprintf_action_command(
  *  to the output string.
  */
 int bacapp_snprintf_value(
-    char *str, size_t str_len, BACNET_OBJECT_PROPERTY_VALUE *object_value)
+    char *str, size_t str_len, const BACNET_OBJECT_PROPERTY_VALUE *object_value)
 {
     size_t len = 0, i = 0;
-    char *char_str;
-    BACNET_APPLICATION_DATA_VALUE *value;
+    const char *char_str;
+    const BACNET_APPLICATION_DATA_VALUE *value;
     BACNET_PROPERTY_ID property = PROP_ALL;
     BACNET_OBJECT_TYPE object_type = MAX_BACNET_OBJECT_TYPE;
     int ret_val = 0;
@@ -3019,8 +3024,9 @@ int bacapp_snprintf_value(
             case BACNET_APPLICATION_TAG_OCTET_STRING:
                 len = octetstring_length(&value->type.Octet_String);
                 if (len > 0) {
-                    uint8_t *octet_str;
-                    octet_str = octetstring_value(&value->type.Octet_String);
+                    const uint8_t *octet_str;
+                    octet_str = octetstring_value(
+                        (BACNET_OCTET_STRING *)&value->type.Octet_String);
                     for (i = 0; i < len; i++) {
                         slen =
                             bacapp_snprintf(str, str_len, "%02X", *octet_str);
@@ -3067,7 +3073,7 @@ int bacapp_snprintf_value(
 #endif
                 {
                     for (i = 0; i < len; i++) {
-                        if (isprint(*((unsigned char *)char_str))) {
+                        if (isprint(*((const unsigned char *)char_str))) {
                             slen =
                                 bacapp_snprintf(str, str_len, "%c", *char_str);
                         } else {
@@ -3291,7 +3297,7 @@ int bacapp_snprintf_value(
  * @return true if the value was sent to the stream
  */
 bool bacapp_print_value(
-    FILE *stream, BACNET_OBJECT_PROPERTY_VALUE *object_value)
+    FILE *stream, const BACNET_OBJECT_PROPERTY_VALUE *object_value)
 {
     bool retval = false;
     int str_len = 0;
@@ -3326,7 +3332,7 @@ bool bacapp_print_value(
 }
 #else
 bool bacapp_print_value(
-    FILE *stream, BACNET_OBJECT_PROPERTY_VALUE *object_value)
+    FILE *stream, const BACNET_OBJECT_PROPERTY_VALUE *object_value)
 {
     (void)stream;
     (void)object_value;
@@ -3999,11 +4005,12 @@ void bacapp_property_value_list_link(
  *
  * @return Bytes encoded or zero on error.
  */
-int bacapp_property_value_encode(uint8_t *apdu, BACNET_PROPERTY_VALUE *value)
+int bacapp_property_value_encode(
+    uint8_t *apdu, const BACNET_PROPERTY_VALUE *value)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
-    BACNET_APPLICATION_DATA_VALUE *app_data = NULL;
+    const BACNET_APPLICATION_DATA_VALUE *app_data = NULL;
 
     if (value) {
         /* tag 0 - propertyIdentifier */
@@ -4072,7 +4079,7 @@ int bacapp_property_value_encode(uint8_t *apdu, BACNET_PROPERTY_VALUE *value)
  * @return Bytes decoded or BACNET_STATUS_ERROR on error.
  */
 int bacapp_property_value_decode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_PROPERTY_VALUE *value)
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_PROPERTY_VALUE *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -4190,8 +4197,8 @@ int bacapp_property_value_decode(
 /* generic - can be used by other unit tests
    returns true if matching or same, false if different */
 bool bacapp_same_value(
-    BACNET_APPLICATION_DATA_VALUE *value,
-    BACNET_APPLICATION_DATA_VALUE *test_value)
+    const BACNET_APPLICATION_DATA_VALUE *value,
+    const BACNET_APPLICATION_DATA_VALUE *test_value)
 {
     bool status = false; /*return value */
 

--- a/src/bacnet/bacapp.c
+++ b/src/bacnet/bacapp.c
@@ -2567,6 +2567,7 @@ static int bacapp_snprintf_weeklyschedule(
             dummyPropValue.value = &dummyDataValue;
             dummyPropValue.object_property = PROP_PRESENT_VALUE;
             dummyPropValue.object_type = OBJECT_SCHEDULE;
+            dummyPropValue.array_index = 0;
             slen = bacapp_snprintf_value(str, str_len, &dummyPropValue);
             ret_val += bacapp_snprintf_shift(slen, &str, &str_len);
             if (ti < ds->TV_Count - 1) {

--- a/src/bacnet/bacapp.h
+++ b/src/bacnet/bacapp.h
@@ -225,17 +225,17 @@ extern "C" {
     BACNET_STACK_EXPORT
     int bacapp_property_value_encode(
         uint8_t *apdu,
-        BACNET_PROPERTY_VALUE *value);
+        const BACNET_PROPERTY_VALUE *value);
     BACNET_STACK_EXPORT
     int bacapp_property_value_decode(
-        uint8_t *apdu,
+        const uint8_t *apdu,
         uint32_t apdu_size,
         BACNET_PROPERTY_VALUE *value);
 
     BACNET_STACK_EXPORT
     int bacapp_encode_data(
         uint8_t * apdu,
-        BACNET_APPLICATION_DATA_VALUE * value);
+        const BACNET_APPLICATION_DATA_VALUE * value);
     BACNET_STACK_EXPORT
     int bacapp_encode_known_property(
         uint8_t *apdu,
@@ -244,7 +244,7 @@ extern "C" {
         BACNET_PROPERTY_ID property);
     BACNET_STACK_EXPORT
     int bacapp_data_decode(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint32_t apdu_size,
         uint8_t tag_data_type,
         uint32_t len_value_type,
@@ -252,31 +252,31 @@ extern "C" {
     BACNET_STACK_DEPRECATED("Use bacapp_data_decode() instead")
     BACNET_STACK_EXPORT
     int bacapp_decode_data(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint8_t tag_data_type,
         uint32_t len_value_type,
         BACNET_APPLICATION_DATA_VALUE * value);
 
     BACNET_STACK_EXPORT
     int bacapp_decode_application_data(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint32_t apdu_size,
         BACNET_APPLICATION_DATA_VALUE * value);
 
     BACNET_STACK_EXPORT
     bool bacapp_decode_application_data_safe(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint32_t apdu_size,
         BACNET_APPLICATION_DATA_VALUE * value);
 
     BACNET_STACK_EXPORT
     int bacapp_encode_application_data(
         uint8_t * apdu,
-        BACNET_APPLICATION_DATA_VALUE * value);
+        const BACNET_APPLICATION_DATA_VALUE * value);
 
     BACNET_STACK_EXPORT
     int bacapp_decode_context_data(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned max_apdu_len,
         BACNET_APPLICATION_DATA_VALUE * value,
         BACNET_PROPERTY_ID property);
@@ -292,7 +292,7 @@ extern "C" {
     int bacapp_encode_context_data_value(
         uint8_t * apdu,
         uint8_t context_tag_number,
-        BACNET_APPLICATION_DATA_VALUE * value);
+        const BACNET_APPLICATION_DATA_VALUE * value);
 
     BACNET_STACK_DEPRECATED("Use bacapp_known_property_tag() instead")
     BACNET_STACK_EXPORT
@@ -302,19 +302,19 @@ extern "C" {
     BACNET_STACK_DEPRECATED("Use bacapp_encode_known_property() instead")
     BACNET_STACK_EXPORT
     int bacapp_decode_generic_property(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         int max_apdu_len,
         BACNET_APPLICATION_DATA_VALUE * value,
         BACNET_PROPERTY_ID prop);
 
     BACNET_STACK_EXPORT
     int bacapp_decode_application_tag_value(
-        uint8_t *apdu,
+        const uint8_t *apdu,
         size_t apdu_size,
         BACNET_APPLICATION_TAG tag,
         BACNET_APPLICATION_DATA_VALUE *value);
     BACNET_STACK_EXPORT
-    int bacapp_decode_known_property(uint8_t *apdu,
+    int bacapp_decode_known_property(const uint8_t *apdu,
         int max_apdu_len,
         BACNET_APPLICATION_DATA_VALUE *value,
         BACNET_OBJECT_TYPE object_type,
@@ -333,27 +333,27 @@ extern "C" {
     BACNET_STACK_DEPRECATED("Use bacnet_enclosed_data_length() instead")
     BACNET_STACK_EXPORT
     int bacapp_data_len(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned max_apdu_len,
         BACNET_PROPERTY_ID property);
 
     BACNET_STACK_DEPRECATED("Use bacnet_application_data_length() instead")
     BACNET_STACK_EXPORT
     int bacapp_decode_data_len(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint8_t tag_data_type,
         uint32_t len_value_type);
 
     BACNET_STACK_DEPRECATED("Use bacnet_enclosed_data_length() instead")
     BACNET_STACK_EXPORT
     int bacapp_decode_application_data_len(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned max_apdu_len);
 
     BACNET_STACK_DEPRECATED("Use bacnet_enclosed_data_length() instead")
     BACNET_STACK_EXPORT
     int bacapp_decode_context_data_len(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned max_apdu_len,
         BACNET_PROPERTY_ID property);
 
@@ -371,7 +371,7 @@ extern "C" {
     int bacapp_snprintf_value(
         char *str,
         size_t str_len,
-        BACNET_OBJECT_PROPERTY_VALUE * object_value);
+        const BACNET_OBJECT_PROPERTY_VALUE * object_value);
 
     BACNET_STACK_EXPORT
     bool bacapp_parse_application_data(
@@ -382,12 +382,12 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool bacapp_print_value(
         FILE * stream,
-        BACNET_OBJECT_PROPERTY_VALUE * value);
+        const BACNET_OBJECT_PROPERTY_VALUE * value);
 
     BACNET_STACK_EXPORT
     bool bacapp_same_value(
-        BACNET_APPLICATION_DATA_VALUE * value,
-        BACNET_APPLICATION_DATA_VALUE * test_value);
+        const BACNET_APPLICATION_DATA_VALUE * value,
+        const BACNET_APPLICATION_DATA_VALUE * test_value);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/bacdcode.c
+++ b/src/bacnet/bacdcode.c
@@ -370,7 +370,7 @@ int encode_closing_tag(uint8_t *apdu, uint8_t tag_number)
  * @return  Returns the number of apdu bytes consumed.
  * @deprecated Use bacnet_tag_number_decode() instead
  */
-int decode_tag_number(uint8_t *apdu, uint8_t *tag_number)
+int decode_tag_number(const uint8_t *apdu, uint8_t *tag_number)
 {
     int len = 1; /* return value */
 
@@ -421,7 +421,7 @@ int decode_tag_number(uint8_t *apdu, uint8_t *tag_number)
  * @return  number of bytes decoded, or zero if errors occur
  */
 int bacnet_tag_number_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint8_t *tag_number)
+    const uint8_t *apdu, uint32_t apdu_size, uint8_t *tag_number)
 {
     int len = 0; /* return value */
 
@@ -459,7 +459,7 @@ int bacnet_tag_number_decode(
  * @return returns the number of apdu bytes consumed,
  *  or 0 if apdu_size is too small to fit the data
  */
-int bacnet_tag_encode(uint8_t *apdu, uint32_t apdu_size, BACNET_TAG *tag)
+int bacnet_tag_encode(uint8_t *apdu, uint32_t apdu_size, const BACNET_TAG *tag)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
 
@@ -503,7 +503,7 @@ int bacnet_tag_encode(uint8_t *apdu, uint32_t apdu_size, BACNET_TAG *tag)
  *
  * @return the number of apdu bytes consumed, or zero if malformed
  */
-int bacnet_tag_decode(uint8_t *apdu, uint32_t apdu_size, BACNET_TAG *tag)
+int bacnet_tag_decode(const uint8_t *apdu, uint32_t apdu_size, BACNET_TAG *tag)
 {
     int len = 0;
     uint8_t tag_number = 0;
@@ -583,7 +583,7 @@ int bacnet_tag_decode(uint8_t *apdu, uint32_t apdu_size, BACNET_TAG *tag)
  * @return  true/false
  * @deprecated Use bacnet_is_opening_tag() instead
  */
-bool decode_is_opening_tag(uint8_t *apdu)
+bool decode_is_opening_tag(const uint8_t *apdu)
 {
     return (bool)((apdu[0] & 0x07) == 6);
 }
@@ -596,7 +596,7 @@ bool decode_is_opening_tag(uint8_t *apdu)
  *
  * @return true if an opening tag has been found.
  */
-bool bacnet_is_opening_tag(uint8_t *apdu, uint32_t apdu_size)
+bool bacnet_is_opening_tag(const uint8_t *apdu, uint32_t apdu_size)
 {
     bool tag = false;
 
@@ -616,7 +616,7 @@ bool bacnet_is_opening_tag(uint8_t *apdu, uint32_t apdu_size)
  * @return  true/false
  * @deprecated Use bacnet_is_closing_tag() instead
  */
-bool decode_is_closing_tag(uint8_t *apdu)
+bool decode_is_closing_tag(const uint8_t *apdu)
 {
     return (bool)((apdu[0] & 0x07) == 7);
 }
@@ -629,7 +629,7 @@ bool decode_is_closing_tag(uint8_t *apdu)
  *
  * @return true if a closing tag has been found.
  */
-bool bacnet_is_closing_tag(uint8_t *apdu, uint32_t apdu_size)
+bool bacnet_is_closing_tag(const uint8_t *apdu, uint32_t apdu_size)
 {
     bool tag = false;
 
@@ -650,7 +650,7 @@ bool bacnet_is_closing_tag(uint8_t *apdu, uint32_t apdu_size)
  *
  * @return true if a context specific tag has been found.
  */
-bool bacnet_is_context_specific(uint8_t *apdu, uint32_t apdu_size)
+bool bacnet_is_context_specific(const uint8_t *apdu, uint32_t apdu_size)
 {
     bool tag = false;
 
@@ -678,7 +678,7 @@ bool bacnet_is_context_specific(uint8_t *apdu, uint32_t apdu_size)
  * @deprecated Use bacnet_tag_decode() instead
  */
 int decode_tag_number_and_value(
-    uint8_t *apdu, uint8_t *tag_number, uint32_t *value)
+    const uint8_t *apdu, uint8_t *tag_number, uint32_t *value)
 {
     int len = 1;
     uint16_t value16;
@@ -738,7 +738,7 @@ int decode_tag_number_and_value(
  * @deprecated use bacnet_tag_decode() instead
  */
 int bacnet_tag_number_and_value_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint8_t *tag_number, uint32_t *value)
+    const uint8_t *apdu, uint32_t apdu_size, uint8_t *tag_number, uint32_t *value)
 {
     int len = 0;
     BACNET_TAG tag = { 0 };
@@ -805,7 +805,7 @@ int bacnet_application_data_length(
  *  or BACNET_STATUS_ERROR.
  */
 int bacnet_enclosed_data_length(
-    uint8_t *apdu, size_t apdu_size)
+    const uint8_t *apdu, size_t apdu_size)
 {
     int len = 0;
     int total_len = 0;
@@ -898,7 +898,7 @@ int bacnet_enclosed_data_length(
  * @return true on a match, false otherwise.
  * @deprecated Use bacnet_is_context_tag_number() instead
  */
-bool decode_is_context_tag(uint8_t *apdu, uint8_t tag_number)
+bool decode_is_context_tag(const uint8_t *apdu, uint8_t tag_number)
 {
     uint8_t my_tag_number = 0;
 
@@ -921,7 +921,7 @@ bool decode_is_context_tag(uint8_t *apdu, uint8_t tag_number)
  * @deprecated Use bacnet_is_context_tag_number() instead
  */
 bool decode_is_context_tag_with_length(
-    uint8_t *apdu, uint8_t tag_number, int *tag_length)
+    const uint8_t *apdu, uint8_t tag_number, int *tag_length)
 {
     uint8_t my_tag_number = 0;
 
@@ -946,8 +946,8 @@ bool decode_is_context_tag_with_length(
  * @return true on a match, false otherwise.
  */
 bool bacnet_is_context_tag_number(
-    uint8_t *apdu, uint32_t apdu_size, uint8_t tag_number, int *tag_length,
-    uint32_t *len_value_type)
+    const uint8_t *apdu, uint32_t apdu_size, uint8_t tag_number,
+    int *tag_length, uint32_t *len_value_type)
 {
     bool match = false;
     int len;
@@ -980,7 +980,7 @@ bool bacnet_is_context_tag_number(
  * @return true on a match, false otherwise.
  * @deprecated Use bacnet_is_opening_tag_number() instead
  */
-bool decode_is_opening_tag_number(uint8_t *apdu, uint8_t tag_number)
+bool decode_is_opening_tag_number(const uint8_t *apdu, uint8_t tag_number)
 {
     uint8_t my_tag_number = 0;
 
@@ -1006,7 +1006,7 @@ bool decode_is_opening_tag_number(uint8_t *apdu, uint8_t tag_number)
  * @return true if the tag number matches and is an opening tag.
  */
 bool bacnet_is_opening_tag_number(
-    uint8_t *apdu, uint32_t apdu_size, uint8_t tag_number, int *tag_length)
+    const uint8_t *apdu, uint32_t apdu_size, uint8_t tag_number, int *tag_length)
 {
     bool match = false;
     int len;
@@ -1036,7 +1036,7 @@ bool bacnet_is_opening_tag_number(
  * @return true on a match, false otherwise.
  * @deprecated Use bacnet_is_closing_tag_number() instead
  */
-bool decode_is_closing_tag_number(uint8_t *apdu, uint8_t tag_number)
+bool decode_is_closing_tag_number(const uint8_t *apdu, uint8_t tag_number)
 {
     uint8_t my_tag_number = 0;
 
@@ -1060,7 +1060,7 @@ bool decode_is_closing_tag_number(uint8_t *apdu, uint8_t tag_number)
  * @return true if the tag number matches is an closing tag.
  */
 bool bacnet_is_closing_tag_number(
-    uint8_t *apdu, uint32_t apdu_size, uint8_t tag_number, int *tag_length)
+    const uint8_t *apdu, uint32_t apdu_size, uint8_t tag_number, int *tag_length)
 {
     bool match = false;
     int len;
@@ -1136,7 +1136,7 @@ int encode_context_boolean(
  * @return true/false
  * @deprecated Use bacnet_boolean_context_decode() instead
  */
-bool decode_context_boolean(uint8_t *apdu)
+bool decode_context_boolean(const uint8_t *apdu)
 {
     bool boolean_value = false;
 
@@ -1160,7 +1160,7 @@ bool decode_context_boolean(uint8_t *apdu)
  * @deprecated Use bacnet_boolean_context_decode() instead
  */
 int decode_context_boolean2(
-    uint8_t *apdu, uint8_t tag_number, bool *boolean_value)
+    const uint8_t *apdu, uint8_t tag_number, bool *boolean_value)
 {
     int len = 0;
     if (decode_is_context_tag_with_length(&apdu[len], tag_number, &len)) {
@@ -1239,7 +1239,7 @@ int bacnet_boolean_application_encode(
  * or #BACNET_STATUS_ERROR (-1) if malformed
  */
 int bacnet_boolean_application_decode(
-    uint8_t *apdu, uint32_t apdu_size, bool *boolean_value)
+    const uint8_t *apdu, uint32_t apdu_size, bool *boolean_value)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     int len = 0;
@@ -1284,7 +1284,7 @@ int bacnet_boolean_application_decode(
  * or #BACNET_STATUS_ERROR (-1) if malformed
  */
 int bacnet_boolean_context_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint8_t tag_value, bool *boolean_value)
+    const uint8_t *apdu, uint32_t apdu_size, uint8_t tag_value, bool *boolean_value)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     int len = 0;
@@ -1392,7 +1392,7 @@ static uint8_t byte_reverse_bits(uint8_t in_byte)
  * @deprecated Use bacnet_bitstring_decode() instead.
  */
 int decode_bitstring(
-    uint8_t *apdu, uint32_t len_value, BACNET_BIT_STRING *bit_string)
+    const uint8_t *apdu, uint32_t len_value, BACNET_BIT_STRING *bit_string)
 {
     int len = 0; /* Return value */
     uint8_t unused_bits;
@@ -1435,7 +1435,7 @@ int decode_bitstring(
  *
  * @return  number of bytes decoded, or zero if errors occur
  */
-int bacnet_bitstring_decode(uint8_t *apdu,
+int bacnet_bitstring_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     uint32_t len_value,
     BACNET_BIT_STRING *value)
@@ -1483,7 +1483,7 @@ int bacnet_bitstring_decode(uint8_t *apdu,
  *  or 0 if apdu_size is too small to fit the data
  */
 int bacnet_bitstring_application_encode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_BIT_STRING *value)
+    uint8_t *apdu, uint32_t apdu_size, const BACNET_BIT_STRING *value)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
 
@@ -1510,7 +1510,7 @@ int bacnet_bitstring_application_encode(
  * or #BACNET_STATUS_ERROR (-1) if malformed
  */
 int bacnet_bitstring_application_decode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_BIT_STRING *value)
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_BIT_STRING *value)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     int len = 0;
@@ -1548,7 +1548,7 @@ int bacnet_bitstring_application_decode(
  * @return  number of bytes decoded, or zero if tag number mismatch, or
  * #BACNET_STATUS_ERROR (-1) if malformed
  */
-int bacnet_bitstring_context_decode(uint8_t *apdu,
+int bacnet_bitstring_context_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     uint8_t tag_value,
     BACNET_BIT_STRING *value)
@@ -1590,7 +1590,7 @@ int bacnet_bitstring_context_decode(uint8_t *apdu,
  * @deprecated Use bacnet_bitstring_context_decode() instead.
  */
 int decode_context_bitstring(
-    uint8_t *apdu, uint8_t tag_number, BACNET_BIT_STRING *bit_string)
+    const uint8_t *apdu, uint8_t tag_number, BACNET_BIT_STRING *bit_string)
 {
     uint32_t len_value;
     int len = 0;
@@ -1616,7 +1616,7 @@ int decode_context_bitstring(
  *
  * @return the number of apdu bytes encoded
  */
-int encode_bitstring(uint8_t *apdu, BACNET_BIT_STRING *bit_string)
+int encode_bitstring(uint8_t *apdu, const BACNET_BIT_STRING *bit_string)
 {
     int len = 0;
     uint8_t remaining_used_bits = 0;
@@ -1659,7 +1659,7 @@ int encode_bitstring(uint8_t *apdu, BACNET_BIT_STRING *bit_string)
  *
  * @return the number of apdu bytes encoded
  */
-int encode_application_bitstring(uint8_t *apdu, BACNET_BIT_STRING *value)
+int encode_application_bitstring(uint8_t *apdu, const BACNET_BIT_STRING *value)
 {
     int len = 0;
     uint32_t bit_string_encoded_length = 1; /* 1 for the bits remaining octet */
@@ -1689,7 +1689,7 @@ int encode_application_bitstring(uint8_t *apdu, BACNET_BIT_STRING *value)
  * @return the number of apdu bytes encoded
  */
 int encode_context_bitstring(
-    uint8_t *apdu, uint8_t tag_number, BACNET_BIT_STRING *value)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_BIT_STRING *value)
 {
     int len = 0;
     uint32_t bit_string_encoded_length = 1; /* 1 for the bits remaining octet */
@@ -1717,7 +1717,7 @@ int encode_context_bitstring(
  *
  * @return the number of apdu bytes consumed
  */
-int decode_object_id_safe(uint8_t *apdu,
+int decode_object_id_safe(const uint8_t *apdu,
     uint32_t len_value_type,
     BACNET_OBJECT_TYPE *object_type,
     uint32_t *instance)
@@ -1754,7 +1754,7 @@ int decode_object_id_safe(uint8_t *apdu,
  * @return the number of apdu bytes consumed
  */
 int decode_object_id(
-    uint8_t *apdu, BACNET_OBJECT_TYPE *object_type, uint32_t *instance)
+    const uint8_t *apdu, BACNET_OBJECT_TYPE *object_type, uint32_t *instance)
 {
     const uint32_t len_value = 4;
 
@@ -1772,7 +1772,7 @@ int decode_object_id(
  *
  * @return the number of apdu bytes consumed, or 0 if apdu is too small
  */
-int bacnet_object_id_decode(uint8_t *apdu,
+int bacnet_object_id_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     uint32_t len_value_type,
     BACNET_OBJECT_TYPE *object_type,
@@ -1833,7 +1833,7 @@ int bacnet_object_id_application_encode(
  * @return number of bytes decoded, zero if wrong tag number,
  * or #BACNET_STATUS_ERROR (-1) if malformed
  */
-int bacnet_object_id_application_decode(uint8_t *apdu,
+int bacnet_object_id_application_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     BACNET_OBJECT_TYPE *object_type,
     uint32_t *object_instance)
@@ -1875,7 +1875,7 @@ int bacnet_object_id_application_decode(uint8_t *apdu,
  * @return  number of bytes decoded, zero if wrong tag number,
  * or #BACNET_STATUS_ERROR (-1) if malformed
  */
-int bacnet_object_id_context_decode(uint8_t *apdu,
+int bacnet_object_id_context_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     uint8_t tag_value,
     BACNET_OBJECT_TYPE *object_type,
@@ -1918,7 +1918,7 @@ int bacnet_object_id_context_decode(uint8_t *apdu,
  *  if wrong tag number or malformed
  * @deprecated Use bacnet_object_id_context_decode() instead
  */
-int decode_context_object_id(uint8_t *apdu,
+int decode_context_object_id(const uint8_t *apdu,
     uint8_t tag_number,
     BACNET_OBJECT_TYPE *object_type,
     uint32_t *instance)
@@ -2029,15 +2029,15 @@ int encode_application_object_id(
  *
  * @return returns the number of apdu bytes consumed
  */
-int encode_octet_string(uint8_t *apdu, BACNET_OCTET_STRING *octet_string)
+int encode_octet_string(uint8_t *apdu, const BACNET_OCTET_STRING *octet_string)
 {
     int len = 0; /* return value */
-    uint8_t *value;
+    const uint8_t *value;
     int i = 0; /* loop counter */
 
     if (octet_string) {
         len = (int)octetstring_length(octet_string);
-        value = octetstring_value(octet_string);
+        value = octetstring_value((BACNET_OCTET_STRING *)octet_string);
         if (value && apdu) {
             for (i = 0; i < len; i++) {
                 apdu[i] = value[i];
@@ -2058,7 +2058,7 @@ int encode_octet_string(uint8_t *apdu, BACNET_OCTET_STRING *octet_string)
  *
  * @return returns the number of apdu bytes consumed
  */
-int encode_application_octet_string(uint8_t *apdu, BACNET_OCTET_STRING *value)
+int encode_application_octet_string(uint8_t *apdu, const BACNET_OCTET_STRING *value)
 {
     int len = 0;
 
@@ -2086,7 +2086,7 @@ int encode_application_octet_string(uint8_t *apdu, BACNET_OCTET_STRING *value)
  * @return returns the number of apdu bytes consumed
  */
 int encode_context_octet_string(
-    uint8_t *apdu, uint8_t tag_number, BACNET_OCTET_STRING *value)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_OCTET_STRING *value)
 {
     int len = 0;
 
@@ -2114,7 +2114,7 @@ int encode_context_octet_string(
  *
  * @return  number of bytes decoded (0..N), or BACNET_STATUS_ERROR on error
  */
-int bacnet_octet_string_decode(uint8_t *apdu,
+int bacnet_octet_string_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     uint32_t len_value,
     BACNET_OCTET_STRING *value)
@@ -2146,7 +2146,7 @@ int bacnet_octet_string_decode(uint8_t *apdu,
  * @deprecated use bacnet_octet_string_decode() instead
  */
 int decode_octet_string(
-    uint8_t *apdu, uint32_t len_value, BACNET_OCTET_STRING *value)
+    const uint8_t *apdu, uint32_t len_value, BACNET_OCTET_STRING *value)
 {
     const uint16_t apdu_len_max = MAX_APDU;
 
@@ -2167,7 +2167,7 @@ int decode_octet_string(
  * @deprecated use bacnet_octet_string_context_decode() instead
  */
 int decode_context_octet_string(
-    uint8_t *apdu, uint8_t tag_number, BACNET_OCTET_STRING *octet_string)
+    const uint8_t *apdu, uint8_t tag_number, BACNET_OCTET_STRING *octet_string)
 {
     int len = 0; /* return value */
     bool status = false;
@@ -2205,7 +2205,7 @@ int decode_context_octet_string(
  *  or 0 if apdu_size is too small to fit the data
  */
 int bacnet_octet_string_application_encode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_OCTET_STRING *value)
+    uint8_t *apdu, uint32_t apdu_size, const BACNET_OCTET_STRING *value)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
 
@@ -2232,7 +2232,7 @@ int bacnet_octet_string_application_encode(
  * or #BACNET_STATUS_ERROR (-1) if malformed
  */
 int bacnet_octet_string_application_decode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_OCTET_STRING *value)
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_OCTET_STRING *value)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     int len = 0;
@@ -2270,7 +2270,7 @@ int bacnet_octet_string_application_decode(
  * @return  number of bytes decoded, or zero if tag number mismatch, or
  * #BACNET_STATUS_ERROR (-1) if malformed
  */
-int bacnet_octet_string_context_decode(uint8_t *apdu,
+int bacnet_octet_string_context_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     uint8_t tag_value,
     BACNET_OCTET_STRING *value)
@@ -2316,7 +2316,7 @@ int bacnet_octet_string_context_decode(uint8_t *apdu,
 uint32_t encode_bacnet_character_string_safe(uint8_t *apdu,
     uint32_t max_apdu,
     uint8_t encoding,
-    char *value,
+    const char *value,
     uint32_t length)
 {
     uint32_t apdu_len = 1 /*encoding */;
@@ -2348,12 +2348,12 @@ uint32_t encode_bacnet_character_string_safe(uint8_t *apdu,
  * @return returns the number of apdu bytes consumed
  */
 int encode_bacnet_character_string(
-    uint8_t *apdu, BACNET_CHARACTER_STRING *char_string)
+    uint8_t *apdu, const BACNET_CHARACTER_STRING *char_string)
 {
     uint32_t apdu_len = 1 /*encoding */;
     uint32_t i;
     size_t length;
-    char *value;
+    const char *value;
 
     length = characterstring_length(char_string);
     if (apdu) {
@@ -2379,7 +2379,7 @@ int encode_bacnet_character_string(
  * @return returns the number of apdu bytes consumed
  */
 int encode_application_character_string(
-    uint8_t *apdu, BACNET_CHARACTER_STRING *char_string)
+    uint8_t *apdu, const BACNET_CHARACTER_STRING *char_string)
 {
     int len = 0;
     uint8_t *apdu_offset = NULL;
@@ -2407,7 +2407,7 @@ int encode_application_character_string(
  * @return returns the number of apdu bytes consumed
  */
 int encode_context_character_string(
-    uint8_t *apdu, uint8_t tag_number, BACNET_CHARACTER_STRING *char_string)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_CHARACTER_STRING *char_string)
 {
     int len = 0;
     uint8_t *apdu_offset = NULL;
@@ -2434,12 +2434,12 @@ int encode_context_character_string(
  *
  * @return  number of bytes decoded, or zero if errors occur
  */
-int bacnet_character_string_decode(uint8_t *apdu,
+int bacnet_character_string_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     uint32_t len_value,
     BACNET_CHARACTER_STRING *char_string)
 {
-    char *string_value = NULL;
+    const char *string_value = NULL;
     int len = 0;
     uint8_t encoding;
 
@@ -2448,7 +2448,7 @@ int bacnet_character_string_decode(uint8_t *apdu,
         if (len_value > 0) {
             encoding = apdu[0];
             if (len_value > 1) {
-                string_value = (char *)&apdu[1];
+                string_value = (const char *)&apdu[1];
                 (void)characterstring_init(
                     char_string, encoding, string_value, len_value - 1);
             }
@@ -2472,7 +2472,7 @@ int bacnet_character_string_decode(uint8_t *apdu,
  * @deprecated use bacnet_character_string_decode() instead
  */
 int decode_character_string(
-    uint8_t *apdu, uint32_t len_value, BACNET_CHARACTER_STRING *value)
+    const uint8_t *apdu, uint32_t len_value, BACNET_CHARACTER_STRING *value)
 {
     const uint32_t apdu_size = MAX_APDU;
 
@@ -2492,7 +2492,7 @@ int decode_character_string(
  *  or 0 if apdu_size is too small to fit the data
  */
 int bacnet_character_string_application_encode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_CHARACTER_STRING *value)
+    uint8_t *apdu, uint32_t apdu_size, const BACNET_CHARACTER_STRING *value)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
 
@@ -2519,7 +2519,7 @@ int bacnet_character_string_application_encode(
  * or #BACNET_STATUS_ERROR (-1) if malformed
  */
 int bacnet_character_string_application_decode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_CHARACTER_STRING *value)
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_CHARACTER_STRING *value)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     int len = 0;
@@ -2557,7 +2557,7 @@ int bacnet_character_string_application_decode(
  * @return  number of bytes decoded, or zero if tag number mismatch, or
  * #BACNET_STATUS_ERROR (-1) if malformed
  */
-int bacnet_character_string_context_decode(uint8_t *apdu,
+int bacnet_character_string_context_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     uint8_t tag_value,
     BACNET_CHARACTER_STRING *value)
@@ -2599,7 +2599,7 @@ int bacnet_character_string_context_decode(uint8_t *apdu,
  * @deprecated use bacnet_character_string_context_decode() instead
  */
 int decode_context_character_string(
-    uint8_t *apdu, uint8_t tag_value, BACNET_CHARACTER_STRING *value)
+    const uint8_t *apdu, uint8_t tag_value, BACNET_CHARACTER_STRING *value)
 {
     int len = 0; /* return value */
     const uint32_t apdu_size = MAX_APDU;
@@ -2625,7 +2625,7 @@ int decode_context_character_string(
  *
  * @return  number of bytes decoded, or zero if errors occur
  */
-int bacnet_unsigned_decode(uint8_t *apdu,
+int bacnet_unsigned_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     uint32_t len_value,
     BACNET_UNSIGNED_INTEGER *value)
@@ -2720,7 +2720,7 @@ int bacnet_unsigned_decode(uint8_t *apdu,
  * @return  number of bytes decoded, zero if wrong tag number,
  * or #BACNET_STATUS_ERROR (-1) if malformed
  */
-int bacnet_unsigned_context_decode(uint8_t *apdu,
+int bacnet_unsigned_context_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     uint8_t tag_value,
     BACNET_UNSIGNED_INTEGER *value)
@@ -2789,7 +2789,7 @@ int bacnet_unsigned_application_encode(
  * or #BACNET_STATUS_ERROR (-1) if malformed
  */
 int bacnet_unsigned_application_decode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_UNSIGNED_INTEGER *value)
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_UNSIGNED_INTEGER *value)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     int len = 0;
@@ -2827,7 +2827,7 @@ int bacnet_unsigned_application_decode(
  * @deprecated use bacnet_unsigned_decode() instead
  */
 int decode_unsigned(
-    uint8_t *apdu, uint32_t len_value, BACNET_UNSIGNED_INTEGER *value)
+    const uint8_t *apdu, uint32_t len_value, BACNET_UNSIGNED_INTEGER *value)
 {
 #ifdef UINT64_MAX
     const uint32_t apdu_size = 8;
@@ -2852,7 +2852,7 @@ int decode_unsigned(
  * @deprecated use bacnet_unsigned_context_decode() instead
  */
 int decode_context_unsigned(
-    uint8_t *apdu, uint8_t tag_value, BACNET_UNSIGNED_INTEGER *value)
+    const uint8_t *apdu, uint8_t tag_value, BACNET_UNSIGNED_INTEGER *value)
 {
     int len = 0; /* return value */
 #ifdef UINT64_MAX
@@ -2976,7 +2976,7 @@ int encode_application_unsigned(uint8_t *apdu, BACNET_UNSIGNED_INTEGER value)
  * @return  number of bytes decoded, or zero if errors occur
  */
 int bacnet_enumerated_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint32_t len_value, uint32_t *value)
+    const uint8_t *apdu, uint32_t apdu_size, uint32_t len_value, uint32_t *value)
 {
     BACNET_UNSIGNED_INTEGER unsigned_value = 0;
     int len;
@@ -3002,7 +3002,7 @@ int bacnet_enumerated_decode(
  *
  * @return  number of bytes decoded, or zero if errors occur
  */
-int decode_enumerated(uint8_t *apdu, uint32_t len_value, uint32_t *value)
+int decode_enumerated(const uint8_t *apdu, uint32_t len_value, uint32_t *value)
 {
     const uint32_t apdu_size = 4;
 
@@ -3049,7 +3049,7 @@ int bacnet_enumerated_application_encode(
  * or #BACNET_STATUS_ERROR (-1) if malformed
  */
 int bacnet_enumerated_application_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint32_t *value)
+    const uint8_t *apdu, uint32_t apdu_size, uint32_t *value)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     int len = 0;
@@ -3097,7 +3097,7 @@ int bacnet_enumerated_application_decode(
  * #BACNET_STATUS_ERROR (-1) if malformed
  */
 int bacnet_enumerated_context_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint8_t tag_value, uint32_t *value)
+    const uint8_t *apdu, uint32_t apdu_size, uint8_t tag_value, uint32_t *value)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     int len = 0;
@@ -3135,7 +3135,7 @@ int bacnet_enumerated_context_decode(
  *  if wrong tag number or malformed
  * @deprecated use bacnet_enumerated_context_decode() instead
  */
-int decode_context_enumerated(uint8_t *apdu, uint8_t tag_value, uint32_t *value)
+int decode_context_enumerated(const uint8_t *apdu, uint8_t tag_value, uint32_t *value)
 {
     const uint32_t apdu_size = 6;
     int len = 0;
@@ -3229,7 +3229,7 @@ int encode_context_enumerated(uint8_t *apdu, uint8_t tag_number, uint32_t value)
  * @return  number of bytes decoded, or zero if errors occur
  */
 int bacnet_signed_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint32_t len_value, int32_t *value)
+    const uint8_t *apdu, uint32_t apdu_size, uint32_t len_value, int32_t *value)
 {
     int len = 0;
 
@@ -3272,7 +3272,7 @@ int bacnet_signed_decode(
  * or error (-1) if malformed
  */
 int bacnet_signed_context_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint8_t tag_value, int32_t *value)
+    const uint8_t *apdu, uint32_t apdu_size, uint8_t tag_value, int32_t *value)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     int len = 0;
@@ -3337,7 +3337,7 @@ int bacnet_signed_application_encode(
  * or #BACNET_STATUS_ERROR (-1) if malformed
  */
 int bacnet_signed_application_decode(
-    uint8_t *apdu, uint32_t apdu_size, int32_t *value)
+    const uint8_t *apdu, uint32_t apdu_size, int32_t *value)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     int len = 0;
@@ -3375,7 +3375,7 @@ int bacnet_signed_application_decode(
  * wrong tag number, or error (-1) if malformed
  * @deprecated use bacnet_signed_decode() instead
  */
-int decode_signed(uint8_t *apdu, uint32_t len_value, int32_t *value)
+int decode_signed(const uint8_t *apdu, uint32_t len_value, int32_t *value)
 {
     const unsigned apdu_size = 4;
 
@@ -3395,7 +3395,7 @@ int decode_signed(uint8_t *apdu, uint32_t len_value, int32_t *value)
  * wrong tag number, or error (-1) if malformed
  * @deprecated use bacnet_signed_context_decode() instead
  */
-int decode_context_signed(uint8_t *apdu, uint8_t tag_value, int32_t *value)
+int decode_context_signed(const uint8_t *apdu, uint8_t tag_value, int32_t *value)
 {
     const uint32_t apdu_size = 6;
     int len = 0;
@@ -3555,7 +3555,7 @@ int encode_context_real(uint8_t *apdu, uint8_t tag_number, float value)
  * @return  number of bytes decoded, or zero if errors occur
  */
 int bacnet_real_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint32_t len_value, float *value)
+    const uint8_t *apdu, uint32_t apdu_size, uint32_t len_value, float *value)
 {
     int len = 0;
 
@@ -3580,7 +3580,7 @@ int bacnet_real_decode(
  * or error (-1) if malformed
  */
 int bacnet_real_context_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint8_t tag_value, float *value)
+    const uint8_t *apdu, uint32_t apdu_size, uint8_t tag_value, float *value)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     int len = 0;
@@ -3645,7 +3645,7 @@ int bacnet_real_application_encode(
  * or #BACNET_STATUS_ERROR (-1) if malformed
  */
 int bacnet_real_application_decode(
-    uint8_t *apdu, uint32_t apdu_size, float *value)
+    const uint8_t *apdu, uint32_t apdu_size, float *value)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     int len = 0;
@@ -3683,7 +3683,7 @@ int bacnet_real_application_decode(
  *  if wrong tag number or malformed
  * @deprecated use bacnet_real_context_decode() instead
  */
-int decode_context_real(uint8_t *apdu, uint8_t tag_number, float *real_value)
+int decode_context_real(const uint8_t *apdu, uint8_t tag_number, float *real_value)
 {
     uint32_t len_value;
     int len = 0;
@@ -3763,7 +3763,7 @@ int encode_context_double(uint8_t *apdu, uint8_t tag_number, double value)
  * @return  number of bytes decoded, or zero if errors occur
  */
 int bacnet_double_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint32_t len_value, double *value)
+    const uint8_t *apdu, uint32_t apdu_size, uint32_t len_value, double *value)
 {
     int len = 0;
 
@@ -3788,7 +3788,7 @@ int bacnet_double_decode(
  * or error (-1) if malformed
  */
 int bacnet_double_context_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint8_t tag_value, double *value)
+    const uint8_t *apdu, uint32_t apdu_size, uint8_t tag_value, double *value)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     int len = 0;
@@ -3853,7 +3853,7 @@ int bacnet_double_application_encode(
  * or #BACNET_STATUS_ERROR (-1) if malformed
  */
 int bacnet_double_application_decode(
-    uint8_t *apdu, uint32_t apdu_size, double *value)
+    const uint8_t *apdu, uint32_t apdu_size, double *value)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     int len = 0;
@@ -3892,7 +3892,7 @@ int bacnet_double_application_decode(
  * @deprecated use bacnet_double_context_decode() instead
  */
 int decode_context_double(
-    uint8_t *apdu, uint8_t tag_number, double *double_value)
+    const uint8_t *apdu, uint8_t tag_number, double *double_value)
 {
     uint32_t len_value;
     int len = 0;
@@ -3917,7 +3917,7 @@ int decode_context_double(
  *
  * @return the number of apdu bytes consumed.
  */
-int encode_bacnet_time(uint8_t *apdu, BACNET_TIME *btime)
+int encode_bacnet_time(uint8_t *apdu, const BACNET_TIME *btime)
 {
     if (apdu) {
         apdu[0] = btime->hour;
@@ -3939,7 +3939,7 @@ int encode_bacnet_time(uint8_t *apdu, BACNET_TIME *btime)
  *
  * @return the number of apdu bytes consumed.
  */
-int encode_application_time(uint8_t *apdu, BACNET_TIME *btime)
+int encode_application_time(uint8_t *apdu, const BACNET_TIME *btime)
 {
     int len = 0;
     uint8_t *apdu_offset = NULL;
@@ -3965,7 +3965,8 @@ int encode_application_time(uint8_t *apdu, BACNET_TIME *btime)
  *
  * @return the number of apdu bytes consumed.
  */
-int encode_context_time(uint8_t *apdu, uint8_t tag_number, BACNET_TIME *btime)
+int encode_context_time(
+    uint8_t *apdu, uint8_t tag_number, const BACNET_TIME *btime)
 {
     int len = 0; /* return value */
     uint8_t *apdu_offset = NULL;
@@ -3993,7 +3994,7 @@ int encode_context_time(uint8_t *apdu, uint8_t tag_number, BACNET_TIME *btime)
  * @return  number of bytes decoded, or zero if errors occur
  */
 int bacnet_time_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint32_t len_value, BACNET_TIME *value)
+    const uint8_t *apdu, uint32_t apdu_size, uint32_t len_value, BACNET_TIME *value)
 {
     int len = 0;
 
@@ -4025,7 +4026,7 @@ int bacnet_time_decode(
  * or error (-1) if malformed
  */
 int bacnet_time_context_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint8_t tag_value, BACNET_TIME *value)
+    const uint8_t *apdu, uint32_t apdu_size, uint8_t tag_value, BACNET_TIME *value)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     int len = 0;
@@ -4063,7 +4064,7 @@ int bacnet_time_context_decode(
  *  or 0 if apdu_size is too small to fit the data
  */
 int bacnet_time_application_encode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_TIME *value)
+    uint8_t *apdu, uint32_t apdu_size, const BACNET_TIME *value)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
 
@@ -4090,7 +4091,7 @@ int bacnet_time_application_encode(
  * or #BACNET_STATUS_ERROR (-1) if malformed
  */
 int bacnet_time_application_decode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_TIME *value)
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_TIME *value)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     int len = 0;
@@ -4126,7 +4127,7 @@ int bacnet_time_application_decode(
  * @return  number of bytes decoded, or zero if errors occur
  * @deprecated use bacnet_time_decode() instead
  */
-int decode_bacnet_time(uint8_t *apdu, BACNET_TIME *value)
+int decode_bacnet_time(const uint8_t *apdu, BACNET_TIME *value)
 {
     const uint32_t apdu_size = 4;
     const uint32_t len_value = 4;
@@ -4146,7 +4147,7 @@ int decode_bacnet_time(uint8_t *apdu, BACNET_TIME *value)
  * @deprecated use bacnet_time_decode() instead
  */
 int decode_bacnet_time_safe(
-    uint8_t *apdu, uint32_t len_value, BACNET_TIME *btime)
+    const uint8_t *apdu, uint32_t len_value, BACNET_TIME *btime)
 {
     if (len_value != 4) {
         if (btime) {
@@ -4173,7 +4174,7 @@ int decode_bacnet_time_safe(
  *  or wrong tag number
  * @deprecated use bacnet_time_application_decode() instead
  */
-int decode_application_time(uint8_t *apdu, BACNET_TIME *btime)
+int decode_application_time(const uint8_t *apdu, BACNET_TIME *btime)
 {
     int len = 0;
     uint8_t tag_number;
@@ -4203,7 +4204,7 @@ int decode_application_time(uint8_t *apdu, BACNET_TIME *btime)
  * @deprecated use bacnet_time_context_decode() instead
  */
 int decode_context_bacnet_time(
-    uint8_t *apdu, uint8_t tag_number, BACNET_TIME *btime)
+    const uint8_t *apdu, uint8_t tag_number, BACNET_TIME *btime)
 {
     int len = 0;
     if (decode_is_context_tag_with_length(&apdu[len], tag_number, &len)) {
@@ -4231,7 +4232,7 @@ int decode_context_bacnet_time(
  *
  * @return the number of apdu bytes consumed, or #BACNET_STATUS_ERROR
  */
-int encode_bacnet_date(uint8_t *apdu, BACNET_DATE *bdate)
+int encode_bacnet_date(uint8_t *apdu, const BACNET_DATE *bdate)
 {
     if (apdu) {
         if (bdate->year >= 1900) {
@@ -4264,7 +4265,7 @@ int encode_bacnet_date(uint8_t *apdu, BACNET_DATE *bdate)
  *
  * @return the number of apdu bytes consumed.
  */
-int encode_application_date(uint8_t *apdu, BACNET_DATE *bdate)
+int encode_application_date(uint8_t *apdu, const BACNET_DATE *bdate)
 {
     int len = 0;
     uint8_t *apdu_offset = NULL;
@@ -4290,7 +4291,7 @@ int encode_application_date(uint8_t *apdu, BACNET_DATE *bdate)
  *
  * @return the number of apdu bytes consumed.
  */
-int encode_context_date(uint8_t *apdu, uint8_t tag_number, BACNET_DATE *bdate)
+int encode_context_date(uint8_t *apdu, uint8_t tag_number, const BACNET_DATE *bdate)
 {
     int len = 0; /* return value */
     uint8_t *apdu_offset = NULL;
@@ -4316,7 +4317,7 @@ int encode_context_date(uint8_t *apdu, uint8_t tag_number, BACNET_DATE *bdate)
  * @return  number of bytes decoded, or zero if errors occur
  * @deprecated use bacnet_date_decode() instead
  */
-int decode_date(uint8_t *apdu, BACNET_DATE *bdate)
+int decode_date(const uint8_t *apdu, BACNET_DATE *bdate)
 {
     bdate->year = (uint16_t)apdu[0] + 1900;
     bdate->month = apdu[1];
@@ -4338,7 +4339,7 @@ int decode_date(uint8_t *apdu, BACNET_DATE *bdate)
  * @return  number of bytes decoded, or zero if errors occur
  * @deprecated use bacnet_date_decode() instead
  */
-int decode_date_safe(uint8_t *apdu, uint32_t len_value, BACNET_DATE *bdate)
+int decode_date_safe(const uint8_t *apdu, uint32_t len_value, BACNET_DATE *bdate)
 {
     if (len_value != 4) {
         bdate->day = 0;
@@ -4364,7 +4365,7 @@ int decode_date_safe(uint8_t *apdu, uint32_t len_value, BACNET_DATE *bdate)
  * @return  number of bytes decoded, or zero if errors occur
  */
 int bacnet_date_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint32_t len_value, BACNET_DATE *value)
+    const uint8_t *apdu, uint32_t apdu_size, uint32_t len_value, BACNET_DATE *value)
 {
     int len = 0;
 
@@ -4396,7 +4397,10 @@ int bacnet_date_decode(
  * or error (-1) if malformed
  */
 int bacnet_date_context_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint8_t tag_value, BACNET_DATE *value)
+    const uint8_t *apdu,
+    uint32_t apdu_size,
+    uint8_t tag_value,
+    BACNET_DATE *value)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     int len = 0;
@@ -4434,7 +4438,7 @@ int bacnet_date_context_decode(
  *  or 0 if apdu_size is too small to fit the data
  */
 int bacnet_date_application_encode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_DATE *value)
+    uint8_t *apdu, uint32_t apdu_size, const BACNET_DATE *value)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
 
@@ -4461,7 +4465,7 @@ int bacnet_date_application_encode(
  * or #BACNET_STATUS_ERROR (-1) if malformed
  */
 int bacnet_date_application_decode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_DATE *value)
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_DATE *value)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     int len = 0;
@@ -4498,7 +4502,7 @@ int bacnet_date_application_decode(
  *  or wrong tag number
  * @deprecated use bacnet_date_application_decode() instead
  */
-int decode_application_date(uint8_t *apdu, BACNET_DATE *value)
+int decode_application_date(const uint8_t *apdu, BACNET_DATE *value)
 {
     int len = 0;
     const uint32_t apdu_size = BACNET_TAG_SIZE + 4;
@@ -4525,7 +4529,7 @@ int decode_application_date(uint8_t *apdu, BACNET_DATE *value)
  *  if wrong tag number or malformed
  * @deprecated use bacnet_date_context_decode() instead
  */
-int decode_context_date(uint8_t *apdu, uint8_t tag_value, BACNET_DATE *value)
+int decode_context_date(const uint8_t *apdu, uint8_t tag_value, BACNET_DATE *value)
 {
     int len = 0;
     const uint32_t apdu_size = BACNET_TAG_SIZE + 4;

--- a/src/bacnet/bacdcode.h
+++ b/src/bacnet/bacdcode.h
@@ -59,68 +59,76 @@ BACNET_STACK_EXPORT
 int encode_closing_tag(uint8_t *apdu, uint8_t tag_number);
 
 BACNET_STACK_EXPORT
-int bacnet_tag_encode(uint8_t *apdu, uint32_t apdu_size, BACNET_TAG *tag);
+int bacnet_tag_encode(uint8_t *apdu, uint32_t apdu_size, const BACNET_TAG *tag);
 BACNET_STACK_EXPORT
-int bacnet_tag_decode(uint8_t *apdu, uint32_t apdu_size, BACNET_TAG *tag);
+int bacnet_tag_decode(
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_TAG *tag);
 
 BACNET_STACK_EXPORT
-bool bacnet_is_opening_tag(uint8_t *apdu, uint32_t apdu_size);
+bool bacnet_is_opening_tag(const uint8_t *apdu, uint32_t apdu_size);
 BACNET_STACK_EXPORT
-bool bacnet_is_closing_tag(uint8_t *apdu, uint32_t apdu_size);
+bool bacnet_is_closing_tag(const uint8_t *apdu, uint32_t apdu_size);
 BACNET_STACK_EXPORT
-bool bacnet_is_context_specific(uint8_t *apdu, uint32_t apdu_size);
+bool bacnet_is_context_specific(const uint8_t *apdu, uint32_t apdu_size);
 
 BACNET_STACK_EXPORT
 bool bacnet_is_context_tag_number(
-    uint8_t *apdu, uint32_t apdu_size, uint8_t tag_number, int *tag_length,
+    const uint8_t *apdu,
+    uint32_t apdu_size,
+    uint8_t tag_number,
+    int *tag_length,
     uint32_t *len_value_type);
 BACNET_STACK_EXPORT
 int bacnet_tag_number_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint8_t *tag_number);
+    const uint8_t *apdu, uint32_t apdu_size, uint8_t *tag_number);
 BACNET_STACK_EXPORT
 bool bacnet_is_opening_tag_number(
-    uint8_t *apdu, uint32_t apdu_size, uint8_t tag_number, int *tag_length);
+    const uint8_t *apdu,
+    uint32_t apdu_size,
+    uint8_t tag_number,
+    int *tag_length);
 BACNET_STACK_EXPORT
 bool bacnet_is_closing_tag_number(
-    uint8_t *apdu, uint32_t apdu_size, uint8_t tag_number, int *tag_length);
+    const uint8_t *apdu, uint32_t apdu_size, uint8_t tag_number,
+    int *tag_length);
 
 BACNET_STACK_EXPORT
 int bacnet_application_data_length(
     uint8_t tag_number, uint32_t len_value_type);
 BACNET_STACK_EXPORT
 int bacnet_enclosed_data_length(
-    uint8_t *apdu, size_t apdu_size);
+    const uint8_t *apdu, size_t apdu_size);
 
 BACNET_STACK_DEPRECATED("Use bacnet_tag_decode() instead")
 BACNET_STACK_EXPORT
 int bacnet_tag_number_and_value_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint8_t *tag_number, uint32_t *value);
+    const uint8_t *apdu, uint32_t apdu_size, uint8_t *tag_number, uint32_t *value);
 BACNET_STACK_DEPRECATED("Use bacnet_tag_number_decode() instead")
 BACNET_STACK_EXPORT
-int decode_tag_number(uint8_t *apdu, uint8_t *tag_number);
+int decode_tag_number(const uint8_t *apdu, uint8_t *tag_number);
 BACNET_STACK_DEPRECATED("Use bacnet_tag_decode() instead")
 BACNET_STACK_EXPORT
 int decode_tag_number_and_value(
-    uint8_t *apdu, uint8_t *tag_number, uint32_t *value);
+    const uint8_t *apdu, uint8_t *tag_number, uint32_t *value);
 BACNET_STACK_DEPRECATED("Use bacnet_is_opening_tag_number() instead")
 BACNET_STACK_EXPORT
-bool decode_is_opening_tag_number(uint8_t *apdu, uint8_t tag_number);
+bool decode_is_opening_tag_number(const uint8_t *apdu, uint8_t tag_number);
 BACNET_STACK_DEPRECATED("Use bacnet_is_closing_tag_number() instead")
 BACNET_STACK_EXPORT
-bool decode_is_closing_tag_number(uint8_t *apdu, uint8_t tag_number);
+bool decode_is_closing_tag_number(const uint8_t *apdu, uint8_t tag_number);
 BACNET_STACK_DEPRECATED("Use bacnet_is_context_tag_number() instead")
 BACNET_STACK_EXPORT
-bool decode_is_context_tag(uint8_t *apdu, uint8_t tag_number);
+bool decode_is_context_tag(const uint8_t *apdu, uint8_t tag_number);
 BACNET_STACK_DEPRECATED("Use bacnet_is_context_tag_number() instead")
 BACNET_STACK_EXPORT
 bool decode_is_context_tag_with_length(
-    uint8_t *apdu, uint8_t tag_number, int *tag_length);
+    const uint8_t *apdu, uint8_t tag_number, int *tag_length);
 BACNET_STACK_DEPRECATED("Use bacnet_is_opening_tag() instead")
 BACNET_STACK_EXPORT
-bool decode_is_opening_tag(uint8_t *apdu);
+bool decode_is_opening_tag(const uint8_t *apdu);
 BACNET_STACK_DEPRECATED("Use bacnet_is_closing_tag() instead")
 BACNET_STACK_EXPORT
-bool decode_is_closing_tag(uint8_t *apdu);
+bool decode_is_closing_tag(const uint8_t *apdu);
 
 BACNET_STACK_EXPORT
 int encode_application_null(uint8_t *apdu);
@@ -137,54 +145,54 @@ int encode_context_boolean(
     uint8_t *apdu, uint8_t tag_number, bool boolean_value);
 BACNET_STACK_DEPRECATED("Use bacnet_boolean_context_decode() instead")
 BACNET_STACK_EXPORT
-bool decode_context_boolean(uint8_t *apdu);
+bool decode_context_boolean(const uint8_t *apdu);
 BACNET_STACK_EXPORT
 BACNET_STACK_DEPRECATED("Use bacnet_boolean_context_decode() instead")
 int decode_context_boolean2(
-    uint8_t *apdu, uint8_t tag_number, bool *boolean_value);
+    const uint8_t *apdu, uint8_t tag_number, bool *boolean_value);
 
 BACNET_STACK_EXPORT
 int bacnet_boolean_application_encode(
     uint8_t *apdu, uint32_t apdu_size, bool value);
 BACNET_STACK_EXPORT
 int bacnet_boolean_application_decode(
-    uint8_t *apdu, uint32_t apdu_len_max, bool *value);
+    const uint8_t *apdu, uint32_t apdu_len_max, bool *value);
 BACNET_STACK_EXPORT
-int bacnet_boolean_context_decode(uint8_t *apdu,
+int bacnet_boolean_context_decode(const uint8_t *apdu,
     uint32_t apdu_len_max,
     uint8_t tag_value,
     bool *boolean_value);
 
 BACNET_STACK_EXPORT
-int encode_bitstring(uint8_t *apdu, BACNET_BIT_STRING *bit_string);
+int encode_bitstring(uint8_t *apdu, const BACNET_BIT_STRING *bit_string);
 BACNET_STACK_EXPORT
-int encode_application_bitstring(uint8_t *apdu, BACNET_BIT_STRING *bit_string);
+int encode_application_bitstring(uint8_t *apdu, const BACNET_BIT_STRING *bit_string);
 BACNET_STACK_EXPORT
 int encode_context_bitstring(
-    uint8_t *apdu, uint8_t tag_number, BACNET_BIT_STRING *bit_string);
+    uint8_t *apdu, uint8_t tag_number, const BACNET_BIT_STRING *bit_string);
 BACNET_STACK_DEPRECATED("Use bacnet_bitstring_decode() instead")
 BACNET_STACK_EXPORT
 int decode_bitstring(
-    uint8_t *apdu, uint32_t len_value, BACNET_BIT_STRING *bit_string);
+    const uint8_t *apdu, uint32_t len_value, BACNET_BIT_STRING *bit_string);
 BACNET_STACK_DEPRECATED("Use bacnet_bitstring_context_decode() instead")
 BACNET_STACK_EXPORT
 int decode_context_bitstring(
-    uint8_t *apdu, uint8_t tag_number, BACNET_BIT_STRING *bit_string);
+    const uint8_t *apdu, uint8_t tag_number, BACNET_BIT_STRING *bit_string);
 BACNET_STACK_EXPORT
-int bacnet_bitstring_decode(uint8_t *apdu,
+int bacnet_bitstring_decode(const uint8_t *apdu,
     uint32_t apdu_len_max,
     uint32_t len_value,
     BACNET_BIT_STRING *value);
 
 BACNET_STACK_EXPORT
 int bacnet_bitstring_application_encode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_BIT_STRING *value);
+    uint8_t *apdu, uint32_t apdu_size, const BACNET_BIT_STRING *value);
 BACNET_STACK_EXPORT
 int bacnet_bitstring_application_decode(
-    uint8_t *apdu, uint32_t apdu_len_max, BACNET_BIT_STRING *value);
+    const uint8_t *apdu, uint32_t apdu_len_max, BACNET_BIT_STRING *value);
 BACNET_STACK_EXPORT
 int bacnet_bitstring_context_decode(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     uint32_t apdu_len_max,
     uint8_t tag_value,
     BACNET_BIT_STRING *value);
@@ -195,19 +203,19 @@ BACNET_STACK_EXPORT
 int encode_context_real(uint8_t *apdu, uint8_t tag_number, float value);
 BACNET_STACK_DEPRECATED("Use bacnet_real_context_decode() instead")
 BACNET_STACK_EXPORT
-int decode_context_real(uint8_t *apdu, uint8_t tag_number, float *real_value);
+int decode_context_real(const uint8_t *apdu, uint8_t tag_number, float *real_value);
 BACNET_STACK_EXPORT
 int bacnet_real_decode(
-    uint8_t *apdu, uint32_t apdu_len_max, uint32_t len_value, float *value);
+    const uint8_t *apdu, uint32_t apdu_len_max, uint32_t len_value, float *value);
 BACNET_STACK_EXPORT
 int bacnet_real_context_decode(
-    uint8_t *apdu, uint32_t apdu_len_max, uint8_t tag_value, float *value);
+    const uint8_t *apdu, uint32_t apdu_len_max, uint8_t tag_value, float *value);
 BACNET_STACK_EXPORT
 int bacnet_real_application_encode(
     uint8_t *apdu, uint32_t apdu_size, float value);
 BACNET_STACK_EXPORT
 int bacnet_real_application_decode(
-    uint8_t *apdu, uint32_t apdu_len_max, float *value);
+    const uint8_t *apdu, uint32_t apdu_len_max, float *value);
 
 BACNET_STACK_EXPORT
 int encode_application_double(uint8_t *apdu, double value);
@@ -216,19 +224,19 @@ int encode_context_double(uint8_t *apdu, uint8_t tag_number, double value);
 BACNET_STACK_DEPRECATED("Use bacnet_double_context_decode() instead")
 BACNET_STACK_EXPORT
 int decode_context_double(
-    uint8_t *apdu, uint8_t tag_number, double *double_value);
+    const uint8_t *apdu, uint8_t tag_number, double *double_value);
 BACNET_STACK_EXPORT
 int bacnet_double_decode(
-    uint8_t *apdu, uint32_t apdu_len_max, uint32_t len_value, double *value);
+    const uint8_t *apdu, uint32_t apdu_len_max, uint32_t len_value, double *value);
 BACNET_STACK_EXPORT
 int bacnet_double_context_decode(
-    uint8_t *apdu, uint32_t apdu_len_max, uint8_t tag_value, double *value);
+    const uint8_t *apdu, uint32_t apdu_len_max, uint8_t tag_value, double *value);
 BACNET_STACK_EXPORT
 int bacnet_double_application_encode(
     uint8_t *apdu, uint32_t apdu_size, double value);
 BACNET_STACK_EXPORT
 int bacnet_double_application_decode(
-    uint8_t *apdu, uint32_t apdu_len_max, double *value);
+    const uint8_t *apdu, uint32_t apdu_len_max, double *value);
 
 BACNET_STACK_EXPORT
 int encode_bacnet_object_id(
@@ -244,20 +252,22 @@ int encode_application_object_id(
 BACNET_STACK_DEPRECATED("Use bacnet_object_id_decode() instead")
 BACNET_STACK_EXPORT
 int decode_object_id(
-    uint8_t *apdu, BACNET_OBJECT_TYPE *object_type, uint32_t *object_instance);
+    const uint8_t *apdu,
+    BACNET_OBJECT_TYPE *object_type,
+    uint32_t *object_instance);
 BACNET_STACK_DEPRECATED("Use bacnet_object_id_context_decode() instead")
 BACNET_STACK_EXPORT
-int decode_context_object_id(uint8_t *apdu,
+int decode_context_object_id(const uint8_t *apdu,
     uint8_t tag_number,
     BACNET_OBJECT_TYPE *object_type,
     uint32_t *instance);
 BACNET_STACK_EXPORT
-int decode_object_id_safe(uint8_t *apdu,
+int decode_object_id_safe(const uint8_t *apdu,
     uint32_t len_value,
     BACNET_OBJECT_TYPE *object_type,
     uint32_t *object_instance);
 BACNET_STACK_EXPORT
-int bacnet_object_id_decode(uint8_t *apdu,
+int bacnet_object_id_decode(const uint8_t *apdu,
     uint32_t apdu_len_max,
     uint32_t len_value,
     BACNET_OBJECT_TYPE *object_type,
@@ -271,49 +281,49 @@ int bacnet_object_id_application_encode(
     uint32_t object_instance);
 BACNET_STACK_EXPORT
 int bacnet_object_id_application_decode(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     uint32_t apdu_len_max,
     BACNET_OBJECT_TYPE *object_type,
     uint32_t *object_instance);
 BACNET_STACK_EXPORT
 int bacnet_object_id_context_decode(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     uint32_t apdu_len_max,
     uint8_t tag_value,
     BACNET_OBJECT_TYPE *object_type,
     uint32_t *instance);
 
 BACNET_STACK_EXPORT
-int encode_octet_string(uint8_t *apdu, BACNET_OCTET_STRING *octet_string);
+int encode_octet_string(uint8_t *apdu, const BACNET_OCTET_STRING *octet_string);
 BACNET_STACK_EXPORT
 int encode_application_octet_string(
-    uint8_t *apdu, BACNET_OCTET_STRING *octet_string);
+    uint8_t *apdu, const BACNET_OCTET_STRING *octet_string);
 BACNET_STACK_EXPORT
 int encode_context_octet_string(
-    uint8_t *apdu, uint8_t tag_number, BACNET_OCTET_STRING *octet_string);
+    uint8_t *apdu, uint8_t tag_number, const BACNET_OCTET_STRING *octet_string);
 BACNET_STACK_EXPORT
 BACNET_STACK_DEPRECATED("Use bacnet_octet_string_decode() instead")
 int decode_octet_string(
-    uint8_t *apdu, uint32_t len_value, BACNET_OCTET_STRING *octet_string);
+    const uint8_t *apdu, uint32_t len_value, BACNET_OCTET_STRING *octet_string);
 BACNET_STACK_DEPRECATED("Use bacnet_octet_string_context_decode() instead")
 BACNET_STACK_EXPORT
 int decode_context_octet_string(
-    uint8_t *apdu, uint8_t tag_number, BACNET_OCTET_STRING *octet_string);
+    const uint8_t *apdu, uint8_t tag_number, BACNET_OCTET_STRING *octet_string);
 BACNET_STACK_EXPORT
-int bacnet_octet_string_decode(uint8_t *apdu,
+int bacnet_octet_string_decode(const uint8_t *apdu,
     uint32_t apdu_len_max,
     uint32_t len_value,
     BACNET_OCTET_STRING *value);
 
 BACNET_STACK_EXPORT
 int bacnet_octet_string_application_encode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_OCTET_STRING *value);
+    uint8_t *apdu, uint32_t apdu_size, const BACNET_OCTET_STRING *value);
 BACNET_STACK_EXPORT
 int bacnet_octet_string_application_decode(
-    uint8_t *apdu, uint32_t apdu_len_max, BACNET_OCTET_STRING *value);
+    const uint8_t *apdu, uint32_t apdu_len_max, BACNET_OCTET_STRING *value);
 BACNET_STACK_EXPORT
 int bacnet_octet_string_context_decode(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     uint32_t apdu_len_max,
     uint8_t tag_value,
     BACNET_OCTET_STRING *value);
@@ -322,40 +332,44 @@ BACNET_STACK_EXPORT
 uint32_t encode_bacnet_character_string_safe(uint8_t *apdu,
     uint32_t max_apdu,
     uint8_t encoding,
-    char *pString,
+    const char *pString,
     uint32_t length);
 BACNET_STACK_EXPORT
 int encode_bacnet_character_string(
-    uint8_t *apdu, BACNET_CHARACTER_STRING *char_string);
+    uint8_t *apdu, const BACNET_CHARACTER_STRING *char_string);
 BACNET_STACK_EXPORT
 int encode_application_character_string(
-    uint8_t *apdu, BACNET_CHARACTER_STRING *char_string);
+    uint8_t *apdu, const BACNET_CHARACTER_STRING *char_string);
 BACNET_STACK_EXPORT
 int encode_context_character_string(
-    uint8_t *apdu, uint8_t tag_number, BACNET_CHARACTER_STRING *char_string);
+    uint8_t *apdu, uint8_t tag_number, const BACNET_CHARACTER_STRING *char_string);
 BACNET_STACK_DEPRECATED("Use bacnet_character_string_decode() instead")
 BACNET_STACK_EXPORT
 int decode_character_string(
-    uint8_t *apdu, uint32_t len_value, BACNET_CHARACTER_STRING *char_string);
+    const uint8_t *apdu,
+    uint32_t len_value,
+    BACNET_CHARACTER_STRING *char_string);
 BACNET_STACK_DEPRECATED("Use bacnet_character_string_context_decode() instead")
 BACNET_STACK_EXPORT
 int decode_context_character_string(
-    uint8_t *apdu, uint8_t tag_number, BACNET_CHARACTER_STRING *char_string);
+    const uint8_t *apdu,
+    uint8_t tag_number,
+    BACNET_CHARACTER_STRING *char_string);
 BACNET_STACK_EXPORT
-int bacnet_character_string_decode(uint8_t *apdu,
+int bacnet_character_string_decode(const uint8_t *apdu,
     uint32_t apdu_len_max,
     uint32_t len_value,
     BACNET_CHARACTER_STRING *char_string);
 
 BACNET_STACK_EXPORT
 int bacnet_character_string_application_encode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_CHARACTER_STRING *value);
+    uint8_t *apdu, uint32_t apdu_size, const BACNET_CHARACTER_STRING *value);
 BACNET_STACK_EXPORT
 int bacnet_character_string_application_decode(
-    uint8_t *apdu, uint32_t apdu_len_max, BACNET_CHARACTER_STRING *value);
+    const uint8_t *apdu, uint32_t apdu_len_max, BACNET_CHARACTER_STRING *value);
 BACNET_STACK_EXPORT
 int bacnet_character_string_context_decode(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     uint32_t apdu_len_max,
     uint8_t tag_value,
     BACNET_CHARACTER_STRING *value);
@@ -370,13 +384,13 @@ int encode_application_unsigned(uint8_t *apdu, BACNET_UNSIGNED_INTEGER value);
 BACNET_STACK_DEPRECATED("Use bacnet_unsigned_decode() instead")
 BACNET_STACK_EXPORT
 int decode_unsigned(
-    uint8_t *apdu, uint32_t len_value, BACNET_UNSIGNED_INTEGER *value);
+    const uint8_t *apdu, uint32_t len_value, BACNET_UNSIGNED_INTEGER *value);
 BACNET_STACK_DEPRECATED("Use bacnet_unsigned_context_decode() instead")
 BACNET_STACK_EXPORT
 int decode_context_unsigned(
-    uint8_t *apdu, uint8_t tag_number, BACNET_UNSIGNED_INTEGER *value);
+    const uint8_t *apdu, uint8_t tag_number, BACNET_UNSIGNED_INTEGER *value);
 BACNET_STACK_EXPORT
-int bacnet_unsigned_decode(uint8_t *apdu,
+int bacnet_unsigned_decode(const uint8_t *apdu,
     uint32_t apdu_max_len,
     uint32_t len_value,
     BACNET_UNSIGNED_INTEGER *value);
@@ -386,10 +400,10 @@ int bacnet_unsigned_application_encode(
     uint8_t *apdu, uint32_t apdu_size, BACNET_UNSIGNED_INTEGER value);
 BACNET_STACK_EXPORT
 int bacnet_unsigned_application_decode(
-    uint8_t *apdu, uint32_t apdu_len_max, BACNET_UNSIGNED_INTEGER *value);
+    const uint8_t *apdu, uint32_t apdu_len_max, BACNET_UNSIGNED_INTEGER *value);
 BACNET_STACK_EXPORT
 int bacnet_unsigned_context_decode(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     uint32_t apdu_len_max,
     uint8_t tag_number,
     BACNET_UNSIGNED_INTEGER *value);
@@ -402,23 +416,23 @@ BACNET_STACK_EXPORT
 int encode_context_signed(uint8_t *apdu, uint8_t tag_number, int32_t value);
 BACNET_STACK_DEPRECATED("Use bacnet_signed_decode() instead")
 BACNET_STACK_EXPORT
-int decode_signed(uint8_t *apdu, uint32_t len_value, int32_t *value);
+int decode_signed(const uint8_t *apdu, uint32_t len_value, int32_t *value);
 BACNET_STACK_DEPRECATED("Use bacnet_signed_context_decode() instead")
 BACNET_STACK_EXPORT
-int decode_context_signed(uint8_t *apdu, uint8_t tag_number, int32_t *value);
+int decode_context_signed(const uint8_t *apdu, uint8_t tag_number, int32_t *value);
 
 BACNET_STACK_EXPORT
 int bacnet_signed_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint32_t len_value, int32_t *value);
+    const uint8_t *apdu, uint32_t apdu_size, uint32_t len_value, int32_t *value);
 BACNET_STACK_EXPORT
 int bacnet_signed_context_decode(
-    uint8_t *apdu, uint32_t apdu_size, uint8_t tag_value, int32_t *value);
+    const uint8_t *apdu, uint32_t apdu_size, uint8_t tag_value, int32_t *value);
 BACNET_STACK_EXPORT
 int bacnet_signed_application_encode(
     uint8_t *apdu, uint32_t apdu_size, int32_t value);
 BACNET_STACK_EXPORT
 int bacnet_signed_application_decode(
-    uint8_t *apdu, uint32_t apdu_size, int32_t *value);
+    const uint8_t *apdu, uint32_t apdu_size, int32_t *value);
 
 BACNET_STACK_EXPORT
 int encode_bacnet_enumerated(uint8_t *apdu, uint32_t value);
@@ -429,14 +443,14 @@ int encode_context_enumerated(
     uint8_t *apdu, uint8_t tag_number, uint32_t value);
 BACNET_STACK_DEPRECATED("Use bacnet_enumerated_decode() instead")
 BACNET_STACK_EXPORT
-int decode_enumerated(uint8_t *apdu, uint32_t len_value, uint32_t *value);
+int decode_enumerated(const uint8_t *apdu, uint32_t len_value, uint32_t *value);
 BACNET_STACK_DEPRECATED("Use bacnet_enumerated_context_decode() instead")
 BACNET_STACK_EXPORT
 int decode_context_enumerated(
-    uint8_t *apdu, uint8_t tag_value, uint32_t *value);
+    const uint8_t *apdu, uint8_t tag_value, uint32_t *value);
 BACNET_STACK_EXPORT
 int bacnet_enumerated_decode(
-    uint8_t *apdu, uint32_t apdu_max_len, uint32_t len_value, uint32_t *value);
+    const uint8_t *apdu, uint32_t apdu_max_len, uint32_t len_value, uint32_t *value);
 
 
 BACNET_STACK_EXPORT
@@ -444,80 +458,84 @@ int bacnet_enumerated_application_encode(
     uint8_t *apdu, uint32_t apdu_size, uint32_t value);
 BACNET_STACK_EXPORT
 int bacnet_enumerated_application_decode(
-    uint8_t *apdu, uint32_t apdu_len_max, uint32_t *value);
+    const uint8_t *apdu, uint32_t apdu_len_max, uint32_t *value);
 BACNET_STACK_EXPORT
 int bacnet_enumerated_context_decode(
-    uint8_t *apdu, uint32_t apdu_len_max, uint8_t tag_value, uint32_t *value);
+    const uint8_t *apdu, uint32_t apdu_len_max, uint8_t tag_value, uint32_t *value);
 
 BACNET_STACK_EXPORT
-int encode_bacnet_time(uint8_t *apdu, BACNET_TIME *btime);
+int encode_bacnet_time(uint8_t *apdu, const BACNET_TIME *btime);
 BACNET_STACK_EXPORT
-int encode_application_time(uint8_t *apdu, BACNET_TIME *btime);
+int encode_application_time(uint8_t *apdu, const BACNET_TIME *btime);
 BACNET_STACK_EXPORT
-int encode_context_time(uint8_t *apdu, uint8_t tag_number, BACNET_TIME *btime);
+int encode_context_time(
+    uint8_t *apdu, uint8_t tag_number, const BACNET_TIME *btime);
 BACNET_STACK_DEPRECATED("Use bacnet_time_decode() instead")
 BACNET_STACK_EXPORT
-int decode_bacnet_time(uint8_t *apdu, BACNET_TIME *btime);
+int decode_bacnet_time(const uint8_t *apdu, BACNET_TIME *btime);
 BACNET_STACK_DEPRECATED("Use bacnet_time_decode() instead")
 BACNET_STACK_EXPORT
 int decode_bacnet_time_safe(
-    uint8_t *apdu, uint32_t len_value, BACNET_TIME *btime);
+    const uint8_t *apdu, uint32_t len_value, BACNET_TIME *btime);
 BACNET_STACK_DEPRECATED("Use bacnet_time_application_decode() instead")
 BACNET_STACK_EXPORT
-int decode_application_time(uint8_t *apdu, BACNET_TIME *btime);
+int decode_application_time(const uint8_t *apdu, BACNET_TIME *btime);
 BACNET_STACK_DEPRECATED("Use bacnet_time_context_decode() instead")
 BACNET_STACK_EXPORT
 int decode_context_bacnet_time(
-    uint8_t *apdu, uint8_t tag_number, BACNET_TIME *btime);
+    const uint8_t *apdu, uint8_t tag_number, BACNET_TIME *btime);
 BACNET_STACK_EXPORT
-int bacnet_time_decode(uint8_t *apdu,
+int bacnet_time_decode(const uint8_t *apdu,
     uint32_t apdu_len_max,
     uint32_t len_value,
     BACNET_TIME *value);
 BACNET_STACK_EXPORT
-int bacnet_time_context_decode(uint8_t *apdu,
+int bacnet_time_context_decode(const uint8_t *apdu,
     uint32_t apdu_len_max,
     uint8_t tag_value,
     BACNET_TIME *value);
 BACNET_STACK_EXPORT
 int bacnet_time_application_encode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_TIME *value);
+    uint8_t *apdu, uint32_t apdu_size, const BACNET_TIME *value);
 BACNET_STACK_EXPORT
 int bacnet_time_application_decode(
-    uint8_t *apdu, uint32_t apdu_len_max, BACNET_TIME *value);
+    const uint8_t *apdu, uint32_t apdu_len_max, BACNET_TIME *value);
 
 BACNET_STACK_EXPORT
-int encode_bacnet_date(uint8_t *apdu, BACNET_DATE *bdate);
+int encode_bacnet_date(uint8_t *apdu, const BACNET_DATE *bdate);
 BACNET_STACK_EXPORT
-int encode_application_date(uint8_t *apdu, BACNET_DATE *bdate);
+int encode_application_date(uint8_t *apdu, const BACNET_DATE *bdate);
 BACNET_STACK_EXPORT
-int encode_context_date(uint8_t *apdu, uint8_t tag_number, BACNET_DATE *bdate);
+int encode_context_date(
+    uint8_t *apdu, uint8_t tag_number, const BACNET_DATE *bdate);
 BACNET_STACK_DEPRECATED("Use bacnet_date_decode() instead")
 BACNET_STACK_EXPORT
-int decode_date(uint8_t *apdu, BACNET_DATE *bdate);
+int decode_date(const uint8_t *apdu, BACNET_DATE *bdate);
 BACNET_STACK_DEPRECATED("Use bacnet_date_decode() instead")
 BACNET_STACK_EXPORT
-int decode_date_safe(uint8_t *apdu, uint32_t len_value, BACNET_DATE *bdate);
+int decode_date_safe(
+    const uint8_t *apdu, uint32_t len_value, BACNET_DATE *bdate);
 BACNET_STACK_DEPRECATED("Use bacnet_date_application_decode() instead")
 BACNET_STACK_EXPORT
-int decode_application_date(uint8_t *apdu, BACNET_DATE *bdate);
+int decode_application_date(const uint8_t *apdu, BACNET_DATE *bdate);
 BACNET_STACK_DEPRECATED("Use bacnet_date_context_decode() instead")
 BACNET_STACK_EXPORT
-int decode_context_date(uint8_t *apdu, uint8_t tag_number, BACNET_DATE *bdate);
+int decode_context_date(
+    const uint8_t *apdu, uint8_t tag_number, BACNET_DATE *bdate);
 BACNET_STACK_EXPORT
-int bacnet_date_decode(uint8_t *apdu,
+int bacnet_date_decode(const uint8_t *apdu,
     uint32_t apdu_len_max,
     uint32_t len_value,
     BACNET_DATE *value);
 
 BACNET_STACK_EXPORT
 int bacnet_date_application_encode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_DATE *value);
+    uint8_t *apdu, uint32_t apdu_size, const BACNET_DATE *value);
 BACNET_STACK_EXPORT
 int bacnet_date_application_decode(
-    uint8_t *apdu, uint32_t apdu_len_max, BACNET_DATE *value);
+    const uint8_t *apdu, uint32_t apdu_len_max, BACNET_DATE *value);
 BACNET_STACK_EXPORT
-int bacnet_date_context_decode(uint8_t *apdu,
+int bacnet_date_context_decode(const uint8_t *apdu,
     uint32_t apdu_len_max,
     uint8_t tag_value,
     BACNET_DATE *value);

--- a/src/bacnet/bacdest.c
+++ b/src/bacnet/bacdest.c
@@ -67,7 +67,8 @@ void bacnet_destination_default_init(BACNET_DESTINATION *destination)
  * @param r2 - BACnetRecipient 2 structure
  * @return true if r1 and r2 are the same
  */
-bool bacnet_recipient_same(BACNET_RECIPIENT *r1, BACNET_RECIPIENT *r2)
+bool bacnet_recipient_same(
+    const BACNET_RECIPIENT *r1, const BACNET_RECIPIENT *r2)
 {
     bool status = false;
 
@@ -98,7 +99,7 @@ bool bacnet_recipient_same(BACNET_RECIPIENT *r1, BACNET_RECIPIENT *r2)
  * @param src - BACnetRecipient 1 structure
  * @param dest - BACnetRecipient 2 structure
  */
-void bacnet_recipient_copy(BACNET_RECIPIENT *dest, BACNET_RECIPIENT *src)
+void bacnet_recipient_copy(BACNET_RECIPIENT *dest, const BACNET_RECIPIENT *src)
 {
     if (dest && src) {
         memmove(dest, src, sizeof(BACNET_RECIPIENT));
@@ -110,7 +111,7 @@ void bacnet_recipient_copy(BACNET_RECIPIENT *dest, BACNET_RECIPIENT *src)
  * @param recipient - BACnetRecipient structure
  * @return true if BACnetRecipient is equal to the device object wildcard
  */
-bool bacnet_recipient_device_wildcard(BACNET_RECIPIENT *recipient)
+bool bacnet_recipient_device_wildcard(const BACNET_RECIPIENT *recipient)
 {
     bool status = false;
 
@@ -130,7 +131,7 @@ bool bacnet_recipient_device_wildcard(BACNET_RECIPIENT *recipient)
  * @param recipient - BACnetRecipient structure
  * @return true if BACnetRecipient is a valid device object instance
  */
-bool bacnet_recipient_device_valid(BACNET_RECIPIENT *recipient)
+bool bacnet_recipient_device_valid(const BACNET_RECIPIENT *recipient)
 {
     bool status = false;
 
@@ -151,7 +152,8 @@ bool bacnet_recipient_device_valid(BACNET_RECIPIENT *recipient)
  * @param d2 - BACnetDestination 2 structure
  * @return true if dest1 and dest2 are the same
  */
-bool bacnet_destination_same(BACNET_DESTINATION *d1, BACNET_DESTINATION *d2)
+bool bacnet_destination_same(
+    const BACNET_DESTINATION *d1, const BACNET_DESTINATION *d2)
 {
     bool status = false;
 
@@ -185,7 +187,8 @@ bool bacnet_destination_same(BACNET_DESTINATION *d1, BACNET_DESTINATION *d2)
  * @param dest - BACnetDestination 1 structure
  * @param src - BACnetDestination 2 structure
  */
-void bacnet_destination_copy(BACNET_DESTINATION *dest, BACNET_DESTINATION *src)
+void bacnet_destination_copy(
+    BACNET_DESTINATION *dest, const BACNET_DESTINATION *src)
 {
     if (dest && src) {
         memmove(dest, src, sizeof(BACNET_DESTINATION));
@@ -197,7 +200,7 @@ void bacnet_destination_copy(BACNET_DESTINATION *dest, BACNET_DESTINATION *src)
  * @param d1 - BACnetDestination 1 structure
  * @return true if d1 and d2 (defaults) are the same
  */
-bool bacnet_destination_default(BACNET_DESTINATION *d1)
+bool bacnet_destination_default(const BACNET_DESTINATION *d1)
 {
     BACNET_DESTINATION d2 = { 0 };
 
@@ -224,7 +227,8 @@ bool bacnet_destination_default(BACNET_DESTINATION *d1)
  *
  * @return bytes encoded or zero on error.
  */
-int bacnet_destination_encode(uint8_t *apdu, BACNET_DESTINATION *destination)
+int bacnet_destination_encode(
+    uint8_t *apdu, const BACNET_DESTINATION *destination)
 {
     int apdu_len = 0, len = 0;
 
@@ -300,7 +304,7 @@ int bacnet_destination_encode(uint8_t *apdu, BACNET_DESTINATION *destination)
  * @return length of the APDU buffer, or 0 if not able to encode
  */
 int bacnet_destination_context_encode(
-    uint8_t *apdu, uint8_t tag_number, BACNET_DESTINATION *destination)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_DESTINATION *destination)
 {
     int len = 0;
     int apdu_len = 0;
@@ -343,7 +347,7 @@ int bacnet_destination_context_encode(
  * @return bytes encoded or #BACNET_STATUS_REJECT on error.
  */
 int bacnet_destination_decode(
-    uint8_t *apdu, int apdu_size, BACNET_DESTINATION *destination)
+    const uint8_t *apdu, int apdu_size, BACNET_DESTINATION *destination)
 {
     int len = 0, apdu_len = 0;
     BACNET_APPLICATION_DATA_VALUE value = { 0 };
@@ -519,7 +523,7 @@ int bacnet_destination_to_ascii(
     buf_len += bacapp_snprintf_shift(len, &buf, &buf_size);
     comma = false;
     for (i = 0; i < 7; i++) {
-        if (bitstring_bit((BACNET_BIT_STRING *)&bacdest->ValidDays, i)) {
+        if (bitstring_bit(&bacdest->ValidDays, i)) {
             if (comma) {
                 len = snprintf(buf, buf_size, ",");
                 buf_len += bacapp_snprintf_shift(len, &buf, &buf_size);
@@ -602,15 +606,12 @@ int bacnet_destination_to_ascii(
     comma = false;
     /* TODO remove casting when bitstring_bit() has const added - Github issue
      * #320 */
-    if (bitstring_bit(
-            (BACNET_BIT_STRING *)&bacdest->Transitions,
-            TRANSITION_TO_OFFNORMAL)) {
+    if (bitstring_bit(&bacdest->Transitions, TRANSITION_TO_OFFNORMAL)) {
         len = snprintf(buf, buf_size, "to-offnormal");
         buf_len += bacapp_snprintf_shift(len, &buf, &buf_size);
         comma = true;
     }
-    if (bitstring_bit(
-            (BACNET_BIT_STRING *)&bacdest->Transitions, TRANSITION_TO_FAULT)) {
+    if (bitstring_bit(&bacdest->Transitions, TRANSITION_TO_FAULT)) {
         if (comma) {
             len = snprintf(buf, buf_size, ",");
             buf_len += bacapp_snprintf_shift(len, &buf, &buf_size);
@@ -619,8 +620,7 @@ int bacnet_destination_to_ascii(
         buf_len += bacapp_snprintf_shift(len, &buf, &buf_size);
         comma = true;
     }
-    if (bitstring_bit(
-            (BACNET_BIT_STRING *)&bacdest->Transitions, TRANSITION_TO_NORMAL)) {
+    if (bitstring_bit(&bacdest->Transitions, TRANSITION_TO_NORMAL)) {
         if (comma) {
             len = snprintf(buf, buf_size, ",");
             buf_len += bacapp_snprintf_shift(len, &buf, &buf_size);

--- a/src/bacnet/bacdest.h
+++ b/src/bacnet/bacdest.h
@@ -62,31 +62,35 @@ extern "C" {
 #endif /* __cplusplus */
 
 BACNET_STACK_EXPORT
-int bacnet_destination_encode(uint8_t *apdu, BACNET_DESTINATION *destination);
+int bacnet_destination_encode(
+    uint8_t *apdu, const BACNET_DESTINATION *destination);
 BACNET_STACK_EXPORT
 int bacnet_destination_context_encode(
-    uint8_t *apdu, uint8_t tag_number, BACNET_DESTINATION *destination);
+    uint8_t *apdu, uint8_t tag_number, const BACNET_DESTINATION *destination);
 BACNET_STACK_EXPORT
 int bacnet_destination_decode(
-    uint8_t *apdu, int apdu_len, BACNET_DESTINATION *destination);
+    const uint8_t *apdu, int apdu_len, BACNET_DESTINATION *destination);
 BACNET_STACK_EXPORT
 void bacnet_destination_default_init(BACNET_DESTINATION *destination);
 BACNET_STACK_EXPORT
-bool bacnet_destination_default(BACNET_DESTINATION *destination);
+bool bacnet_destination_default(const BACNET_DESTINATION *destination);
 BACNET_STACK_EXPORT
 bool bacnet_destination_same(
-    BACNET_DESTINATION *dest1, BACNET_DESTINATION *dest2);
+    const BACNET_DESTINATION *dest1, const BACNET_DESTINATION *dest2);
 BACNET_STACK_EXPORT
-void bacnet_destination_copy(BACNET_DESTINATION *dest, BACNET_DESTINATION *src);
+void bacnet_destination_copy(
+    BACNET_DESTINATION *dest, const BACNET_DESTINATION *src);
 
 BACNET_STACK_EXPORT
-void bacnet_recipient_copy(BACNET_RECIPIENT *dest, BACNET_RECIPIENT *src);
+void bacnet_recipient_copy(
+    BACNET_RECIPIENT *dest, const BACNET_RECIPIENT *src);
 BACNET_STACK_EXPORT
-bool bacnet_recipient_same(BACNET_RECIPIENT *r1, BACNET_RECIPIENT *r2);
+bool bacnet_recipient_same(
+    const BACNET_RECIPIENT *r1, const BACNET_RECIPIENT *r2);
 BACNET_STACK_EXPORT
-bool bacnet_recipient_device_wildcard(BACNET_RECIPIENT *recipient);
+bool bacnet_recipient_device_wildcard(const BACNET_RECIPIENT *recipient);
 BACNET_STACK_EXPORT
-bool bacnet_recipient_device_valid(BACNET_RECIPIENT *recipient);
+bool bacnet_recipient_device_valid(const BACNET_RECIPIENT *recipient);
 
 BACNET_STACK_EXPORT
 int bacnet_destination_to_ascii(

--- a/src/bacnet/bacdevobjpropref.c
+++ b/src/bacnet/bacdevobjpropref.c
@@ -26,7 +26,7 @@
  */
 int bacapp_encode_context_device_obj_property_ref(uint8_t *apdu,
     uint8_t tag_number,
-    BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value)
+    const BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value)
 {
     int len;
     int apdu_len = 0;
@@ -69,7 +69,7 @@ int bacapp_encode_context_device_obj_property_ref(uint8_t *apdu,
  * @return Bytes encoded.
  */
 int bacapp_encode_device_obj_property_ref(
-    uint8_t *apdu, BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value)
+    uint8_t *apdu, const BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value)
 {
     int len;
     int apdu_len = 0;
@@ -131,7 +131,7 @@ int bacapp_encode_device_obj_property_ref(
  *
  * @return number of bytes decoded or BACNET_STATUS_ERROR on failure.
  */
-int bacnet_device_object_property_reference_decode(uint8_t *apdu,
+int bacnet_device_object_property_reference_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value)
 {
@@ -226,7 +226,7 @@ int bacnet_device_object_property_reference_decode(uint8_t *apdu,
  *
  * @return number of bytes decoded or BACNET_STATUS_ERROR on failure.
  */
-int bacnet_device_object_property_reference_context_decode(uint8_t *apdu,
+int bacnet_device_object_property_reference_context_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     uint8_t tag_number,
     BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value)
@@ -267,8 +267,8 @@ int bacnet_device_object_property_reference_context_decode(uint8_t *apdu,
  * @return true if the values are the same
  */
 bool bacnet_device_object_property_reference_same(
-    BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value1,
-    BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value2)
+    const BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value1,
+    const BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value2)
 {
     bool status = false;
 
@@ -309,7 +309,7 @@ bool bacnet_device_object_property_reference_same(
  * @deprecated Use bacnet_device_object_property_reference_decode() instead
  */
 int bacapp_decode_device_obj_property_ref(
-    uint8_t *apdu, BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value)
+    const uint8_t *apdu, BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value)
 {
     return bacnet_device_object_property_reference_decode(
         apdu, MAX_APDU, value);
@@ -328,7 +328,7 @@ int bacapp_decode_device_obj_property_ref(
  * @deprecated Use bacnet_device_object_property_reference_context_decode()
  * instead
  */
-int bacapp_decode_context_device_obj_property_ref(uint8_t *apdu,
+int bacapp_decode_context_device_obj_property_ref(const uint8_t *apdu,
     uint8_t tag_number,
     BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value)
 {
@@ -352,7 +352,7 @@ int bacapp_decode_context_device_obj_property_ref(uint8_t *apdu,
  * @return Bytes encoded or 0 on failure.
  */
 int bacapp_encode_context_device_obj_ref(
-    uint8_t *apdu, uint8_t tag_number, BACNET_DEVICE_OBJECT_REFERENCE *value)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_DEVICE_OBJECT_REFERENCE *value)
 {
     int len;
     int apdu_len = 0;
@@ -389,7 +389,7 @@ int bacapp_encode_context_device_obj_ref(
  * @return Bytes encoded or 0 on failure.
  */
 int bacapp_encode_device_obj_ref(
-    uint8_t *apdu, BACNET_DEVICE_OBJECT_REFERENCE *value)
+    uint8_t *apdu, const BACNET_DEVICE_OBJECT_REFERENCE *value)
 {
     int len;
     int apdu_len = 0;
@@ -431,7 +431,7 @@ int bacapp_encode_device_obj_ref(
  * @return number of bytes decoded or BACNET_STATUS_ERROR on failure.
  */
 int bacnet_device_object_reference_decode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_DEVICE_OBJECT_REFERENCE *value)
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_DEVICE_OBJECT_REFERENCE *value)
 {
     int len;
     int apdu_len = 0;
@@ -489,7 +489,7 @@ int bacnet_device_object_reference_decode(
  *
  * @return number of bytes decoded or BACNET_STATUS_ERROR on failure.
  */
-int bacnet_device_object_reference_context_decode(uint8_t *apdu,
+int bacnet_device_object_reference_context_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     uint8_t tag_number,
     BACNET_DEVICE_OBJECT_REFERENCE *value)
@@ -529,8 +529,9 @@ int bacnet_device_object_reference_context_decode(uint8_t *apdu,
  * @param value2 - value 2 structure
  * @return true if the values are the same
  */
-bool bacnet_device_object_reference_same(BACNET_DEVICE_OBJECT_REFERENCE *value1,
-    BACNET_DEVICE_OBJECT_REFERENCE *value2)
+bool bacnet_device_object_reference_same(
+    const BACNET_DEVICE_OBJECT_REFERENCE *value1,
+    const BACNET_DEVICE_OBJECT_REFERENCE *value2)
 {
     bool status = false;
 
@@ -564,7 +565,7 @@ bool bacnet_device_object_reference_same(BACNET_DEVICE_OBJECT_REFERENCE *value1,
  * @deprecated Use bacnet_device_object_reference_decode() instead.
  */
 int bacapp_decode_device_obj_ref(
-    uint8_t *apdu, BACNET_DEVICE_OBJECT_REFERENCE *value)
+    const uint8_t *apdu, BACNET_DEVICE_OBJECT_REFERENCE *value)
 {
     return bacnet_device_object_reference_decode(apdu, MAX_APDU, value);
 }
@@ -582,7 +583,7 @@ int bacapp_decode_device_obj_ref(
  * @deprecated Use bacnet_device_object_reference_context_decode() instead.
  */
 int bacapp_decode_context_device_obj_ref(
-    uint8_t *apdu, uint8_t tag_number, BACNET_DEVICE_OBJECT_REFERENCE *value)
+    const uint8_t *apdu, uint8_t tag_number, BACNET_DEVICE_OBJECT_REFERENCE *value)
 {
     return bacnet_device_object_reference_context_decode(
         apdu, MAX_APDU, tag_number, value);
@@ -604,7 +605,7 @@ int bacapp_decode_context_device_obj_ref(
  * @return length of the APDU buffer
  */
 int bacapp_encode_obj_property_ref(
-    uint8_t *apdu, BACNET_OBJECT_PROPERTY_REFERENCE *reference)
+    uint8_t *apdu, const BACNET_OBJECT_PROPERTY_REFERENCE *reference)
 {
     int len = 0;
     int apdu_len = 0;
@@ -643,7 +644,7 @@ int bacapp_encode_obj_property_ref(
  */
 int bacapp_encode_context_obj_property_ref(uint8_t *apdu,
     uint8_t tag_number,
-    BACNET_OBJECT_PROPERTY_REFERENCE *reference)
+    const BACNET_OBJECT_PROPERTY_REFERENCE *reference)
 {
     int len = 0;
     int apdu_len = 0;
@@ -683,7 +684,7 @@ int bacapp_encode_context_obj_property_ref(uint8_t *apdu,
  * @param reference - BACnetObjectPropertyReference to decode into
  * @return number of bytes decoded or BACNET_STATUS_ERROR on failure.
  */
-int bacapp_decode_obj_property_ref(uint8_t *apdu,
+int bacapp_decode_obj_property_ref(const uint8_t *apdu,
     uint16_t apdu_size,
     BACNET_OBJECT_PROPERTY_REFERENCE *reference)
 {
@@ -755,7 +756,7 @@ int bacapp_decode_obj_property_ref(uint8_t *apdu,
  *
  * @return number of bytes decoded or BACNET_STATUS_ERROR on failure.
  */
-int bacapp_decode_context_obj_property_ref(uint8_t *apdu,
+int bacapp_decode_context_obj_property_ref(const uint8_t *apdu,
     uint16_t apdu_size,
     uint8_t tag_number,
     BACNET_OBJECT_PROPERTY_REFERENCE *value)
@@ -795,8 +796,8 @@ int bacapp_decode_context_obj_property_ref(uint8_t *apdu,
  * @return true if the values are the same
  */
 bool bacnet_object_property_reference_same(
-    BACNET_OBJECT_PROPERTY_REFERENCE *value1,
-    BACNET_OBJECT_PROPERTY_REFERENCE *value2)
+    const BACNET_OBJECT_PROPERTY_REFERENCE *value1,
+    const BACNET_OBJECT_PROPERTY_REFERENCE *value2)
 {
     bool status = false;
 

--- a/src/bacnet/bacdevobjpropref.h
+++ b/src/bacnet/bacdevobjpropref.h
@@ -57,94 +57,107 @@ extern "C" {
 
 BACNET_STACK_EXPORT
 int bacapp_encode_device_obj_property_ref(
-    uint8_t *apdu, BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value);
+    uint8_t *apdu, const BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value);
 
 BACNET_STACK_EXPORT
 int bacapp_encode_context_device_obj_property_ref(uint8_t *apdu,
     uint8_t tag_number,
-    BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value);
+    const BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value);
 
 BACNET_STACK_DEPRECATED(
     "Use bacnet_device_object_property_reference_decode() instead")
 BACNET_STACK_EXPORT
 int bacapp_decode_device_obj_property_ref(
-    uint8_t *apdu, BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value);
+    const uint8_t *apdu, BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value);
 
 BACNET_STACK_DEPRECATED(
     "Use bacnet_device_object_property_reference_context_decode() instead")
 BACNET_STACK_EXPORT
-int bacapp_decode_context_device_obj_property_ref(uint8_t *apdu,
+int bacapp_decode_context_device_obj_property_ref(const uint8_t *apdu,
     uint8_t tag_number,
     BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value);
 
 BACNET_STACK_EXPORT
 int bacapp_encode_device_obj_ref(
-    uint8_t *apdu, BACNET_DEVICE_OBJECT_REFERENCE *value);
+    uint8_t *apdu, const BACNET_DEVICE_OBJECT_REFERENCE *value);
 
 BACNET_STACK_EXPORT
 int bacapp_encode_context_device_obj_ref(
-    uint8_t *apdu, uint8_t tag_number, BACNET_DEVICE_OBJECT_REFERENCE *value);
+    uint8_t *apdu,
+    uint8_t tag_number,
+    const BACNET_DEVICE_OBJECT_REFERENCE *value);
 
 BACNET_STACK_EXPORT
 int bacapp_decode_device_obj_ref(
-    uint8_t *apdu, BACNET_DEVICE_OBJECT_REFERENCE *value);
+    const uint8_t *apdu, BACNET_DEVICE_OBJECT_REFERENCE *value);
 
 BACNET_STACK_EXPORT
 int bacapp_decode_context_device_obj_ref(
-    uint8_t *apdu, uint8_t tag_number, BACNET_DEVICE_OBJECT_REFERENCE *value);
+    const uint8_t *apdu,
+    uint8_t tag_number,
+    BACNET_DEVICE_OBJECT_REFERENCE *value);
 
 BACNET_STACK_EXPORT
 int bacapp_encode_obj_property_ref(
-    uint8_t *apdu, BACNET_OBJECT_PROPERTY_REFERENCE *value);
+    uint8_t *apdu, const BACNET_OBJECT_PROPERTY_REFERENCE *value);
 
 BACNET_STACK_EXPORT
 int bacapp_encode_context_obj_property_ref(
-    uint8_t *apdu, uint8_t tag_number, BACNET_OBJECT_PROPERTY_REFERENCE *value);
+    uint8_t *apdu,
+    uint8_t tag_number,
+    const BACNET_OBJECT_PROPERTY_REFERENCE *value);
 
 BACNET_STACK_EXPORT
-int bacapp_decode_obj_property_ref(uint8_t *apdu,
+int bacapp_decode_obj_property_ref(
+    const uint8_t *apdu,
     uint16_t apdu_len_max,
     BACNET_OBJECT_PROPERTY_REFERENCE *value);
 
 BACNET_STACK_EXPORT
-int bacapp_decode_context_obj_property_ref(uint8_t *apdu,
+int bacapp_decode_context_obj_property_ref(
+    const uint8_t *apdu,
     uint16_t apdu_len_max,
     uint8_t tag_number,
     BACNET_OBJECT_PROPERTY_REFERENCE *value);
 
 BACNET_STACK_EXPORT
-int bacnet_device_object_property_reference_decode(uint8_t *apdu,
+int bacnet_device_object_property_reference_decode(
+    const uint8_t *apdu,
     uint32_t apdu_size,
     BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value);
 BACNET_STACK_EXPORT
-int bacnet_device_object_property_reference_context_decode(uint8_t *apdu,
+int bacnet_device_object_property_reference_context_decode(
+    const uint8_t *apdu,
     uint32_t apdu_size,
     uint8_t tag_number,
     BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value);
 
 BACNET_STACK_EXPORT
 int bacnet_device_object_reference_decode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_DEVICE_OBJECT_REFERENCE *value);
+    const uint8_t *apdu,
+    uint32_t apdu_size,
+    BACNET_DEVICE_OBJECT_REFERENCE *value);
 BACNET_STACK_EXPORT
-int bacnet_device_object_reference_context_decode(uint8_t *apdu,
+int bacnet_device_object_reference_context_decode(
+    const uint8_t *apdu,
     uint32_t apdu_size,
     uint8_t tag_number,
     BACNET_DEVICE_OBJECT_REFERENCE *value);
 
 BACNET_STACK_EXPORT
 bool bacnet_device_object_property_reference_same(
-    BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value1,
-    BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value2);
+    const BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value1,
+    const BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value2);
 
 BACNET_STACK_EXPORT
 bool bacnet_device_object_reference_same(
-    BACNET_DEVICE_OBJECT_REFERENCE *value1,
-    BACNET_DEVICE_OBJECT_REFERENCE *value2);
+    const BACNET_DEVICE_OBJECT_REFERENCE *value1,
+    const BACNET_DEVICE_OBJECT_REFERENCE *value2);
 
 BACNET_STACK_EXPORT
 bool bacnet_object_property_reference_same(
-    BACNET_OBJECT_PROPERTY_REFERENCE *value1,
-    BACNET_OBJECT_PROPERTY_REFERENCE *value2);
+    const BACNET_OBJECT_PROPERTY_REFERENCE *value1,
+    const BACNET_OBJECT_PROPERTY_REFERENCE *value2);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/bacerror.c
+++ b/src/bacnet/bacerror.c
@@ -84,7 +84,7 @@ int bacerror_encode_apdu(uint8_t *apdu,
  *
  * @return number of bytes decoded, or #BACNET_STATUS_ERROR (-1) if malformed
  */
-int bacerror_decode_error_class_and_code(uint8_t *apdu,
+int bacerror_decode_error_class_and_code(const uint8_t *apdu,
     unsigned apdu_size,
     BACNET_ERROR_CLASS *error_class,
     BACNET_ERROR_CODE *error_code)
@@ -130,7 +130,7 @@ int bacerror_decode_error_class_and_code(uint8_t *apdu,
  *
  * @return number of bytes decoded, or #BACNET_STATUS_ERROR (-1) if malformed
  */
-int bacerror_decode_service_request(uint8_t *apdu,
+int bacerror_decode_service_request(const uint8_t *apdu,
     unsigned apdu_size,
     uint8_t *invoke_id,
     BACNET_CONFIRMED_SERVICE *service,

--- a/src/bacnet/bacerror.h
+++ b/src/bacnet/bacerror.h
@@ -27,7 +27,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     int bacerror_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_size,
         uint8_t * invoke_id,
         BACNET_CONFIRMED_SERVICE * service,
@@ -36,7 +36,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     int bacerror_decode_error_class_and_code(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_size,
         BACNET_ERROR_CLASS * error_class,
         BACNET_ERROR_CODE * error_code);

--- a/src/bacnet/bacint.c
+++ b/src/bacnet/bacint.c
@@ -23,7 +23,7 @@ int encode_unsigned16(uint8_t *apdu, uint16_t value)
     return 2;
 }
 
-int decode_unsigned16(uint8_t *apdu, uint16_t *value)
+int decode_unsigned16(const uint8_t *apdu, uint16_t *value)
 {
     if (apdu && value) {
         *value  = (uint16_t)apdu[0] << 8;
@@ -44,7 +44,7 @@ int encode_unsigned24(uint8_t *apdu, uint32_t value)
     return 3;
 }
 
-int decode_unsigned24(uint8_t *apdu, uint32_t *value)
+int decode_unsigned24(const uint8_t *apdu, uint32_t *value)
 {
     if (apdu && value) {
         *value  = (uint32_t)apdu[0] << 16;
@@ -67,7 +67,7 @@ int encode_unsigned32(uint8_t *apdu, uint32_t value)
     return 4;
 }
 
-int decode_unsigned32(uint8_t *apdu, uint32_t *value)
+int decode_unsigned32(const uint8_t *apdu, uint32_t *value)
 {
     if (apdu && value) {
         *value  = (uint32_t)apdu[0] << 24;
@@ -105,7 +105,7 @@ int encode_unsigned40(uint8_t *buffer, uint64_t value)
  * @param       value - pointer to 64-bit value to store the decoded value
  * @return      Returns the number of bytes decoded
  */
-int decode_unsigned40(uint8_t *buffer, uint64_t *value)
+int decode_unsigned40(const uint8_t *buffer, uint64_t *value)
 {
     if (buffer && value) {
         *value  = (uint64_t)buffer[0] << 32;
@@ -144,7 +144,7 @@ int encode_unsigned48(uint8_t *buffer, uint64_t value)
  * @param       value - pointer to 64-bit value to store the decoded value
  * @return      Returns the number of bytes decoded
  */
-int decode_unsigned48(uint8_t *buffer, uint64_t *value)
+int decode_unsigned48(const uint8_t *buffer, uint64_t *value)
 {
     if (buffer && value) {
         *value  = (uint64_t)buffer[0] << 40;
@@ -185,7 +185,7 @@ int encode_unsigned56(uint8_t *buffer, uint64_t value)
  * @param       value - pointer to 64-bit value to store the decoded value
  * @return      Returns the number of bytes decoded
  */
-int decode_unsigned56(uint8_t *buffer, uint64_t *value)
+int decode_unsigned56(const uint8_t *buffer, uint64_t *value)
 {
     if (buffer && value) {
         *value  = (uint64_t)buffer[0] << 48;
@@ -228,7 +228,7 @@ int encode_unsigned64(uint8_t *buffer, uint64_t value)
  * @param       value - pointer to 64-bit value to store the decoded value
  * @return      Returns the number of bytes decoded
  */
-int decode_unsigned64(uint8_t *buffer, uint64_t *value)
+int decode_unsigned64(const uint8_t *buffer, uint64_t *value)
 {
     if (buffer && value) {
         *value  = (uint64_t)buffer[0] << 56;
@@ -294,7 +294,7 @@ int encode_signed8(uint8_t *apdu, int8_t value)
     return 1;
 }
 
-int decode_signed8(uint8_t *apdu, int32_t *value)
+int decode_signed8(const uint8_t *apdu, int32_t *value)
 {
     if (apdu && value) {
         /* negative - bit 7 is set */
@@ -319,7 +319,7 @@ int encode_signed16(uint8_t *apdu, int16_t value)
     return 2;
 }
 
-int decode_signed16(uint8_t *apdu, int32_t *value)
+int decode_signed16(const uint8_t *apdu, int32_t *value)
 {
     if (apdu && value) {
         /* negative - bit 7 is set */
@@ -346,7 +346,7 @@ int encode_signed24(uint8_t *apdu, int32_t value)
     return 3;
 }
 
-int decode_signed24(uint8_t *apdu, int32_t *value)
+int decode_signed24(const uint8_t *apdu, int32_t *value)
 {
     if (apdu && value) {
         /* negative - bit 7 is set */
@@ -375,7 +375,7 @@ int encode_signed32(uint8_t *apdu, int32_t value)
     return 4;
 }
 
-int decode_signed32(uint8_t *apdu, int32_t *value)
+int decode_signed32(const uint8_t *apdu, int32_t *value)
 {
     if (apdu && value) {
         *value  = (int32_t)apdu[0] << 24;

--- a/src/bacnet/bacint.h
+++ b/src/bacnet/bacint.h
@@ -25,7 +25,7 @@ extern "C" {
         uint16_t value);
     BACNET_STACK_EXPORT
     int decode_unsigned16(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint16_t * value);
     BACNET_STACK_EXPORT
     int encode_unsigned24(
@@ -33,7 +33,7 @@ extern "C" {
         uint32_t value);
     BACNET_STACK_EXPORT
     int decode_unsigned24(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint32_t * value);
     BACNET_STACK_EXPORT
     int encode_unsigned32(
@@ -41,7 +41,7 @@ extern "C" {
         uint32_t value);
     BACNET_STACK_EXPORT
     int decode_unsigned32(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint32_t * value);
 #ifdef UINT64_MAX
     BACNET_STACK_EXPORT
@@ -50,7 +50,7 @@ extern "C" {
         uint64_t value);
     BACNET_STACK_EXPORT
     int decode_unsigned40(
-        uint8_t * buffer,
+        const uint8_t * buffer,
         uint64_t * value);
     BACNET_STACK_EXPORT
     int encode_unsigned48(
@@ -58,7 +58,7 @@ extern "C" {
         uint64_t value);
     BACNET_STACK_EXPORT
     int decode_unsigned48(
-        uint8_t * buffer,
+        const uint8_t * buffer,
         uint64_t * value);
     BACNET_STACK_EXPORT
     int encode_unsigned56(
@@ -66,7 +66,7 @@ extern "C" {
         uint64_t value);
     BACNET_STACK_EXPORT
     int decode_unsigned56(
-        uint8_t * buffer,
+        const uint8_t * buffer,
         uint64_t * value);
     BACNET_STACK_EXPORT
     int encode_unsigned64(
@@ -74,7 +74,7 @@ extern "C" {
         uint64_t value);
     BACNET_STACK_EXPORT
     int decode_unsigned64(
-        uint8_t * buffer,
+        const uint8_t * buffer,
         uint64_t * value);
 #endif
 
@@ -92,7 +92,7 @@ extern "C" {
         int8_t value);
     BACNET_STACK_EXPORT
     int decode_signed8(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         int32_t * value);
     BACNET_STACK_EXPORT
     int encode_signed16(
@@ -100,7 +100,7 @@ extern "C" {
         int16_t value);
     BACNET_STACK_EXPORT
     int decode_signed16(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         int32_t * value);
     BACNET_STACK_EXPORT
     int encode_signed24(
@@ -108,7 +108,7 @@ extern "C" {
         int32_t value);
     BACNET_STACK_EXPORT
     int decode_signed24(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         int32_t * value);
     BACNET_STACK_EXPORT
     int encode_signed32(
@@ -116,7 +116,7 @@ extern "C" {
         int32_t value);
     BACNET_STACK_EXPORT
     int decode_signed32(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         int32_t * value);
 
 #ifdef __cplusplus

--- a/src/bacnet/bacprop.c
+++ b/src/bacnet/bacprop.c
@@ -45,7 +45,7 @@ PROP_TAG_DATA bacnet_object_device_property_tag_map[] = {
  * @return Value found or the default value.
  */
 signed bacprop_tag_by_index_default(
-    PROP_TAG_DATA *data_list, signed index, signed default_ret)
+    const PROP_TAG_DATA *data_list, signed index, signed default_ret)
 {
     signed pUnsigned = 0;
 

--- a/src/bacnet/bacprop.h
+++ b/src/bacnet/bacprop.h
@@ -25,7 +25,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     signed bacprop_tag_by_index_default(
-        PROP_TAG_DATA * data_list,
+        const PROP_TAG_DATA * data_list,
         signed index,
         signed default_ret);
 

--- a/src/bacnet/bacpropstates.c
+++ b/src/bacnet/bacpropstates.c
@@ -44,7 +44,7 @@
  * @return number of bytes decoded, or #BACNET_STATUS_ERROR (-1) if malformed
  */
 int bacapp_property_state_decode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_PROPERTY_STATE *value)
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_PROPERTY_STATE *value)
 {
     BACNET_TAG tag = { 0 };
     uint32_t enum_value = 0;
@@ -298,13 +298,14 @@ int bacapp_property_state_decode(
     return apdu_len;
 }
 
-int bacapp_decode_property_state(uint8_t *apdu, BACNET_PROPERTY_STATE *value)
+int bacapp_decode_property_state(
+    const uint8_t *apdu, BACNET_PROPERTY_STATE *value)
 {
     return bacapp_property_state_decode(apdu, MAX_APDU, value);
 }
 
 int bacapp_decode_context_property_state(
-    uint8_t *apdu, uint8_t tag_number, BACNET_PROPERTY_STATE *value)
+    const uint8_t *apdu, uint8_t tag_number, BACNET_PROPERTY_STATE *value)
 {
     int len = 0;
     int section_length;
@@ -335,7 +336,8 @@ int bacapp_decode_context_property_state(
  * @param value  Pointer to the value used for encoding
  * @return number of bytes encoded, or zero if unable to encode
  */
-int bacapp_encode_property_state(uint8_t *apdu, BACNET_PROPERTY_STATE *value)
+int bacapp_encode_property_state(
+    uint8_t *apdu, const BACNET_PROPERTY_STATE *value)
 {
     int len = 0; /* length of each encoding */
 

--- a/src/bacnet/bacpropstates.h
+++ b/src/bacnet/bacpropstates.h
@@ -89,25 +89,25 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     int bacapp_property_state_decode(
-        uint8_t *apdu,
+        const uint8_t *apdu,
         uint32_t apdu_size,
         BACNET_PROPERTY_STATE *value);
 
     BACNET_STACK_EXPORT
     int bacapp_decode_property_state(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         BACNET_PROPERTY_STATE * value);
 
     BACNET_STACK_EXPORT
     int bacapp_decode_context_property_state(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint8_t tag_number,
         BACNET_PROPERTY_STATE * value);
 
     BACNET_STACK_EXPORT
     int bacapp_encode_property_state(
         uint8_t * apdu,
-        BACNET_PROPERTY_STATE * value);
+        const BACNET_PROPERTY_STATE * value);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/bacreal.c
+++ b/src/bacnet/bacreal.c
@@ -21,7 +21,7 @@
 
 /* from clause 20.2.6 Encoding of a Real Number Value */
 /* returns the number of apdu bytes consumed */
-int decode_real(uint8_t *apdu, float *real_value)
+int decode_real(const uint8_t *apdu, float *real_value)
 {
     union {
         uint8_t byte[4];
@@ -49,7 +49,7 @@ int decode_real(uint8_t *apdu, float *real_value)
     return 4;
 }
 
-int decode_real_safe(uint8_t *apdu, uint32_t len_value, float *real_value)
+int decode_real_safe(const uint8_t *apdu, uint32_t len_value, float *real_value)
 {
     if (len_value != 4) {
         if (real_value) {
@@ -93,7 +93,7 @@ int encode_bacnet_real(float value, uint8_t *apdu)
 
 /* from clause 20.2.7 Encoding of a Double Precision Real Number Value */
 /* returns the number of apdu bytes consumed */
-int decode_double(uint8_t *apdu, double *double_value)
+int decode_double(const uint8_t *apdu, double *double_value)
 {
     union {
         uint8_t byte[8];
@@ -129,7 +129,8 @@ int decode_double(uint8_t *apdu, double *double_value)
     return 8;
 }
 
-int decode_double_safe(uint8_t *apdu, uint32_t len_value, double *double_value)
+int decode_double_safe(
+    const uint8_t *apdu, uint32_t len_value, double *double_value)
 {
     if (len_value != 8) {
         if (double_value) {

--- a/src/bacnet/bacreal.h
+++ b/src/bacnet/bacreal.h
@@ -20,13 +20,13 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     int decode_real_safe(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint32_t len_value,
         float *real_value);
 
     BACNET_STACK_EXPORT
     int decode_real(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         float *real_value);
 
     BACNET_STACK_EXPORT
@@ -35,11 +35,11 @@ extern "C" {
         uint8_t * apdu);
     BACNET_STACK_EXPORT
     int decode_double(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         double *real_value);
     BACNET_STACK_EXPORT
     int decode_double_safe(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint32_t len_value,
         double *double_value);
 

--- a/src/bacnet/bacstr.c
+++ b/src/bacnet/bacstr.c
@@ -86,7 +86,7 @@ void bitstring_set_bit(
  *
  * @return Value 0/1
  */
-bool bitstring_bit(BACNET_BIT_STRING *bit_string, uint8_t bit_number)
+bool bitstring_bit(const BACNET_BIT_STRING *bit_string, uint8_t bit_number)
 {
     bool value = false;
     unsigned byte_number = bit_number / 8;
@@ -111,7 +111,7 @@ bool bitstring_bit(BACNET_BIT_STRING *bit_string, uint8_t bit_number)
  *
  * @return Bits used [0..(MAX_BITSTRING_BYTES*8)-1]
  */
-uint8_t bitstring_bits_used(BACNET_BIT_STRING *bit_string)
+uint8_t bitstring_bits_used(const BACNET_BIT_STRING *bit_string)
 {
     return (bit_string ? bit_string->bits_used : 0);
 }
@@ -123,7 +123,7 @@ uint8_t bitstring_bits_used(BACNET_BIT_STRING *bit_string)
  *
  * @return Bytes used [0..MAX_BITSTRING_BYTES]
  */
-uint8_t bitstring_bytes_used(BACNET_BIT_STRING *bit_string)
+uint8_t bitstring_bytes_used(const BACNET_BIT_STRING *bit_string)
 {
     uint8_t len = 0; /* return value */
     uint8_t used_bytes = 0;
@@ -148,7 +148,7 @@ uint8_t bitstring_bytes_used(BACNET_BIT_STRING *bit_string)
  *
  * @return Value of the octet.
  */
-uint8_t bitstring_octet(BACNET_BIT_STRING *bit_string, uint8_t octet_index)
+uint8_t bitstring_octet(const BACNET_BIT_STRING *bit_string, uint8_t octet_index)
 {
     uint8_t octet = 0;
 
@@ -217,7 +217,7 @@ bool bitstring_set_bits_used(
  *
  * @return Capacitiy in bits [0..(MAX_BITSTRING_BYTES*8)]
  */
-unsigned bitstring_bits_capacity(BACNET_BIT_STRING *bit_string)
+unsigned bitstring_bits_capacity(const BACNET_BIT_STRING *bit_string)
 {
     if (bit_string) {
         return min((MAX_BITSTRING_BYTES * 8), (UINT8_MAX + 1));
@@ -234,7 +234,7 @@ unsigned bitstring_bits_capacity(BACNET_BIT_STRING *bit_string)
  *
  * @return true on success, false otherwise.
  */
-bool bitstring_copy(BACNET_BIT_STRING *dest, BACNET_BIT_STRING *src)
+bool bitstring_copy(BACNET_BIT_STRING *dest, const BACNET_BIT_STRING *src)
 {
     unsigned i;
     bool status = false;
@@ -260,7 +260,7 @@ bool bitstring_copy(BACNET_BIT_STRING *dest, BACNET_BIT_STRING *src)
  *         the same, false otherwise.
  */
 bool bitstring_same(
-    BACNET_BIT_STRING *bitstring1, BACNET_BIT_STRING *bitstring2)
+    const BACNET_BIT_STRING *bitstring1, const BACNET_BIT_STRING *bitstring2)
 {
     int i; /* loop counter */
     int bytes_used = 0;
@@ -409,7 +409,7 @@ bool characterstring_init(BACNET_CHARACTER_STRING *char_string,
  */
 size_t characterstring_strnlen(const char *str, size_t maxlen)
 {
-    char* p = memchr(str, 0, maxlen);
+    const char* p = memchr(str, 0, maxlen);
     if (p == NULL) {
         return maxlen;
     }
@@ -460,7 +460,7 @@ bool characterstring_init_ansi(
  * @return true/false
  */
 bool characterstring_copy(
-    BACNET_CHARACTER_STRING *dest, BACNET_CHARACTER_STRING *src)
+    BACNET_CHARACTER_STRING *dest, const BACNET_CHARACTER_STRING *src)
 {
     if (dest && src) {
         return characterstring_init(dest, characterstring_encoding(src),
@@ -480,7 +480,7 @@ bool characterstring_copy(
  * @return true/false
  */
 bool characterstring_ansi_copy(
-    char *dest, size_t dest_max_len, BACNET_CHARACTER_STRING *src)
+    char *dest, size_t dest_max_len, const BACNET_CHARACTER_STRING *src)
 {
     size_t i; /* counter */
 
@@ -511,7 +511,7 @@ bool characterstring_ansi_copy(
  * @return true if the character encoding and string contents are the same
  */
 bool characterstring_same(
-    BACNET_CHARACTER_STRING *dest, BACNET_CHARACTER_STRING *src)
+    const BACNET_CHARACTER_STRING *dest, const BACNET_CHARACTER_STRING *src)
 {
     size_t i; /* counter */
     bool same_status = false;
@@ -550,7 +550,7 @@ bool characterstring_same(
  *
  * @return true if the character encoding and string contents are the same
  */
-bool characterstring_ansi_same(BACNET_CHARACTER_STRING *dest, const char *src)
+bool characterstring_ansi_same(const BACNET_CHARACTER_STRING *dest, const char *src)
 {
     size_t i; /* counter */
     bool same_status = false;
@@ -643,9 +643,9 @@ bool characterstring_truncate(
  *
  * @return Pointer to a zero-terminated C-string.
  */
-char *characterstring_value(BACNET_CHARACTER_STRING *char_string)
+const char *characterstring_value(const BACNET_CHARACTER_STRING *char_string)
 {
-    char *value = NULL;
+    const char *value = NULL;
 
     if (char_string) {
         value = char_string->value;
@@ -662,7 +662,7 @@ char *characterstring_value(BACNET_CHARACTER_STRING *char_string)
  * @return Length of the character string, but
  *         maximum MAX_CHARACTER_STRING_BYTES.
  */
-size_t characterstring_length(BACNET_CHARACTER_STRING *char_string)
+size_t characterstring_length(const BACNET_CHARACTER_STRING *char_string)
 {
     size_t length = 0;
 
@@ -685,7 +685,7 @@ size_t characterstring_length(BACNET_CHARACTER_STRING *char_string)
  *
  * @return MAX_CHARACTER_STRING_BYTES
  */
-size_t characterstring_capacity(BACNET_CHARACTER_STRING *char_string)
+size_t characterstring_capacity(const BACNET_CHARACTER_STRING *char_string)
 {
     size_t length = 0;
 
@@ -703,7 +703,7 @@ size_t characterstring_capacity(BACNET_CHARACTER_STRING *char_string)
  *
  * @return Encoding, like CHARACTER_ANSI_X34
  */
-uint8_t characterstring_encoding(BACNET_CHARACTER_STRING *char_string)
+uint8_t characterstring_encoding(const BACNET_CHARACTER_STRING *char_string)
 {
     uint8_t encoding = 0;
 
@@ -754,7 +754,7 @@ bool characterstring_set_encoding(
  *
  * @return true/false on error
  */
-bool characterstring_printable(BACNET_CHARACTER_STRING *char_string)
+bool characterstring_printable(const BACNET_CHARACTER_STRING *char_string)
 {
     bool status = false; /* return value */
     size_t i; /* counter */
@@ -825,7 +825,7 @@ bool utf8_isvalid(const char *str, size_t length)
         return false;
     }
     /* Check characters. */
-    pend = (unsigned char *)str + length;
+    pend = (const unsigned char *)str + length;
     for (p = (const unsigned char *)str; p < pend; p++) {
         c = *p;
         /* null in middle of string */
@@ -917,7 +917,7 @@ bool utf8_isvalid(const char *str, size_t length)
  *
  * @return true if the string is valid, false otherwise.
  */
-bool characterstring_valid(BACNET_CHARACTER_STRING *char_string)
+bool characterstring_valid(const BACNET_CHARACTER_STRING *char_string)
 {
     bool valid = false; /* return value */
 
@@ -950,7 +950,7 @@ bool characterstring_valid(BACNET_CHARACTER_STRING *char_string)
  * @return true on success, false if the string exceeds capacity.
  */
 bool octetstring_init(
-    BACNET_OCTET_STRING *octet_string, uint8_t *value, size_t length)
+    BACNET_OCTET_STRING *octet_string, const uint8_t *value, size_t length)
 {
     bool status = false; /* return value */
     size_t i; /* counter */
@@ -1039,10 +1039,11 @@ bool octetstring_init_ascii_hex(
  *
  * @return true on success, false otherwise.
  */
-bool octetstring_copy(BACNET_OCTET_STRING *dest, BACNET_OCTET_STRING *src)
+bool octetstring_copy(BACNET_OCTET_STRING *dest, const BACNET_OCTET_STRING *src)
 {
     return octetstring_init(
-        dest, octetstring_value(src), octetstring_length(src));
+        dest, octetstring_value(
+            (BACNET_OCTET_STRING *)src), octetstring_length(src));
 }
 
 /**
@@ -1057,7 +1058,7 @@ bool octetstring_copy(BACNET_OCTET_STRING *dest, BACNET_OCTET_STRING *src)
  * the dest cannot hold entire octetstring value.
  */
 size_t octetstring_copy_value(
-    uint8_t *dest, size_t length, BACNET_OCTET_STRING *src)
+    uint8_t *dest, size_t length, const BACNET_OCTET_STRING *src)
 {
     size_t bytes_copied = 0;
     size_t i; /* counter */
@@ -1084,7 +1085,7 @@ size_t octetstring_copy_value(
  * @return false if the string exceeds capacity.
  */
 bool octetstring_append(
-    BACNET_OCTET_STRING *octet_string, uint8_t *value, size_t length)
+    BACNET_OCTET_STRING *octet_string, const uint8_t *value, size_t length)
 {
     size_t i; /* counter */
     bool status = false; /* return value */
@@ -1153,7 +1154,7 @@ uint8_t *octetstring_value(BACNET_OCTET_STRING *octet_string)
  *
  * @return Length in bytes. Returns always 0 on error.
  */
-size_t octetstring_length(BACNET_OCTET_STRING *octet_string)
+size_t octetstring_length(const BACNET_OCTET_STRING *octet_string)
 {
     size_t length = 0;
 
@@ -1175,7 +1176,7 @@ size_t octetstring_length(BACNET_OCTET_STRING *octet_string)
  *
  * @return Capacity in bytes. Returns always 0 on error.
  */
-size_t octetstring_capacity(BACNET_OCTET_STRING *octet_string)
+size_t octetstring_capacity(const BACNET_OCTET_STRING *octet_string)
 {
     size_t length = 0;
 
@@ -1195,7 +1196,7 @@ size_t octetstring_capacity(BACNET_OCTET_STRING *octet_string)
  * @return true if the octet strings are the same, false otherwise.
  */
 bool octetstring_value_same(
-    BACNET_OCTET_STRING *octet_string1, BACNET_OCTET_STRING *octet_string2)
+    const BACNET_OCTET_STRING *octet_string1, const BACNET_OCTET_STRING *octet_string2)
 {
     size_t i = 0; /* loop counter */
 

--- a/src/bacnet/bacstr.h
+++ b/src/bacnet/bacstr.h
@@ -46,22 +46,22 @@ extern "C" {
         bool value);
     BACNET_STACK_EXPORT
     bool bitstring_bit(
-        BACNET_BIT_STRING * bit_string,
+        const BACNET_BIT_STRING * bit_string,
         uint8_t bit_number);
     BACNET_STACK_EXPORT
     uint8_t bitstring_bits_used(
-        BACNET_BIT_STRING * bit_string);
+        const BACNET_BIT_STRING * bit_string);
 /* returns the number of bytes that a bit string is using */
     BACNET_STACK_EXPORT
     uint8_t bitstring_bytes_used(
-        BACNET_BIT_STRING * bit_string);
+        const BACNET_BIT_STRING * bit_string);
     BACNET_STACK_EXPORT
     unsigned bitstring_bits_capacity(
-        BACNET_BIT_STRING * bit_string);
+        const BACNET_BIT_STRING * bit_string);
 /* used for encoding and decoding from the APDU */
     BACNET_STACK_EXPORT
     uint8_t bitstring_octet(
-        BACNET_BIT_STRING * bit_string,
+        const BACNET_BIT_STRING * bit_string,
         uint8_t octet_index);
     BACNET_STACK_EXPORT
     bool bitstring_set_octet(
@@ -76,11 +76,11 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool bitstring_copy(
         BACNET_BIT_STRING * dest,
-        BACNET_BIT_STRING * src);
+        const BACNET_BIT_STRING * src);
     BACNET_STACK_EXPORT
     bool bitstring_same(
-        BACNET_BIT_STRING * bitstring1,
-        BACNET_BIT_STRING * bitstring2);
+        const BACNET_BIT_STRING * bitstring1,
+        const BACNET_BIT_STRING * bitstring2);
     BACNET_STACK_EXPORT
     bool bitstring_init_ascii(
         BACNET_BIT_STRING * bit_string,
@@ -111,20 +111,20 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool characterstring_copy(
         BACNET_CHARACTER_STRING * dest,
-        BACNET_CHARACTER_STRING * src);
+        const BACNET_CHARACTER_STRING * src);
     BACNET_STACK_EXPORT
     bool characterstring_ansi_copy(
         char *dest,
         size_t dest_max_len,
-        BACNET_CHARACTER_STRING * src);
+        const BACNET_CHARACTER_STRING * src);
 /* returns true if the strings are the same length, encoding, value */
     BACNET_STACK_EXPORT
     bool characterstring_same(
-        BACNET_CHARACTER_STRING * dest,
-        BACNET_CHARACTER_STRING * src);
+        const BACNET_CHARACTER_STRING * dest,
+        const BACNET_CHARACTER_STRING * src);
     BACNET_STACK_EXPORT
     bool characterstring_ansi_same(
-        BACNET_CHARACTER_STRING * dest,
+        const BACNET_CHARACTER_STRING * dest,
         const char *src);
 /* returns false if the string exceeds capacity */
     BACNET_STACK_EXPORT
@@ -145,24 +145,24 @@ extern "C" {
         uint8_t encoding);
 /* Returns the value */
     BACNET_STACK_EXPORT
-    char *characterstring_value(
-        BACNET_CHARACTER_STRING * char_string);
+    const char *characterstring_value(
+        const BACNET_CHARACTER_STRING * char_string);
 /* returns the length */
     BACNET_STACK_EXPORT
     size_t characterstring_length(
-        BACNET_CHARACTER_STRING * char_string);
+        const BACNET_CHARACTER_STRING * char_string);
     BACNET_STACK_EXPORT
     uint8_t characterstring_encoding(
-        BACNET_CHARACTER_STRING * char_string);
+        const BACNET_CHARACTER_STRING * char_string);
     BACNET_STACK_EXPORT
     size_t characterstring_capacity(
-        BACNET_CHARACTER_STRING * char_string);
+        const BACNET_CHARACTER_STRING * char_string);
     BACNET_STACK_EXPORT
     bool characterstring_printable(
-        BACNET_CHARACTER_STRING * char_string);
+        const BACNET_CHARACTER_STRING * char_string);
     BACNET_STACK_EXPORT
     bool characterstring_valid(
-        BACNET_CHARACTER_STRING * char_string);
+        const BACNET_CHARACTER_STRING * char_string);
     BACNET_STACK_EXPORT
     bool utf8_isvalid(
         const char *str,
@@ -173,7 +173,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool octetstring_init(
         BACNET_OCTET_STRING * octet_string,
-        uint8_t * value,
+        const uint8_t * value,
         size_t length);
     /* converts an null terminated ASCII Hex string to an octet string.
        returns true if successfully converted and fits; false if too long */
@@ -184,17 +184,17 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool octetstring_copy(
         BACNET_OCTET_STRING * dest,
-        BACNET_OCTET_STRING * src);
+        const BACNET_OCTET_STRING * src);
     BACNET_STACK_EXPORT
     size_t octetstring_copy_value(
         uint8_t * dest,
         size_t length,
-        BACNET_OCTET_STRING * src);
+        const BACNET_OCTET_STRING * src);
 /* returns false if the string exceeds capacity */
     BACNET_STACK_EXPORT
     bool octetstring_append(
         BACNET_OCTET_STRING * octet_string,
-        uint8_t * value,
+        const uint8_t * value,
         size_t length);
 /* This function sets a new length without changing the value.
    If length exceeds capacity, no modification happens and
@@ -210,15 +210,15 @@ extern "C" {
 /* Returns the length.*/
     BACNET_STACK_EXPORT
     size_t octetstring_length(
-        BACNET_OCTET_STRING * octet_string);
+        const BACNET_OCTET_STRING * octet_string);
     BACNET_STACK_EXPORT
     size_t octetstring_capacity(
-        BACNET_OCTET_STRING * octet_string);
+        const BACNET_OCTET_STRING * octet_string);
     /* returns true if the same length and contents */
     BACNET_STACK_EXPORT
     bool octetstring_value_same(
-        BACNET_OCTET_STRING * octet_string1,
-        BACNET_OCTET_STRING * octet_string2);
+        const BACNET_OCTET_STRING * octet_string1,
+        const BACNET_OCTET_STRING * octet_string2);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/bactimevalue.c
+++ b/src/bacnet/bactimevalue.c
@@ -65,7 +65,7 @@ static bool is_data_value_schedule_compatible(uint8_t tag)
  * @param value - value to be encoded
  * @return the number of apdu bytes encoded
  */
-int bacnet_time_value_encode(uint8_t *apdu, BACNET_TIME_VALUE *value)
+int bacnet_time_value_encode(uint8_t *apdu, const BACNET_TIME_VALUE *value)
 {
     int len;
     int apdu_len = 0;
@@ -86,7 +86,7 @@ int bacnet_time_value_encode(uint8_t *apdu, BACNET_TIME_VALUE *value)
     return apdu_len;
 }
 
-int bacapp_encode_time_value(uint8_t *apdu, BACNET_TIME_VALUE *value)
+int bacapp_encode_time_value(uint8_t *apdu, const BACNET_TIME_VALUE *value)
 {
     return bacnet_time_value_encode(apdu, value);
 }
@@ -100,7 +100,7 @@ int bacapp_encode_time_value(uint8_t *apdu, BACNET_TIME_VALUE *value)
  * @return the number of apdu bytes encoded
  */
 int bacnet_time_value_context_encode(
-    uint8_t *apdu, uint8_t tag_number, BACNET_TIME_VALUE *value)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_TIME_VALUE *value)
 {
     int len;
     int apdu_len = 0;
@@ -122,7 +122,7 @@ int bacnet_time_value_context_encode(
 }
 
 int bacapp_encode_context_time_value(
-    uint8_t *apdu, uint8_t tag_number, BACNET_TIME_VALUE *value)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_TIME_VALUE *value)
 {
     return bacnet_time_value_context_encode(apdu, tag_number, value);
 }
@@ -178,7 +178,7 @@ int bacnet_primitive_to_application_data_value(
  * @return  number of bytes decoded, or BACNET_STATUS_ERROR if errors occur
  */
 int bacnet_time_value_decode(
-    uint8_t *apdu, int apdu_size, BACNET_TIME_VALUE *value)
+    const uint8_t *apdu, int apdu_size, BACNET_TIME_VALUE *value)
 {
     int len;
     int apdu_len = 0;
@@ -206,7 +206,7 @@ int bacnet_time_value_decode(
     return apdu_len;
 }
 
-int bacapp_decode_time_value(uint8_t *apdu, BACNET_TIME_VALUE *value)
+int bacapp_decode_time_value(const uint8_t *apdu, BACNET_TIME_VALUE *value)
 {
     return bacnet_time_value_decode(apdu, MAX_APDU, value);
 }
@@ -220,7 +220,10 @@ int bacapp_decode_time_value(uint8_t *apdu, BACNET_TIME_VALUE *value)
  * @return number of bytes decoded, or BACNET_STATUS_ERROR if an error occurs
  */
 int bacnet_time_value_context_decode(
-    uint8_t *apdu, int apdu_size, uint8_t tag_number, BACNET_TIME_VALUE *value)
+    const uint8_t *apdu,
+    int apdu_size,
+    uint8_t tag_number,
+    BACNET_TIME_VALUE *value)
 {
     int len;
     int apdu_len = 0;
@@ -249,7 +252,7 @@ int bacnet_time_value_context_decode(
 }
 
 int bacapp_decode_context_time_value(
-    uint8_t *apdu, uint8_t tag_number, BACNET_TIME_VALUE *value)
+    const uint8_t *apdu, uint8_t tag_number, BACNET_TIME_VALUE *value)
 {
     return bacnet_time_value_context_decode(apdu, MAX_APDU, tag_number, value);
 }
@@ -264,7 +267,7 @@ int bacapp_decode_context_time_value(
  * @return number of bytes decoded, or BACNET_STATUS_ERROR if an error occurs
  */
 int bacnet_time_values_context_decode(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     const int apdu_size,
     const uint8_t tag_number,
     BACNET_TIME_VALUE *time_values,
@@ -332,7 +335,7 @@ int bacnet_time_values_context_decode(
 int bacnet_time_values_context_encode(
     uint8_t *apdu,
     uint8_t tag_number,
-    BACNET_TIME_VALUE *time_values,
+    const BACNET_TIME_VALUE *time_values,
     unsigned int max_time_values)
 {
     unsigned int j;

--- a/src/bacnet/bactimevalue.h
+++ b/src/bacnet/bactimevalue.h
@@ -79,38 +79,40 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     int bacnet_time_value_encode(uint8_t * apdu,
-        BACNET_TIME_VALUE * value);
+        const BACNET_TIME_VALUE * value);
 
     BACNET_STACK_DEPRECATED("Use bacnet_time_value_encode() instead")
     BACNET_STACK_EXPORT
-    int bacapp_encode_time_value(uint8_t *apdu, BACNET_TIME_VALUE *value);
+    int bacapp_encode_time_value(uint8_t *apdu,
+        const BACNET_TIME_VALUE *value);
 
     BACNET_STACK_EXPORT
     int bacnet_time_value_context_encode(uint8_t * apdu,
         uint8_t tag_number,
-        BACNET_TIME_VALUE * value);
+        const BACNET_TIME_VALUE * value);
 
     BACNET_STACK_DEPRECATED("Use bacnet_time_value_context_encode() instead")
     BACNET_STACK_EXPORT
-    int bacapp_encode_context_time_value(uint8_t *apdu, uint8_t tag_number, BACNET_TIME_VALUE *value);
+    int bacapp_encode_context_time_value(
+        uint8_t *apdu, uint8_t tag_number, const BACNET_TIME_VALUE *value);
 
     BACNET_STACK_DEPRECATED("Use bacnet_time_value_decode() instead")
     BACNET_STACK_EXPORT
-    int bacapp_decode_time_value(uint8_t * apdu,
+    int bacapp_decode_time_value(const uint8_t * apdu,
         BACNET_TIME_VALUE * value);
 
     BACNET_STACK_EXPORT
-    int bacnet_time_value_decode(uint8_t *apdu, int max_apdu_len,
+    int bacnet_time_value_decode(const uint8_t *apdu, int max_apdu_len,
         BACNET_TIME_VALUE *value);
 
     BACNET_STACK_DEPRECATED("Use bacnet_time_value_context_decode() instead")
     BACNET_STACK_EXPORT
-    int bacapp_decode_context_time_value(uint8_t * apdu,
+    int bacapp_decode_context_time_value(const uint8_t * apdu,
         uint8_t tag_number,
         BACNET_TIME_VALUE * value);
 
     BACNET_STACK_EXPORT
-    int bacnet_time_value_context_decode(uint8_t *apdu, int max_apdu_len,
+    int bacnet_time_value_context_decode(const uint8_t *apdu, int max_apdu_len,
         uint8_t tag_number, BACNET_TIME_VALUE *value);
 
     /**
@@ -125,7 +127,7 @@ extern "C" {
      */
     BACNET_STACK_EXPORT
     int bacnet_time_values_context_decode(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         int max_apdu_len,
         uint8_t tag_number,
         BACNET_TIME_VALUE *time_values,
@@ -145,7 +147,7 @@ extern "C" {
     int bacnet_time_values_context_encode(
         uint8_t * apdu,
         uint8_t tag_number,
-        BACNET_TIME_VALUE * time_values,
+        const BACNET_TIME_VALUE * time_values,
         unsigned int max_time_values);
 
 #ifdef __cplusplus

--- a/src/bacnet/basic/bbmd/h_bbmd.c
+++ b/src/bacnet/basic/bbmd/h_bbmd.c
@@ -253,7 +253,7 @@ void bvlc_maintenance_timer(uint16_t seconds)
  *
  * @return true if the IP from sin match me
  */
-static bool bbmd_address_match_self(BACNET_IP_ADDRESS *addr)
+static bool bbmd_address_match_self(const BACNET_IP_ADDRESS *addr)
 {
     BACNET_IP_ADDRESS my_addr = { 0 };
     bool status = false;
@@ -274,7 +274,7 @@ static bool bbmd_address_match_self(BACNET_IP_ADDRESS *addr)
  *
  * @return True if BDT member is found and has a unicast mask
  */
-static bool bbmd_bdt_member_mask_is_unicast(BACNET_IP_ADDRESS *addr)
+static bool bbmd_bdt_member_mask_is_unicast(const BACNET_IP_ADDRESS *addr)
 {
     bool unicast = false;
     BACNET_IP_ADDRESS my_addr = { 0 };
@@ -312,7 +312,9 @@ static bool bbmd_bdt_member_mask_is_unicast(BACNET_IP_ADDRESS *addr)
  * @return number of bytes encoded in the Forwarded NPDU
  */
 static uint16_t bbmd_forward_npdu(
-    BACNET_IP_ADDRESS *bip_src, uint8_t *npdu, uint16_t npdu_length)
+    const BACNET_IP_ADDRESS *bip_src,
+    const uint8_t *npdu,
+    uint16_t npdu_length)
 {
     BACNET_IP_ADDRESS broadcast_address = { 0 };
     uint8_t mtu[BIP_MPDU_MAX] = { 0 };
@@ -338,8 +340,8 @@ static uint16_t bbmd_forward_npdu(
  * @param original - was the message an original (not forwarded)
  * @return number of bytes encoded in the Forwarded NPDU
  */
-static uint16_t bbmd_bdt_forward_npdu(BACNET_IP_ADDRESS *bip_src,
-    uint8_t *npdu,
+static uint16_t bbmd_bdt_forward_npdu(const BACNET_IP_ADDRESS *bip_src,
+    const uint8_t *npdu,
     uint16_t npdu_length,
     bool original)
 {
@@ -403,8 +405,8 @@ static uint16_t bbmd_bdt_forward_npdu(BACNET_IP_ADDRESS *bip_src,
  * @param original - was the message an original (not forwarded)
  * @return number of bytes encoded in the Forwarded NPDU
  */
-static uint16_t bbmd_fdt_forward_npdu(BACNET_IP_ADDRESS *bip_src,
-    uint8_t *npdu,
+static uint16_t bbmd_fdt_forward_npdu(const BACNET_IP_ADDRESS *bip_src,
+    const uint8_t *npdu,
     uint16_t npdu_length,
     bool original)
 {
@@ -468,7 +470,7 @@ static uint16_t bbmd_fdt_forward_npdu(BACNET_IP_ADDRESS *bip_src,
  * @param original - was the message an original (not forwarded)
  */
 static void bbmd_read_bdt_ack_handler(
-    BACNET_IP_ADDRESS *addr, uint8_t *npdu, uint16_t npdu_length)
+    const BACNET_IP_ADDRESS *addr, const uint8_t *npdu, uint16_t npdu_length)
 {
 #if PRINT_ENABLED
     BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY bdt_entry = { 0 };
@@ -516,7 +518,7 @@ static void bbmd_read_bdt_ack_handler(
  * @param original - was the message an original (not forwarded)
  */
 static void bbmd_read_fdt_ack_handler(
-    BACNET_IP_ADDRESS *addr, uint8_t *npdu, uint16_t npdu_length)
+    const BACNET_IP_ADDRESS *addr, const uint8_t *npdu, uint16_t npdu_length)
 {
 #if PRINT_ENABLED
     BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY fdt_entry = { 0 };
@@ -566,9 +568,9 @@ static void bbmd_read_fdt_ack_handler(
  * @return Upon successful completion, returns the number of bytes sent.
  *  Otherwise, -1 shall be returned and errno set to indicate the error.
  */
-int bvlc_send_pdu(BACNET_ADDRESS *dest,
-    BACNET_NPDU_DATA *npdu_data,
-    uint8_t *pdu,
+int bvlc_send_pdu(const BACNET_ADDRESS *dest,
+    const BACNET_NPDU_DATA *npdu_data,
+    const uint8_t *pdu,
     unsigned pdu_len)
 {
     BACNET_IP_ADDRESS bvlc_dest = { 0 };
@@ -637,7 +639,8 @@ int bvlc_send_pdu(BACNET_ADDRESS *dest,
  * @return Upon successful completion, returns the number of bytes sent.
  *  Otherwise, -1 shall be returned and errno set to indicate the error.
  */
-static int bvlc_send_result(BACNET_IP_ADDRESS *dest_addr, uint16_t result_code)
+static int bvlc_send_result(
+    const BACNET_IP_ADDRESS *dest_addr, uint16_t result_code)
 {
     uint8_t mtu[BIP_MPDU_MAX] = { 0 };
     uint16_t mtu_len = 0;
@@ -1192,7 +1195,8 @@ int bvlc_broadcast_handler(BACNET_IP_ADDRESS *addr,
  *         0 if no registration request is sent, or
  *         -1 if registration fails.
  */
-int bvlc_register_with_bbmd(BACNET_IP_ADDRESS *bbmd_addr, uint16_t ttl_seconds)
+int bvlc_register_with_bbmd(
+    const BACNET_IP_ADDRESS *bbmd_addr, uint16_t ttl_seconds)
 {
     /* Store the BBMD address and port so that we won't broadcast locally. */
     /* We are a foreign device! */
@@ -1232,7 +1236,7 @@ uint16_t bvlc_remote_bbmd_lifetime(void)
  * @param bbmd_addr - IPv4 address of BBMD with which to read
  * @return Positive number (of bytes sent) on success
  */
-int bvlc_bbmd_read_bdt(BACNET_IP_ADDRESS *bbmd_addr)
+int bvlc_bbmd_read_bdt(const BACNET_IP_ADDRESS *bbmd_addr)
 {
     BVLC_Buffer_Len = bvlc_encode_read_broadcast_distribution_table(
         &BVLC_Buffer[0], sizeof(BVLC_Buffer));
@@ -1245,7 +1249,7 @@ int bvlc_bbmd_read_bdt(BACNET_IP_ADDRESS *bbmd_addr)
  * @param bbmd_addr - IPv4 address of BBMD with which to read
  * @return Positive number (of bytes sent) on success
  */
-int bvlc_bbmd_write_bdt(BACNET_IP_ADDRESS *bbmd_addr,
+int bvlc_bbmd_write_bdt(const BACNET_IP_ADDRESS *bbmd_addr,
     BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_list)
 {
     BVLC_Buffer_Len = bvlc_encode_write_broadcast_distribution_table(
@@ -1259,7 +1263,7 @@ int bvlc_bbmd_write_bdt(BACNET_IP_ADDRESS *bbmd_addr,
  * @param bbmd_addr - IPv4 address of BBMD with which to read
  * @return Positive number (of bytes sent) on success
  */
-int bvlc_bbmd_read_fdt(BACNET_IP_ADDRESS *bbmd_addr)
+int bvlc_bbmd_read_fdt(const BACNET_IP_ADDRESS *bbmd_addr)
 {
     BVLC_Buffer_Len = bvlc_encode_read_foreign_device_table(
         &BVLC_Buffer[0], sizeof(BVLC_Buffer));

--- a/src/bacnet/basic/bbmd/h_bbmd.h
+++ b/src/bacnet/basic/bbmd/h_bbmd.h
@@ -47,9 +47,9 @@ int bvlc_bbmd_disabled_handler(BACNET_IP_ADDRESS *addr,
 
 
 BACNET_STACK_EXPORT
-int bvlc_send_pdu(BACNET_ADDRESS *dest,
-    BACNET_NPDU_DATA *npdu_data,
-    uint8_t *pdu,
+int bvlc_send_pdu(const BACNET_ADDRESS *dest,
+    const BACNET_NPDU_DATA *npdu_data,
+    const uint8_t *pdu,
     unsigned pdu_len);
 
 BACNET_STACK_EXPORT
@@ -76,18 +76,18 @@ void bvlc_debug_disable(void);
 
 /* send a Read BDT request */
 BACNET_STACK_EXPORT
-int bvlc_bbmd_read_bdt(BACNET_IP_ADDRESS *bbmd_addr);
+int bvlc_bbmd_read_bdt(const BACNET_IP_ADDRESS *bbmd_addr);
 BACNET_STACK_EXPORT
-int bvlc_bbmd_write_bdt(BACNET_IP_ADDRESS *bbmd_addr,
+int bvlc_bbmd_write_bdt(const BACNET_IP_ADDRESS *bbmd_addr,
     BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_list);
 /* send a Read FDT request */
 BACNET_STACK_EXPORT
-int bvlc_bbmd_read_fdt(BACNET_IP_ADDRESS *bbmd_addr);
+int bvlc_bbmd_read_fdt(const BACNET_IP_ADDRESS *bbmd_addr);
 
 /* registers with a bbmd as a foreign device */
 BACNET_STACK_EXPORT
 int bvlc_register_with_bbmd(
-    BACNET_IP_ADDRESS *address, uint16_t time_to_live_seconds);
+    const BACNET_IP_ADDRESS *address, uint16_t time_to_live_seconds);
 BACNET_STACK_EXPORT
 void bvlc_remote_bbmd_address(
     BACNET_IP_ADDRESS *address);

--- a/src/bacnet/basic/bbmd6/h_bbmd6.c
+++ b/src/bacnet/basic/bbmd6/h_bbmd6.c
@@ -114,7 +114,7 @@ void bvlc6_maintenance_timer(uint16_t seconds)
  * @return true if the address was set
  */
 static bool bbmd6_address_from_vmac(
-    BACNET_IP6_ADDRESS *addr, struct vmac_data *vmac)
+    BACNET_IP6_ADDRESS *addr, const struct vmac_data *vmac)
 {
     bool status = false;
     unsigned int i = 0;
@@ -139,7 +139,7 @@ static bool bbmd6_address_from_vmac(
  * @return true if the address was set
  */
 static bool bbmd6_address_to_vmac(
-    struct vmac_data *vmac, BACNET_IP6_ADDRESS *addr)
+    struct vmac_data *vmac, const BACNET_IP6_ADDRESS *addr)
 {
     bool status = false;
     unsigned int i = 0;
@@ -162,7 +162,7 @@ static bool bbmd6_address_to_vmac(
  * @param device_id - device ID used as the key-pair
  * @param addr - IPv6 source address
  */
-static void bbmd6_add_vmac(uint32_t device_id, BACNET_IP6_ADDRESS *addr)
+static void bbmd6_add_vmac(uint32_t device_id, const BACNET_IP6_ADDRESS *addr)
 {
     bool found = false;
     uint32_t list_device_id = 0;
@@ -224,7 +224,7 @@ static void bbmd6_add_vmac(uint32_t device_id, BACNET_IP6_ADDRESS *addr)
  *
  * @return true if the IPv6 from sin match me
  */
-static bool bbmd6_address_match_self(BACNET_IP6_ADDRESS *addr)
+static bool bbmd6_address_match_self(const BACNET_IP6_ADDRESS *addr)
 {
     BACNET_IP6_ADDRESS my_addr = { 0 };
     bool status = false;
@@ -249,7 +249,7 @@ static bool bbmd6_address_match_self(BACNET_IP6_ADDRESS *addr)
  * @return true if the address was in the VMAC table
  */
 static bool bbmd6_address_from_bacnet_address(
-    BACNET_IP6_ADDRESS *addr, uint32_t *vmac_src, BACNET_ADDRESS *baddr)
+    BACNET_IP6_ADDRESS *addr, uint32_t *vmac_src, const BACNET_ADDRESS *baddr)
 {
     struct vmac_data *vmac;
     bool status = false;
@@ -285,9 +285,9 @@ static bool bbmd6_address_from_bacnet_address(
  * @return Upon successful completion, returns the number of bytes sent.
  *  Otherwise, -1 shall be returned and errno set to indicate the error.
  */
-int bvlc6_send_pdu(BACNET_ADDRESS *dest,
-    BACNET_NPDU_DATA *npdu_data,
-    uint8_t *pdu,
+int bvlc6_send_pdu(const BACNET_ADDRESS *dest,
+    const BACNET_NPDU_DATA *npdu_data,
+    const uint8_t *pdu,
     unsigned pdu_len)
 {
     BACNET_IP6_ADDRESS bvlc_dest = { 0 };
@@ -451,7 +451,9 @@ static void bbmd6_send_forward_npdu(BACNET_IP6_ADDRESS *address,
  *  Otherwise, -1 shall be returned and errno set to indicate the error.
  */
 static int bvlc6_send_result(
-    BACNET_IP6_ADDRESS *dest_addr, uint32_t vmac_src, uint16_t result_code)
+    const BACNET_IP6_ADDRESS *dest_addr,
+    uint32_t vmac_src,
+    uint16_t result_code)
 {
     uint8_t mtu[BIP6_MPDU_MAX] = { 0 };
     uint16_t mtu_len = 0;
@@ -473,7 +475,7 @@ static int bvlc6_send_result(
  *  Otherwise, -1 shall be returned and errno set to indicate the error.
  */
 static int bvlc6_send_address_resolution_ack(
-    BACNET_IP6_ADDRESS *dest_addr, uint32_t vmac_src, uint32_t vmac_dst)
+    const BACNET_IP6_ADDRESS *dest_addr, uint32_t vmac_src, uint32_t vmac_dst)
 {
     uint8_t mtu[BIP6_MPDU_MAX] = { 0 };
     uint16_t mtu_len = 0;
@@ -497,7 +499,7 @@ static int bvlc6_send_address_resolution_ack(
  *  Otherwise, -1 shall be returned and errno set to indicate the error.
  */
 static int bvlc6_send_virtual_address_resolution_ack(
-    BACNET_IP6_ADDRESS *dest_addr, uint32_t vmac_src, uint32_t vmac_dst)
+    const BACNET_IP6_ADDRESS *dest_addr, uint32_t vmac_src, uint32_t vmac_dst)
 {
     uint8_t mtu[BIP6_MPDU_MAX] = { 0 };
     uint16_t mtu_len = 0;
@@ -516,7 +518,7 @@ static int bvlc6_send_virtual_address_resolution_ack(
  * @param pdu_len - How many bytes in NPDU+APDU buffer.
  */
 static void bbmd6_virtual_address_resolution_handler(
-    BACNET_IP6_ADDRESS *addr, uint8_t *pdu, uint16_t pdu_len)
+    const BACNET_IP6_ADDRESS *addr, const uint8_t *pdu, uint16_t pdu_len)
 {
     int function_len = 0;
     uint32_t vmac_src = 0;
@@ -550,7 +552,7 @@ static void bbmd6_virtual_address_resolution_handler(
  * @param pdu_len - How many bytes in NPDU+APDU buffer.
  */
 static void bbmd6_virtual_address_resolution_ack_handler(
-    BACNET_IP6_ADDRESS *addr, uint8_t *pdu, uint16_t pdu_len)
+    const BACNET_IP6_ADDRESS *addr, const uint8_t *pdu, uint16_t pdu_len)
 {
     int function_len = 0;
     uint32_t vmac_src = 0;
@@ -578,7 +580,7 @@ static void bbmd6_virtual_address_resolution_ack_handler(
  * @param pdu_len - How many bytes in NPDU+APDU buffer.
  */
 static void bbmd6_address_resolution_handler(
-    BACNET_IP6_ADDRESS *addr, uint8_t *pdu, uint16_t pdu_len)
+    const BACNET_IP6_ADDRESS *addr, const uint8_t *pdu, uint16_t pdu_len)
 {
     int function_len = 0;
     uint32_t vmac_src = 0;
@@ -614,7 +616,7 @@ static void bbmd6_address_resolution_handler(
  * @param pdu_len - How many bytes in NPDU+APDU buffer.
  */
 static void bbmd6_address_resolution_ack_handler(
-    BACNET_IP6_ADDRESS *addr, uint8_t *pdu, uint16_t pdu_len)
+    const BACNET_IP6_ADDRESS *addr, const uint8_t *pdu, uint16_t pdu_len)
 {
     int function_len = 0;
     uint32_t vmac_src = 0;
@@ -1039,7 +1041,7 @@ int bvlc6_handler(BACNET_IP6_ADDRESS *addr,
  *         0 if no registration request is sent, or
  *         -1 if registration fails.
  */
-int bvlc6_register_with_bbmd(BACNET_IP6_ADDRESS *bbmd_addr,
+int bvlc6_register_with_bbmd(const BACNET_IP6_ADDRESS *bbmd_addr,
     uint16_t ttl_seconds)
 {
     uint8_t mtu[BIP6_MPDU_MAX] = { 0 };

--- a/src/bacnet/basic/bbmd6/h_bbmd6.h
+++ b/src/bacnet/basic/bbmd6/h_bbmd6.h
@@ -41,14 +41,14 @@ extern "C" {
         uint16_t mtu_len);
 
     BACNET_STACK_EXPORT
-    int bvlc6_send_pdu(BACNET_ADDRESS *dest,
-        BACNET_NPDU_DATA *npdu_data,
-        uint8_t *pdu,
+    int bvlc6_send_pdu(const BACNET_ADDRESS *dest,
+        const BACNET_NPDU_DATA *npdu_data,
+        const uint8_t *pdu,
         unsigned pdu_len);
 
     BACNET_STACK_EXPORT
     int bvlc6_register_with_bbmd(
-        BACNET_IP6_ADDRESS *bbmd_addr,
+        const BACNET_IP6_ADDRESS *bbmd_addr,
         uint16_t time_to_live_seconds);
 
     BACNET_STACK_EXPORT

--- a/src/bacnet/basic/bbmd6/vmac.c
+++ b/src/bacnet/basic/bbmd6/vmac.c
@@ -52,7 +52,7 @@ unsigned int VMAC_Count(void)
  *
  * @return true if the device ID and MAC are added
  */
-bool VMAC_Add(uint32_t device_id, struct vmac_data *src)
+bool VMAC_Add(uint32_t device_id, const struct vmac_data *src)
 {
     bool status = false;
     struct vmac_data *pVMAC = NULL;
@@ -126,7 +126,9 @@ struct vmac_data *VMAC_Find_By_Key(uint32_t device_id)
  *
  * @return true if the addresses are different
  */
-bool VMAC_Different(struct vmac_data *vmac1, struct vmac_data *vmac2)
+bool VMAC_Different(
+    const struct vmac_data *vmac1,
+    const struct vmac_data *vmac2)
 {
     bool status = false;
     unsigned int i = 0;
@@ -157,7 +159,9 @@ bool VMAC_Different(struct vmac_data *vmac1, struct vmac_data *vmac2)
  *
  * @return true if the addresses are the same
  */
-bool VMAC_Match(struct vmac_data *vmac1, struct vmac_data *vmac2)
+bool VMAC_Match(
+    const struct vmac_data *vmac1,
+    const struct vmac_data *vmac2)
 {
     bool status = false;
     unsigned int i = 0;
@@ -190,7 +194,7 @@ bool VMAC_Match(struct vmac_data *vmac1, struct vmac_data *vmac2)
  *
  * @return true if the VMAC address was found
  */
-bool VMAC_Find_By_Data(struct vmac_data *vmac, uint32_t *device_id)
+bool VMAC_Find_By_Data(const struct vmac_data *vmac, uint32_t *device_id)
 {
     bool status = false;
     struct vmac_data *list_vmac;

--- a/src/bacnet/basic/bbmd6/vmac.h
+++ b/src/bacnet/basic/bbmd6/vmac.h
@@ -35,19 +35,19 @@ extern "C" {
     BACNET_STACK_EXPORT
     struct vmac_data *VMAC_Find_By_Key(uint32_t device_id);
     BACNET_STACK_EXPORT
-    bool VMAC_Find_By_Data(struct vmac_data *vmac, uint32_t *device_id);
+    bool VMAC_Find_By_Data(const struct vmac_data *vmac, uint32_t *device_id);
     BACNET_STACK_EXPORT
-    bool VMAC_Add(uint32_t device_id, struct vmac_data *pVMAC);
+    bool VMAC_Add(uint32_t device_id, const struct vmac_data *pVMAC);
     BACNET_STACK_EXPORT
     bool VMAC_Delete(uint32_t device_id);
     BACNET_STACK_EXPORT
     bool VMAC_Different(
-        struct vmac_data *vmac1,
-        struct vmac_data *vmac2);
+        const struct vmac_data *vmac1,
+        const struct vmac_data *vmac2);
     BACNET_STACK_EXPORT
     bool VMAC_Match(
-        struct vmac_data *vmac1,
-        struct vmac_data *vmac2);
+        const struct vmac_data *vmac1,
+        const struct vmac_data *vmac2);
     BACNET_STACK_EXPORT
     void VMAC_Cleanup(void);
     BACNET_STACK_EXPORT

--- a/src/bacnet/basic/binding/address.c
+++ b/src/bacnet/basic/binding/address.c
@@ -382,7 +382,7 @@ bool address_get_by_device(
  *
  * @return true/false
  */
-bool address_get_device_id(BACNET_ADDRESS *src, uint32_t *device_id)
+bool address_get_device_id(const BACNET_ADDRESS *src, uint32_t *device_id)
 {
     struct Address_Cache_Entry *pMatch;
     bool found = false; /* return value */
@@ -413,7 +413,8 @@ bool address_get_device_id(BACNET_ADDRESS *src, uint32_t *device_id)
  * @param max_apdu  Maximum APDU size.
  * @param src  Pointer to address structure to add.
  */
-void address_add(uint32_t device_id, unsigned max_apdu, BACNET_ADDRESS *src)
+void address_add(
+    uint32_t device_id, unsigned max_apdu, const BACNET_ADDRESS *src)
 {
     bool found = false; /* return value */
     struct Address_Cache_Entry *pMatch;
@@ -594,7 +595,7 @@ bool address_bind_request(
  * @param src  Pointer to the BACnet address.
  */
 void address_add_binding(
-    uint32_t device_id, unsigned max_apdu, BACNET_ADDRESS *src)
+    uint32_t device_id, unsigned max_apdu, const BACNET_ADDRESS *src)
 {
     struct Address_Cache_Entry *pMatch;
     unsigned index;

--- a/src/bacnet/basic/binding/address.h
+++ b/src/bacnet/basic/binding/address.h
@@ -38,7 +38,7 @@ extern "C" {
     void address_add(
         uint32_t device_id,
         unsigned max_apdu,
-        BACNET_ADDRESS * src);
+        const BACNET_ADDRESS * src);
 
     BACNET_STACK_EXPORT
     void address_remove_device(
@@ -67,7 +67,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     bool address_get_device_id(
-        BACNET_ADDRESS * src,
+        const BACNET_ADDRESS * src,
         uint32_t * device_id);
 
     BACNET_STACK_EXPORT
@@ -91,7 +91,7 @@ extern "C" {
     void address_add_binding(
         uint32_t device_id,
         unsigned max_apdu,
-        BACNET_ADDRESS * src);
+        const BACNET_ADDRESS * src);
 
     BACNET_STACK_EXPORT
     int address_list_encode(

--- a/src/bacnet/basic/client/bac-data.c
+++ b/src/bacnet/basic/client/bac-data.c
@@ -109,8 +109,8 @@ static void bacnet_data_object_init(void)
 }
 
 static void bacnet_data_object_store(int index,
-    BACNET_READ_PROPERTY_DATA *rp_data,
-    BACNET_APPLICATION_DATA_VALUE *value)
+    const BACNET_READ_PROPERTY_DATA *rp_data,
+    const BACNET_APPLICATION_DATA_VALUE *value)
 {
     BACNET_DATA_OBJECT *object = NULL;
 
@@ -189,7 +189,7 @@ void bacnet_data_value_save(uint32_t device_instance,
  * @brief Handles the BACnet Data Analog Value processing
  * @param object - BACnet object structure data pointer
  */
-static void bacnet_data_object_process(BACNET_DATA_OBJECT *object)
+static void bacnet_data_object_process(const BACNET_DATA_OBJECT *object)
 {
     if (object && (object->Device_ID < BACNET_MAX_INSTANCE) &&
         (object->Object_ID < BACNET_MAX_INSTANCE)) {

--- a/src/bacnet/basic/client/bac-discover.c
+++ b/src/bacnet/basic/client/bac-discover.c
@@ -555,8 +555,8 @@ bool bacnet_discover_object_property_identifier(uint32_t device_id,
  * @param device_data [in] Pointer to the device data structure
  */
 static void bacnet_device_object_property_add(uint32_t device_id,
-    BACNET_READ_PROPERTY_DATA *rp_data,
-    BACNET_APPLICATION_DATA_VALUE *value,
+    const BACNET_READ_PROPERTY_DATA *rp_data,
+    const BACNET_APPLICATION_DATA_VALUE *value,
     BACNET_DEVICE_DATA *device_data)
 {
     BACNET_OBJECT_DATA *object_data;

--- a/src/bacnet/basic/client/bac-rw.c
+++ b/src/bacnet/basic/client/bac-rw.c
@@ -351,7 +351,7 @@ static uint8_t Send_RPM_All_Request(uint32_t device_id,
  * @param service_request [in] The contents of the service request.
  * @return true if the process is finished
  */
-static bool bacnet_read_write_process(TARGET_DATA *target)
+static bool bacnet_read_write_process(const TARGET_DATA *target)
 {
     bool found = false;
     unsigned max_apdu = 0;

--- a/src/bacnet/basic/npdu/s_router.c
+++ b/src/bacnet/basic/npdu/s_router.c
@@ -46,12 +46,12 @@
  */
 int Send_Network_Layer_Message(BACNET_NETWORK_MESSAGE_TYPE network_message_type,
     BACNET_ADDRESS *dst,
-    int *iArgs)
+    const int *iArgs)
 {
     int len = 0;
     int pdu_len = 0;
     int bytes_sent = 0;
-    int *pVal = iArgs; /* Start with first value */
+    const int *pVal = iArgs; /* Start with first value */
     bool data_expecting_reply = false;
     BACNET_NPDU_DATA npdu_data;
     BACNET_ADDRESS bcastDest;
@@ -209,7 +209,7 @@ void Send_I_Am_Router_To_Network(const int DNET_list[])
 {
     /* Use a NULL dst here since we want a broadcast MAC address. */
     Send_Network_Layer_Message(
-        NETWORK_MESSAGE_I_AM_ROUTER_TO_NETWORK, NULL, (int *)DNET_list);
+        NETWORK_MESSAGE_I_AM_ROUTER_TO_NETWORK, NULL, DNET_list);
 }
 
 /** Finds a specific router, or all reachable BACnet networks.
@@ -253,7 +253,7 @@ void Send_Initialize_Routing_Table(BACNET_ADDRESS *dst, const int DNET_list[])
 {
     /* Use a NULL dst here since we want a broadcast MAC address. */
     Send_Network_Layer_Message(
-        NETWORK_MESSAGE_INIT_RT_TABLE, dst, (int *)DNET_list);
+        NETWORK_MESSAGE_INIT_RT_TABLE, dst, DNET_list);
 }
 
 /** Sends our Routing Table, built from our DNET[] array, as an ACK.
@@ -277,7 +277,7 @@ void Send_Initialize_Routing_Table_Ack(
     BACNET_ADDRESS *dst, const int DNET_list[])
 {
     Send_Network_Layer_Message(
-        NETWORK_MESSAGE_INIT_RT_TABLE_ACK, dst, (int *)DNET_list);
+        NETWORK_MESSAGE_INIT_RT_TABLE_ACK, dst, DNET_list);
 }
 
 /**

--- a/src/bacnet/basic/npdu/s_router.h
+++ b/src/bacnet/basic/npdu/s_router.h
@@ -25,7 +25,7 @@ extern "C" {
     int Send_Network_Layer_Message(
         BACNET_NETWORK_MESSAGE_TYPE network_message_type,
         BACNET_ADDRESS * dst,
-        int *iArgs);
+        const int *iArgs);
     BACNET_STACK_EXPORT
     void Send_Who_Is_Router_To_Network(
         BACNET_ADDRESS * dst,

--- a/src/bacnet/basic/object/acc.h
+++ b/src/bacnet/basic/object/acc.h
@@ -56,7 +56,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Accumulator_Description_Set(
         uint32_t instance,
-        char *new_name);
+        const char *new_name);
 
     BACNET_STACK_EXPORT
     bool Accumulator_Object_Name(

--- a/src/bacnet/basic/object/access_door.h
+++ b/src/bacnet/basic/object/access_door.h
@@ -113,7 +113,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Access_Door_Description_Set(
         uint32_t instance,
-        char *new_name);
+        const char *new_name);
 
     BACNET_STACK_EXPORT
     bool Access_Door_Out_Of_Service(

--- a/src/bacnet/basic/object/ai.c
+++ b/src/bacnet/basic/object/ai.c
@@ -261,7 +261,7 @@ bool Analog_Input_Object_Name(
  *
  * @return  true if object-name was set
  */
-bool Analog_Input_Name_Set(uint32_t object_instance, char *new_name)
+bool Analog_Input_Name_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false;
     struct analog_input_descr *pObject;
@@ -322,10 +322,10 @@ unsigned Analog_Input_Event_State(uint32_t object_instance)
  * @param  object_instance - object-instance number of the object
  * @return description text or NULL if not found
  */
-char *Analog_Input_Description(uint32_t object_instance)
+const char *Analog_Input_Description(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct analog_input_descr *pObject;
+    const char *name = NULL;
+    const struct analog_input_descr *pObject;
 
     pObject = Analog_Input_Object(object_instance);
     if (pObject) {
@@ -341,7 +341,8 @@ char *Analog_Input_Description(uint32_t object_instance)
  * @param  new_name - holds the description to be set
  * @return  true if object-name was set
  */
-bool Analog_Input_Description_Set(uint32_t object_instance, char *new_name)
+bool Analog_Input_Description_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct analog_input_descr *pObject;

--- a/src/bacnet/basic/object/ai.h
+++ b/src/bacnet/basic/object/ai.h
@@ -32,8 +32,8 @@ typedef struct analog_input_descr {
     float Prior_Value;
     float COV_Increment;
     bool Changed;
-    char* Object_Name;
-    char* Description;
+    const char* Object_Name;
+    const char* Description;
 #if defined(INTRINSIC_REPORTING)
     uint32_t Time_Delay;
     uint32_t Notification_Class;
@@ -85,18 +85,18 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Analog_Input_Name_Set(
         uint32_t object_instance,
-        char *new_name);
+        const char *new_name);
     BACNET_STACK_EXPORT
     const char * Analog_Input_Name_ASCII(
         uint32_t object_instance);
 
     BACNET_STACK_EXPORT
-    char *Analog_Input_Description(
+    const char *Analog_Input_Description(
         uint32_t instance);
     BACNET_STACK_EXPORT
     bool Analog_Input_Description_Set(
         uint32_t instance,
-        char *new_name);
+        const char *new_name);
 
     BACNET_STACK_EXPORT
     BACNET_RELIABILITY Analog_Input_Reliability(

--- a/src/bacnet/basic/object/ao.c
+++ b/src/bacnet/basic/object/ao.c
@@ -508,7 +508,7 @@ bool Analog_Output_Object_Name(
  *
  * @return  true if object-name was set
  */
-bool Analog_Output_Name_Set(uint32_t object_instance, char *new_name)
+bool Analog_Output_Name_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -684,7 +684,7 @@ BACNET_RELIABILITY Analog_Output_Reliability(uint32_t object_instance)
  * @param  object_instance - object-instance number of the object
  * @return  true the status flag is in Fault
  */
-static bool Analog_Output_Object_Fault(struct object_data *pObject)
+static bool Analog_Output_Object_Fault(const struct object_data *pObject)
 {
     bool fault = false;
 
@@ -744,14 +744,14 @@ static bool Analog_Output_Fault(uint32_t object_instance)
  * @param  object_instance - object-instance number of the object
  * @return description text or NULL if not found
  */
-char *Analog_Output_Description(uint32_t object_instance)
+const char *Analog_Output_Description(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
-        name = (char *)pObject->Description;
+        name = pObject->Description;
     }
 
     return name;
@@ -763,7 +763,8 @@ char *Analog_Output_Description(uint32_t object_instance)
  * @param  new_name - holds the description to be set
  * @return  true if object-name was set
  */
-bool Analog_Output_Description_Set(uint32_t object_instance, char *new_name)
+bool Analog_Output_Description_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;

--- a/src/bacnet/basic/object/ao.h
+++ b/src/bacnet/basic/object/ao.h
@@ -104,18 +104,18 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Analog_Output_Name_Set(
         uint32_t object_instance,
-        char *new_name);
+        const char *new_name);
     BACNET_STACK_EXPORT
     const char * Analog_Output_Name_ASCII(
         uint32_t object_instance);
 
     BACNET_STACK_EXPORT
-    char *Analog_Output_Description(
+    const char *Analog_Output_Description(
         uint32_t instance);
     BACNET_STACK_EXPORT
     bool Analog_Output_Description_Set(
         uint32_t instance,
-        char *new_name);
+        const char *new_name);
 
     BACNET_STACK_EXPORT
     bool Analog_Output_Units_Set(

--- a/src/bacnet/basic/object/av.c
+++ b/src/bacnet/basic/object/av.c
@@ -273,7 +273,7 @@ bool Analog_Value_Object_Name(
  *
  * @return  true if object-name was set
  */
-bool Analog_Value_Name_Set(uint32_t object_instance, char *new_name)
+bool Analog_Value_Name_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false;
     struct analog_value_descr *pObject;
@@ -330,10 +330,10 @@ unsigned Analog_Value_Event_State(uint32_t object_instance)
  * @param  object_instance - object-instance number of the object
  * @return description text or NULL if not found
  */
-char *Analog_Value_Description(uint32_t object_instance)
+const char *Analog_Value_Description(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct analog_value_descr *pObject;
+    const char *name = NULL;
+    const struct analog_value_descr *pObject;
 
     pObject = Analog_Value_Object(object_instance);
     if (pObject) {
@@ -349,7 +349,8 @@ char *Analog_Value_Description(uint32_t object_instance)
  * @param  new_name - holds the description to be set
  * @return  true if object-name was set
  */
-bool Analog_Value_Description_Set(uint32_t object_instance, char *new_name)
+bool Analog_Value_Description_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct analog_value_descr *pObject;

--- a/src/bacnet/basic/object/av.h
+++ b/src/bacnet/basic/object/av.h
@@ -34,7 +34,7 @@ typedef struct analog_value_descr {
     float COV_Increment;
     bool Changed;
     const char* Object_Name;
-    char* Description;
+    const char* Description;
     BACNET_RELIABILITY Reliability;
 #if defined(INTRINSIC_REPORTING)
     uint32_t Time_Delay;
@@ -82,7 +82,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Analog_Value_Name_Set(
         uint32_t object_instance,
-        char *new_name);
+        const char *new_name);
     BACNET_STACK_EXPORT
     const char *Analog_Value_Name_ASCII(
         uint32_t object_instance);
@@ -131,12 +131,12 @@ extern "C" {
         float value);
 
     BACNET_STACK_EXPORT
-    char *Analog_Value_Description(
+    const char *Analog_Value_Description(
         uint32_t instance);
     BACNET_STACK_EXPORT
     bool Analog_Value_Description_Set(
         uint32_t instance,
-        char *new_name);
+        const char *new_name);
 
     BACNET_STACK_EXPORT
     BACNET_RELIABILITY Analog_Value_Reliability(

--- a/src/bacnet/basic/object/bacfile.c
+++ b/src/bacnet/basic/object/bacfile.c
@@ -331,7 +331,7 @@ uint32_t bacfile_read(uint32_t object_instance, uint8_t *buffer,
  * @param  buffer_size - in bytes
  * @return  file size in bytes
  */
-uint32_t bacfile_write(uint32_t object_instance, uint8_t *buffer,
+uint32_t bacfile_write(uint32_t object_instance, const uint8_t *buffer,
     uint32_t buffer_size)
 {
     const char *pFilename = NULL;
@@ -877,14 +877,14 @@ bool bacfile_write_stream_data(BACNET_ATOMIC_WRITE_FILE_DATA *data)
     return found;
 }
 
-bool bacfile_write_record_data(BACNET_ATOMIC_WRITE_FILE_DATA *data)
+bool bacfile_write_record_data(const BACNET_ATOMIC_WRITE_FILE_DATA *data)
 {
     const char *pFilename = NULL;
     bool found = false;
     FILE *pFile = NULL;
     uint32_t i = 0;
     char dummy_data[FILE_RECORD_SIZE];
-    char *pData = NULL;
+    const char *pData = NULL;
 
     pFilename = bacfile_pathname(data->object_instance);
     if (pFilename) {
@@ -913,7 +913,7 @@ bool bacfile_write_record_data(BACNET_ATOMIC_WRITE_FILE_DATA *data)
                 }
             }
             for (i = 0; i < data->type.record.returnedRecordCount; i++) {
-                if (fwrite(octetstring_value(&data->fileData[i]),
+                if (fwrite(octetstring_value((BACNET_OCTET_STRING*)&data->fileData[i]),
                         octetstring_length(&data->fileData[i]), 1,
                         pFile) != 1) {
                     /* do something if it fails? */
@@ -927,7 +927,7 @@ bool bacfile_write_record_data(BACNET_ATOMIC_WRITE_FILE_DATA *data)
 }
 
 bool bacfile_read_ack_stream_data(
-    uint32_t instance, BACNET_ATOMIC_READ_FILE_DATA *data)
+    uint32_t instance, const BACNET_ATOMIC_READ_FILE_DATA *data)
 {
     bool found = false;
     FILE *pFile = NULL;
@@ -939,7 +939,7 @@ bool bacfile_read_ack_stream_data(
         pFile = fopen(pFilename, "rb+");
         if (pFile) {
             (void)fseek(pFile, data->type.stream.fileStartPosition, SEEK_SET);
-            if (fwrite(octetstring_value(&data->fileData[0]),
+            if (fwrite(octetstring_value((BACNET_OCTET_STRING*)&data->fileData[0]),
                     octetstring_length(&data->fileData[0]), 1, pFile) != 1) {
 #if PRINT_ENABLED
                 fprintf(stderr, "Failed to write to %s (%lu)!\n", pFilename,
@@ -954,7 +954,7 @@ bool bacfile_read_ack_stream_data(
 }
 
 bool bacfile_read_ack_record_data(
-    uint32_t instance, BACNET_ATOMIC_READ_FILE_DATA *data)
+    uint32_t instance, const BACNET_ATOMIC_READ_FILE_DATA *data)
 {
     bool found = false;
     FILE *pFile = NULL;
@@ -978,7 +978,7 @@ bool bacfile_read_ack_record_data(
                 }
             }
             for (i = 0; i < data->type.record.RecordCount; i++) {
-                if (fwrite(octetstring_value(&data->fileData[i]),
+                if (fwrite(octetstring_value((BACNET_OCTET_STRING*)&data->fileData[i]),
                         octetstring_length(&data->fileData[i]), 1,
                         pFile) != 1) {
 #if PRINT_ENABLED

--- a/src/bacnet/basic/object/bacfile.h
+++ b/src/bacnet/basic/object/bacfile.h
@@ -110,7 +110,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool bacfile_read_ack_stream_data(
         uint32_t instance,
-        BACNET_ATOMIC_READ_FILE_DATA * data);
+        const BACNET_ATOMIC_READ_FILE_DATA * data);
     BACNET_STACK_EXPORT
     bool bacfile_write_stream_data(
         BACNET_ATOMIC_WRITE_FILE_DATA * data);
@@ -120,10 +120,10 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool bacfile_read_ack_record_data(
         uint32_t instance,
-        BACNET_ATOMIC_READ_FILE_DATA * data);
+        const BACNET_ATOMIC_READ_FILE_DATA * data);
     BACNET_STACK_EXPORT
     bool bacfile_write_record_data(
-        BACNET_ATOMIC_WRITE_FILE_DATA * data);
+        const BACNET_ATOMIC_WRITE_FILE_DATA * data);
 
     /* handling for read property service */
     BACNET_STACK_EXPORT
@@ -154,7 +154,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     uint32_t bacfile_write(
         uint32_t object_instance,
-        uint8_t *buffer,
+        const uint8_t *buffer,
         uint32_t buffer_size);
 
     BACNET_STACK_EXPORT

--- a/src/bacnet/basic/object/bi.c
+++ b/src/bacnet/basic/object/bi.c
@@ -361,7 +361,7 @@ BACNET_RELIABILITY Binary_Input_Reliability(uint32_t object_instance)
  * @param  object_instance - object-instance number of the object
  * @return  true the status flag is in Fault
  */
-static bool Binary_Input_Object_Fault(struct object_data *pObject)
+static bool Binary_Input_Object_Fault(const struct object_data *pObject)
 {
     bool fault = false;
 
@@ -607,7 +607,7 @@ bool Binary_Input_Object_Name(
  * @param  new_name - holds the object-name to be set
  * @return  true if object-name was set
  */
-bool Binary_Input_Name_Set(uint32_t object_instance, char *new_name)
+bool Binary_Input_Name_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false;
     struct object_data *pObject;
@@ -682,17 +682,17 @@ bool Binary_Input_Polarity_Set(
  * @param  object_instance - object-instance number of the object
  * @return description text or NULL if not found
  */
-char *Binary_Input_Description(uint32_t object_instance)
+const char *Binary_Input_Description(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Binary_Input_Object(object_instance);
     if (pObject) {
         if (pObject->Description == NULL) {
             name = "";
         } else {
-            name = (char *)pObject->Description;
+            name = pObject->Description;
         }
     }
 
@@ -705,7 +705,8 @@ char *Binary_Input_Description(uint32_t object_instance)
  * @param  new_name - holds the description to be set
  * @return  true if object-name was set
  */
-bool Binary_Input_Description_Set(uint32_t object_instance, char *new_name)
+bool Binary_Input_Description_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -725,14 +726,14 @@ bool Binary_Input_Description_Set(uint32_t object_instance, char *new_name)
  * @param object_instance - object-instance number of the object
  * @return inactive-text property value
  */
-char *Binary_Input_Inactive_Text(uint32_t object_instance)
+const char *Binary_Input_Inactive_Text(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Binary_Input_Object(object_instance);
     if (pObject) {
-        name = (char *)pObject->Inactive_Text;
+        name = pObject->Inactive_Text;
     }
 
     return name;
@@ -745,7 +746,8 @@ char *Binary_Input_Inactive_Text(uint32_t object_instance)
  * @param new_name - holds the inactive-text to be set
  * @return true if the inactive-text property value was set
  */
-bool Binary_Input_Inactive_Text_Set(uint32_t object_instance, char *new_name)
+bool Binary_Input_Inactive_Text_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false;
     struct object_data *pObject;
@@ -765,14 +767,14 @@ bool Binary_Input_Inactive_Text_Set(uint32_t object_instance, char *new_name)
  * @param object_instance - object-instance number of the object
  * @return active-text property value
  */
-char *Binary_Input_Active_Text(uint32_t object_instance)
+const char *Binary_Input_Active_Text(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Binary_Input_Object(object_instance);
     if (pObject) {
-        name = (char *)pObject->Active_Text;
+        name = pObject->Active_Text;
     }
 
     return name;
@@ -785,7 +787,8 @@ char *Binary_Input_Active_Text(uint32_t object_instance)
  * @param new_name - holds the active-text to be set
  * @return true if the active-text property value was set
  */
-bool Binary_Input_Active_Text_Set(uint32_t object_instance, char *new_name)
+bool Binary_Input_Active_Text_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false;
     struct object_data *pObject;

--- a/src/bacnet/basic/object/bi.h
+++ b/src/bacnet/basic/object/bi.h
@@ -68,7 +68,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Binary_Input_Name_Set(
         uint32_t object_instance,
-        char *new_name);
+        const char *new_name);
     BACNET_STACK_EXPORT
     const char *Binary_Input_Name_ASCII(
         uint32_t object_instance);
@@ -82,12 +82,12 @@ extern "C" {
         BACNET_BINARY_PV value);
 
     BACNET_STACK_EXPORT
-    char *Binary_Input_Description(
+    const char *Binary_Input_Description(
         uint32_t instance);
     BACNET_STACK_EXPORT
     bool Binary_Input_Description_Set(
         uint32_t instance,
-        char *new_name);
+        const char *new_name);
 
     BACNET_STACK_EXPORT
     BACNET_RELIABILITY Binary_Input_Reliability(
@@ -98,20 +98,20 @@ extern "C" {
         BACNET_RELIABILITY value);
 
     BACNET_STACK_EXPORT
-    char *Binary_Input_Inactive_Text(
+    const char *Binary_Input_Inactive_Text(
         uint32_t instance);
     BACNET_STACK_EXPORT
     bool Binary_Input_Inactive_Text_Set(
         uint32_t instance,
-        char *new_name);
+        const char *new_name);
 
     BACNET_STACK_EXPORT
-    char *Binary_Input_Active_Text(
+    const char *Binary_Input_Active_Text(
         uint32_t instance);
     BACNET_STACK_EXPORT
     bool Binary_Input_Active_Text_Set(
         uint32_t instance,
-        char *new_name);
+        const char *new_name);
 
     BACNET_STACK_EXPORT
     BACNET_POLARITY Binary_Input_Polarity(

--- a/src/bacnet/basic/object/bitstring_value.c
+++ b/src/bacnet/basic/object/bitstring_value.c
@@ -172,7 +172,7 @@ bool BitString_Value_Present_Value(
  * @return  true if value is within range and copied
  */
 bool BitString_Value_Present_Value_Set(
-    uint32_t object_instance, BACNET_BIT_STRING *value)
+    uint32_t object_instance, const BACNET_BIT_STRING *value)
 {
     bool status = false;
     struct object_data *pObject;
@@ -306,7 +306,7 @@ BACNET_RELIABILITY BitString_Value_Reliablity(
  * @param  object_instance - object-instance number of the object
  * @return  true the status flag is in Fault
  */
-static bool BitString_Value_Object_Fault(struct object_data *pObject)
+static bool BitString_Value_Object_Fault(const struct object_data *pObject)
 {
     bool fault = false;
 
@@ -460,7 +460,7 @@ bool BitString_Value_Object_Name(
  *
  * @return  true if object-name was set
  */
-bool BitString_Value_Name_Set(uint32_t object_instance, char *new_name)
+bool BitString_Value_Name_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -498,15 +498,15 @@ const char *BitString_Value_Name_ASCII(uint32_t object_instance)
  * @return  C-string pointer to the description,
  *  or NULL if object doesn't exist
  */
-char *BitString_Value_Description(uint32_t object_instance)
+const char *BitString_Value_Description(uint32_t object_instance)
 {
-    char *name = NULL; /* return value */
-    struct object_data *pObject;
+    const char *name = NULL; /* return value */
+    const struct object_data *pObject;
 
     pObject = BitString_Value_Object(object_instance);
     if (pObject) {
         if (pObject->Description) {
-            name = (char *)pObject->Description;
+            name = pObject->Description;
         } else {
             name = "";
         }
@@ -525,7 +525,7 @@ char *BitString_Value_Description(uint32_t object_instance)
  * @return True on success, false otherwise.
  */
 bool BitString_Value_Description_Set(
-    uint32_t object_instance, char *value)
+    uint32_t object_instance, const char *value)
 {
     bool status = false; /* return value */
     struct object_data *pObject;

--- a/src/bacnet/basic/object/bitstring_value.h
+++ b/src/bacnet/basic/object/bitstring_value.h
@@ -76,7 +76,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool BitString_Value_Name_Set(
         uint32_t object_instance,
-        char *new_name);
+        const char *new_name);
     BACNET_STACK_EXPORT
     const char *BitString_Value_Name_ASCII(
         uint32_t object_instance);
@@ -88,15 +88,15 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool BitString_Value_Present_Value_Set(
         uint32_t object_instance,
-        BACNET_BIT_STRING * value);
+        const BACNET_BIT_STRING * value);
 
     BACNET_STACK_EXPORT
-    char *BitString_Value_Description(
+    const char *BitString_Value_Description(
         uint32_t instance);
     BACNET_STACK_EXPORT
     bool BitString_Value_Description_Set(
         uint32_t object_instance,
-        char *text_string);
+        const char *text_string);
 
     BACNET_STACK_EXPORT
     bool BitString_Value_Out_Of_Service(

--- a/src/bacnet/basic/object/blo.c
+++ b/src/bacnet/basic/object/blo.c
@@ -171,7 +171,7 @@ unsigned Binary_Lighting_Output_Instance_To_Index(uint32_t object_instance)
  * @return the priority-array active status for the specific priority
  */
 static bool Priority_Array_Active(
-    struct object_data *pObject, BACNET_ARRAY_INDEX priority)
+    const struct object_data *pObject, BACNET_ARRAY_INDEX priority)
 {
     bool active = false;
 
@@ -193,7 +193,7 @@ static bool Priority_Array_Active(
  * @return The priority-array value for the specific priority
  */
 static BACNET_BINARY_LIGHTING_PV Priority_Array_Next_Value(
-    struct object_data *pObject, BACNET_ARRAY_INDEX priority)
+    const struct object_data *pObject, BACNET_ARRAY_INDEX priority)
 {
     BACNET_BINARY_LIGHTING_PV value = BINARY_LIGHTING_PV_OFF;
     unsigned p = 0;
@@ -238,7 +238,7 @@ BACNET_BINARY_LIGHTING_PV Binary_Lighting_Output_Present_Value(
  * @return The priority-array value for the specific priority
  */
 static BACNET_BINARY_LIGHTING_PV Priority_Array_Value(
-    struct object_data *pObject, BACNET_ARRAY_INDEX priority)
+    const struct object_data *pObject, BACNET_ARRAY_INDEX priority)
 {
     BACNET_BINARY_LIGHTING_PV value = BINARY_LIGHTING_PV_OFF;
 
@@ -290,7 +290,7 @@ static int Binary_Lighting_Output_Priority_Array_Encode(
  *
  * @return  active priority 1..16, or 0 if no priority is active
  */
-static unsigned Present_Value_Priority(struct object_data *pObject)
+static unsigned Present_Value_Priority(const struct object_data *pObject)
 {
     unsigned p = 0; /* loop counter */
     unsigned priority = 0; /* return value */
@@ -787,7 +787,8 @@ bool Binary_Lighting_Output_Object_Name(
  *
  * @return  true if object-name was set
  */
-bool Binary_Lighting_Output_Name_Set(uint32_t object_instance, char *new_name)
+bool Binary_Lighting_Output_Name_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -826,15 +827,15 @@ const char *Binary_Lighting_Output_Name_ASCII(uint32_t object_instance)
  *
  * @return description text or NULL if not found
  */
-char *Binary_Lighting_Output_Description(uint32_t object_instance)
+const char *Binary_Lighting_Output_Description(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if (pObject->Description) {
-            name = (char *)pObject->Description;
+            name = pObject->Description;
         } else {
             name = "";
         }
@@ -852,7 +853,7 @@ char *Binary_Lighting_Output_Description(uint32_t object_instance)
  * @return  true if object-name was set
  */
 bool Binary_Lighting_Output_Description_Set(
-    uint32_t object_instance, char *new_name)
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;

--- a/src/bacnet/basic/object/blo.h
+++ b/src/bacnet/basic/object/blo.h
@@ -84,14 +84,16 @@ BACNET_STACK_EXPORT
 bool Binary_Lighting_Output_Object_Name(
     uint32_t object_instance, BACNET_CHARACTER_STRING *object_name);
 BACNET_STACK_EXPORT
-bool Binary_Lighting_Output_Name_Set(uint32_t object_instance, char *new_name);
+bool Binary_Lighting_Output_Name_Set(
+    uint32_t object_instance, const char *new_name);
 BACNET_STACK_EXPORT
 const char *Binary_Lighting_Output_Name_ASCII(uint32_t object_instance);
 
 BACNET_STACK_EXPORT
-char *Binary_Lighting_Output_Description(uint32_t instance);
+const char *Binary_Lighting_Output_Description(uint32_t instance);
 BACNET_STACK_EXPORT
-bool Binary_Lighting_Output_Description_Set(uint32_t instance, char *new_name);
+bool Binary_Lighting_Output_Description_Set(
+    uint32_t instance, const char *new_name);
 
 BACNET_STACK_EXPORT
 bool Binary_Lighting_Output_Out_Of_Service(uint32_t instance);

--- a/src/bacnet/basic/object/bo.c
+++ b/src/bacnet/basic/object/bo.c
@@ -537,7 +537,7 @@ bool Binary_Output_Object_Name(
  *
  * @return  true if object-name was set
  */
-bool Binary_Output_Name_Set(uint32_t object_instance, char *new_name)
+bool Binary_Output_Name_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -701,7 +701,7 @@ BACNET_RELIABILITY Binary_Output_Reliability(uint32_t object_instance)
  *
  * @return  true the status flag is in Fault
  */
-static bool Binary_Output_Object_Fault(struct object_data *pObject)
+static bool Binary_Output_Object_Fault(const struct object_data *pObject)
 {
     bool fault = false;
 
@@ -767,14 +767,14 @@ static bool Binary_Output_Fault(uint32_t object_instance)
  *
  * @return description text or NULL if not found
  */
-char *Binary_Output_Description(uint32_t object_instance)
+const char *Binary_Output_Description(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
-        name = (char *)pObject->Description;
+        name = pObject->Description;
     }
 
     return name;
@@ -788,7 +788,8 @@ char *Binary_Output_Description(uint32_t object_instance)
  *
  * @return  true if object-name was set
  */
-bool Binary_Output_Description_Set(uint32_t object_instance, char *new_name)
+bool Binary_Output_Description_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -809,14 +810,14 @@ bool Binary_Output_Description_Set(uint32_t object_instance, char *new_name)
  *
  * @return active text or NULL if not found
  */
-char *Binary_Output_Active_Text(uint32_t object_instance)
+const char *Binary_Output_Active_Text(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
-        name = (char *)pObject->Active_Text;
+        name = pObject->Active_Text;
     }
 
     return name;
@@ -830,7 +831,8 @@ char *Binary_Output_Active_Text(uint32_t object_instance)
  *
  * @return  true if object-name was set
  */
-bool Binary_Output_Active_Text_Set(uint32_t object_instance, char *new_name)
+bool Binary_Output_Active_Text_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -851,14 +853,14 @@ bool Binary_Output_Active_Text_Set(uint32_t object_instance, char *new_name)
  *
  * @return active text or NULL if not found
  */
-char *Binary_Output_Inactive_Text(uint32_t object_instance)
+const char *Binary_Output_Inactive_Text(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
-        name = (char *)pObject->Inactive_Text;
+        name = pObject->Inactive_Text;
     }
 
     return name;
@@ -872,7 +874,8 @@ char *Binary_Output_Inactive_Text(uint32_t object_instance)
  *
  * @return  true if object-name was set
  */
-bool Binary_Output_Inactive_Text_Set(uint32_t object_instance, char *new_name)
+bool Binary_Output_Inactive_Text_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;

--- a/src/bacnet/basic/object/bo.h
+++ b/src/bacnet/basic/object/bo.h
@@ -66,25 +66,25 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Binary_Output_Name_Set(
         uint32_t object_instance,
-        char *new_name);
+        const char *new_name);
     BACNET_STACK_EXPORT
     const char *Binary_Output_Name_ASCII(
         uint32_t object_instance);
 
     BACNET_STACK_EXPORT
-    char *Binary_Output_Inactive_Text(
+    const char *Binary_Output_Inactive_Text(
         uint32_t instance);
     BACNET_STACK_EXPORT
     bool Binary_Output_Inactive_Text_Set(
         uint32_t instance,
-        char *new_name);
+        const char *new_name);
     BACNET_STACK_EXPORT
-    char *Binary_Output_Active_Text(
+    const char *Binary_Output_Active_Text(
         uint32_t instance);
     BACNET_STACK_EXPORT
     bool Binary_Output_Active_Text_Set(
         uint32_t instance,
-        char *new_name);
+        const char *new_name);
 
     BACNET_STACK_EXPORT
     BACNET_BINARY_PV Binary_Output_Present_Value(
@@ -115,12 +115,12 @@ extern "C" {
         bool value);
 
     BACNET_STACK_EXPORT
-    char *Binary_Output_Description(
+    const char *Binary_Output_Description(
         uint32_t instance);
     BACNET_STACK_EXPORT
     bool Binary_Output_Description_Set(
         uint32_t object_instance,
-        char *text_string);
+        const char *text_string);
 
     BACNET_STACK_EXPORT
     BACNET_POLARITY Binary_Output_Polarity(

--- a/src/bacnet/basic/object/bv.c
+++ b/src/bacnet/basic/object/bv.c
@@ -362,7 +362,7 @@ BACNET_RELIABILITY Binary_Value_Reliability(uint32_t object_instance)
  * @param  object_instance - object-instance number of the object
  * @return  true the status flag is in Fault
  */
-static bool Binary_Value_Object_Fault(struct object_data *pObject)
+static bool Binary_Value_Object_Fault(const struct object_data *pObject)
 {
     bool fault = false;
 
@@ -610,7 +610,7 @@ bool Binary_Value_Object_Name(
  * @param  new_name - holds the object-name to be set
  * @return  true if object-name was set
  */
-bool Binary_Value_Name_Set(uint32_t object_instance, char *new_name)
+bool Binary_Value_Name_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false;
     struct object_data *pObject;
@@ -685,17 +685,17 @@ bool Binary_Value_Polarity_Set(
  * @param  object_instance - object-instance number of the object
  * @return description text or NULL if not found
  */
-char *Binary_Value_Description(uint32_t object_instance)
+const char *Binary_Value_Description(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Binary_Value_Object(object_instance);
     if (pObject) {
         if (pObject->Description == NULL) {
             name = "";
         } else {
-            name = (char *)pObject->Description;
+            name = pObject->Description;
         }
     }
 
@@ -708,7 +708,8 @@ char *Binary_Value_Description(uint32_t object_instance)
  * @param  new_name - holds the description to be set
  * @return  true if object-name was set
  */
-bool Binary_Value_Description_Set(uint32_t object_instance, char *new_name)
+bool Binary_Value_Description_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -729,14 +730,14 @@ bool Binary_Value_Description_Set(uint32_t object_instance, char *new_name)
  *
  * @return active text or NULL if not found
  */
-char *Binary_Value_Active_Text(uint32_t object_instance)
+const char *Binary_Value_Active_Text(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Binary_Value_Object(object_instance);
     if (pObject) {
-        name = (char *)pObject->Active_Text;
+        name = pObject->Active_Text;
     }
 
     return name;
@@ -750,7 +751,8 @@ char *Binary_Value_Active_Text(uint32_t object_instance)
  *
  * @return  true if object-name was set
  */
-bool Binary_Value_Active_Text_Set(uint32_t object_instance, char *new_name)
+bool Binary_Value_Active_Text_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -771,14 +773,14 @@ bool Binary_Value_Active_Text_Set(uint32_t object_instance, char *new_name)
  *
  * @return active text or NULL if not found
  */
-char *Binary_Value_Inactive_Text(uint32_t object_instance)
+const char *Binary_Value_Inactive_Text(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Binary_Value_Object(object_instance);
     if (pObject) {
-        name = (char *)pObject->Inactive_Text;
+        name = pObject->Inactive_Text;
     }
 
     return name;
@@ -792,7 +794,8 @@ char *Binary_Value_Inactive_Text(uint32_t object_instance)
  *
  * @return  true if object-name was set
  */
-bool Binary_Value_Inactive_Text_Set(uint32_t object_instance, char *new_name)
+bool Binary_Value_Inactive_Text_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;

--- a/src/bacnet/basic/object/bv.h
+++ b/src/bacnet/basic/object/bv.h
@@ -71,7 +71,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Binary_Value_Name_Set(
         uint32_t object_instance,
-        char *new_name);
+        const char *new_name);
     BACNET_STACK_EXPORT
     const char *Binary_Value_Name_ASCII(
         uint32_t object_instance);
@@ -130,27 +130,27 @@ extern "C" {
         bool value);
 
     BACNET_STACK_EXPORT
-    char *Binary_Value_Description(
+    const char *Binary_Value_Description(
         uint32_t instance);
     BACNET_STACK_EXPORT
     bool Binary_Value_Description_Set(
         uint32_t object_instance,
-        char *text_string);
+        const char *text_string);
 
     BACNET_STACK_EXPORT
-    char *Binary_Value_Inactive_Text(
+    const char *Binary_Value_Inactive_Text(
         uint32_t instance);
     BACNET_STACK_EXPORT
     bool Binary_Value_Inactive_Text_Set(
         uint32_t instance,
-        char *new_name);
+        const char *new_name);
     BACNET_STACK_EXPORT
-    char *Binary_Value_Active_Text(
+    const char *Binary_Value_Active_Text(
         uint32_t instance);
     BACNET_STACK_EXPORT
     bool Binary_Value_Active_Text_Set(
         uint32_t instance,
-        char *new_name);
+        const char *new_name);
 
     BACNET_STACK_EXPORT
     BACNET_POLARITY Binary_Value_Polarity(

--- a/src/bacnet/basic/object/calendar.c
+++ b/src/bacnet/basic/object/calendar.c
@@ -239,7 +239,7 @@ Calendar_Date_List_Get(uint32_t object_instance, uint8_t index)
  * @return  true if the entity is add successfully.
  */
 bool Calendar_Date_List_Add(
-    uint32_t object_instance, BACNET_CALENDAR_ENTRY *value)
+    uint32_t object_instance, const BACNET_CALENDAR_ENTRY *value)
 {
     bool st = false;
     BACNET_CALENDAR_ENTRY *entry;
@@ -403,7 +403,7 @@ bool Calendar_Object_Name(
  *
  * @return  true if object-name was set
  */
-bool Calendar_Name_Set(uint32_t object_instance, char *new_name)
+bool Calendar_Name_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -442,15 +442,15 @@ const char *Calendar_Name_ASCII(uint32_t object_instance)
  *
  * @return description text or NULL if not found
  */
-char *Calendar_Description(uint32_t object_instance)
+const char *Calendar_Description(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if (pObject->Description) {
-            name = (char *)pObject->Description;
+            name = pObject->Description;
         } else {
             name = "";
         }
@@ -467,7 +467,7 @@ char *Calendar_Description(uint32_t object_instance)
  *
  * @return  true if object-name was set
  */
-bool Calendar_Description_Set(uint32_t object_instance, char *new_name)
+bool Calendar_Description_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;

--- a/src/bacnet/basic/object/calendar.h
+++ b/src/bacnet/basic/object/calendar.h
@@ -47,7 +47,7 @@ BACNET_STACK_EXPORT
 bool Calendar_Object_Name(
     uint32_t object_instance, BACNET_CHARACTER_STRING *object_name);
 BACNET_STACK_EXPORT
-bool Calendar_Name_Set(uint32_t object_instance, char *new_name);
+bool Calendar_Name_Set(uint32_t object_instance, const char *new_name);
 BACNET_STACK_EXPORT
 const char *Calendar_Name_ASCII(uint32_t object_instance);
 
@@ -68,7 +68,7 @@ BACNET_CALENDAR_ENTRY *Calendar_Date_List_Get(
     uint32_t object_instance, uint8_t index);
 BACNET_STACK_EXPORT
 bool Calendar_Date_List_Add(
-    uint32_t object_instance, BACNET_CALENDAR_ENTRY *value);
+    uint32_t object_instance, const BACNET_CALENDAR_ENTRY *value);
 BACNET_STACK_EXPORT
 bool Calendar_Date_List_Delete_All(uint32_t object_instance);
 BACNET_STACK_EXPORT
@@ -78,9 +78,9 @@ int Calendar_Date_List_Encode(
     uint32_t object_instance, uint8_t *apdu, int max_apdu);
 
 BACNET_STACK_EXPORT
-char *Calendar_Description(uint32_t object_instance);
+const char *Calendar_Description(uint32_t object_instance);
 BACNET_STACK_EXPORT
-bool Calendar_Description_Set(uint32_t object_instance, char *new_name);
+bool Calendar_Description_Set(uint32_t object_instance, const char *new_name);
 
 BACNET_STACK_EXPORT
 bool Calendar_Write_Enabled(uint32_t instance);

--- a/src/bacnet/basic/object/channel.c
+++ b/src/bacnet/basic/object/channel.c
@@ -99,7 +99,7 @@ void Channel_Property_Lists(
  */
 bool Channel_Valid_Instance(uint32_t object_instance)
 {
-    struct object_data *pObject;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
@@ -179,7 +179,7 @@ BACNET_CHANNEL_VALUE *Channel_Present_Value(uint32_t object_instance)
 unsigned Channel_Last_Priority(uint32_t object_instance)
 {
     unsigned priority = 0;
-    struct object_data *pObject;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
@@ -199,7 +199,7 @@ unsigned Channel_Last_Priority(uint32_t object_instance)
 BACNET_WRITE_STATUS Channel_Write_Status(uint32_t object_instance)
 {
     BACNET_WRITE_STATUS write_status = BACNET_WRITE_STATUS_IDLE;
-    struct object_data *pObject;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
@@ -219,7 +219,7 @@ BACNET_WRITE_STATUS Channel_Write_Status(uint32_t object_instance)
 uint16_t Channel_Number(uint32_t object_instance)
 {
     uint16_t value = 0;
-    struct object_data *pObject;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
@@ -266,7 +266,7 @@ static int Channel_Reference_List_Member_Element_Encode(
     uint32_t object_instance, BACNET_ARRAY_INDEX array_index, uint8_t *apdu)
 {
     int apdu_len = BACNET_STATUS_ERROR;
-    BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value;
+    const BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *value;
     unsigned count = 0;
 
     count = Channel_Reference_List_Member_Count(object_instance);
@@ -287,7 +287,7 @@ static int Channel_Reference_List_Member_Element_Encode(
  * @return member count
  */
 static bool Channel_Reference_List_Member_Valid(
-    BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *pMember)
+    const BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *pMember)
 {
     bool status = false;
 
@@ -348,7 +348,7 @@ BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *Channel_Reference_List_Member_Element(
  */
 bool Channel_Reference_List_Member_Element_Set(uint32_t object_instance,
     unsigned array_index,
-    BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *pMemberSrc)
+    const BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *pMemberSrc)
 {
     BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *pMember = NULL;
     bool status = false;
@@ -378,7 +378,7 @@ bool Channel_Reference_List_Member_Element_Set(uint32_t object_instance,
  * zero if not added
  */
 unsigned Channel_Reference_List_Member_Element_Add(uint32_t object_instance,
-    BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *pMemberSrc)
+    const BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *pMemberSrc)
 {
     BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *pMember = NULL;
     unsigned array_index = 0;
@@ -414,7 +414,7 @@ uint16_t Channel_Control_Groups_Element(
     uint32_t object_instance, int32_t array_index)
 {
     uint16_t value = 0;
-    struct object_data *pObject;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
@@ -469,7 +469,7 @@ static int Channel_Control_Groups_Element_Encode(
 {
     int apdu_len = BACNET_STATUS_ERROR;
     uint16_t value = 1;
-    struct object_data *pObject;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject && (array_index < CONTROL_GROUPS_MAX)) {
@@ -490,7 +490,7 @@ static int Channel_Control_Groups_Element_Encode(
  * @return  true if values are able to be copied
  */
 bool Channel_Value_Copy(
-    BACNET_CHANNEL_VALUE *cvalue, BACNET_APPLICATION_DATA_VALUE *value)
+    BACNET_CHANNEL_VALUE *cvalue, const BACNET_APPLICATION_DATA_VALUE *value)
 {
     bool status = false;
 
@@ -631,7 +631,7 @@ bool Channel_Value_Copy(
  * @return  number of bytes in the APDU, or BACNET_STATUS_ERROR
  */
 int Channel_Value_Encode(
-    uint8_t *apdu, int apdu_max, BACNET_CHANNEL_VALUE *value)
+    uint8_t *apdu, int apdu_max, const BACNET_CHANNEL_VALUE *value)
 {
     int apdu_len = BACNET_STATUS_ERROR;
 
@@ -743,7 +743,7 @@ int Channel_Value_Encode(
  * @return  number of bytes in the APDU, or BACNET_STATUS_ERROR if error.
  */
 static int Coerce_Data_Encode(uint8_t *apdu,
-    BACNET_APPLICATION_DATA_VALUE *value,
+    const BACNET_APPLICATION_DATA_VALUE *value,
     BACNET_APPLICATION_TAG tag)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -1060,7 +1060,7 @@ static int Coerce_Data_Encode(uint8_t *apdu,
  */
 int Channel_Coerce_Data_Encode(uint8_t *apdu,
     size_t apdu_size,
-    BACNET_APPLICATION_DATA_VALUE *value,
+    const BACNET_APPLICATION_DATA_VALUE *value,
     BACNET_APPLICATION_TAG tag)
 {
     int len;
@@ -1084,7 +1084,7 @@ int Channel_Coerce_Data_Encode(uint8_t *apdu,
  * @return  true if values are within range and present-value is sent.
  */
 bool Channel_Write_Member_Value(
-    BACNET_WRITE_PROPERTY_DATA *wp_data, BACNET_APPLICATION_DATA_VALUE *value)
+    BACNET_WRITE_PROPERTY_DATA *wp_data, const BACNET_APPLICATION_DATA_VALUE *value)
 {
     bool status = false;
     int apdu_len = 0;
@@ -1191,13 +1191,13 @@ bool Channel_Write_Member_Value(
  * @return  true if values are within range and present-value is sent.
  */
 static bool Channel_Write_Members(struct object_data *pObject,
-    BACNET_APPLICATION_DATA_VALUE *value,
+    const BACNET_APPLICATION_DATA_VALUE *value,
     uint8_t priority)
 {
     BACNET_WRITE_PROPERTY_DATA wp_data = { 0 };
     bool status = false;
     unsigned m = 0;
-    BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *pMember = NULL;
+    const BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *pMember = NULL;
 
     if (pObject && value) {
         pObject->Write_Status = BACNET_WRITE_STATUS_IN_PROGRESS;
@@ -1244,7 +1244,7 @@ static bool Channel_Write_Members(struct object_data *pObject,
  * @return true if values are within range and present-value is sent.
  */
 bool Channel_Present_Value_Set(
-    BACNET_WRITE_PROPERTY_DATA *wp_data, BACNET_APPLICATION_DATA_VALUE *value)
+    BACNET_WRITE_PROPERTY_DATA *wp_data, const BACNET_APPLICATION_DATA_VALUE *value)
 {
     bool status = false;
     struct object_data *pObject;
@@ -1291,7 +1291,7 @@ bool Channel_Object_Name(
 {
     bool status = false;
     char name_text[24] = "CHANNEL-4194303";
-    struct object_data *pObject;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
@@ -1316,7 +1316,7 @@ bool Channel_Object_Name(
  *
  * @return  true if object-name was set
  */
-bool Channel_Name_Set(uint32_t object_instance, char *new_name)
+bool Channel_Name_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -1359,7 +1359,7 @@ const char *Channel_Name_ASCII(uint32_t object_instance)
 bool Channel_Out_Of_Service(uint32_t object_instance)
 {
     bool value = false;
-    struct object_data *pObject;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
@@ -1402,7 +1402,7 @@ int Channel_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata)
     int apdu_len = 0; /* return value */
     BACNET_BIT_STRING bit_string;
     BACNET_CHARACTER_STRING char_string;
-    BACNET_CHANNEL_VALUE *cvalue = NULL;
+    const BACNET_CHANNEL_VALUE *cvalue = NULL;
     uint32_t unsigned_value = 0;
     unsigned count = 0;
     bool state = false;

--- a/src/bacnet/basic/object/channel.h
+++ b/src/bacnet/basic/object/channel.h
@@ -119,7 +119,7 @@ BACNET_STACK_EXPORT
 bool Channel_Object_Name(
     uint32_t object_instance, BACNET_CHARACTER_STRING *object_name);
 BACNET_STACK_EXPORT
-bool Channel_Name_Set(uint32_t object_instance, char *new_name);
+bool Channel_Name_Set(uint32_t object_instance, const char *new_name);
 BACNET_STACK_EXPORT
 const char *Channel_Name_ASCII(uint32_t object_instance);
 
@@ -132,7 +132,7 @@ BACNET_STACK_EXPORT
 BACNET_CHANNEL_VALUE *Channel_Present_Value(uint32_t object_instance);
 BACNET_STACK_EXPORT
 bool Channel_Present_Value_Set(
-    BACNET_WRITE_PROPERTY_DATA *wp_data, BACNET_APPLICATION_DATA_VALUE *value);
+    BACNET_WRITE_PROPERTY_DATA *wp_data, const BACNET_APPLICATION_DATA_VALUE *value);
 
 BACNET_STACK_EXPORT
 bool Channel_Out_Of_Service(uint32_t object_instance);
@@ -155,10 +155,10 @@ BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *Channel_Reference_List_Member_Element(
 BACNET_STACK_EXPORT
 bool Channel_Reference_List_Member_Element_Set(uint32_t object_instance,
     unsigned array_index,
-    BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *pMemberSrc);
+    const BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *pMemberSrc);
 BACNET_STACK_EXPORT
 unsigned Channel_Reference_List_Member_Element_Add(uint32_t object_instance,
-    BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *pMemberSrc);
+    const BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *pMemberSrc);
 BACNET_STACK_EXPORT
 uint16_t Channel_Control_Groups_Element(
     uint32_t object_instance, int32_t array_index);
@@ -167,18 +167,18 @@ bool Channel_Control_Groups_Element_Set(
     uint32_t object_instance, int32_t array_index, uint16_t value);
 BACNET_STACK_EXPORT
 bool Channel_Value_Copy(
-    BACNET_CHANNEL_VALUE *cvalue, BACNET_APPLICATION_DATA_VALUE *value);
+    BACNET_CHANNEL_VALUE *cvalue, const BACNET_APPLICATION_DATA_VALUE *value);
 BACNET_STACK_EXPORT
 int Channel_Value_Encode(
-    uint8_t *apdu, int apdu_max, BACNET_CHANNEL_VALUE *value);
+    uint8_t *apdu, int apdu_max, const BACNET_CHANNEL_VALUE *value);
 BACNET_STACK_EXPORT
 int Channel_Coerce_Data_Encode(uint8_t *apdu,
     size_t apdu_size,
-    BACNET_APPLICATION_DATA_VALUE *value,
+    const BACNET_APPLICATION_DATA_VALUE *value,
     BACNET_APPLICATION_TAG tag);
 BACNET_STACK_EXPORT
 bool Channel_Write_Member_Value(
-    BACNET_WRITE_PROPERTY_DATA *wp_data, BACNET_APPLICATION_DATA_VALUE *value);
+    BACNET_WRITE_PROPERTY_DATA *wp_data, const BACNET_APPLICATION_DATA_VALUE *value);
 
 BACNET_STACK_EXPORT
 void Channel_Write_Property_Internal_Callback_Set(

--- a/src/bacnet/basic/object/client/device-client.c
+++ b/src/bacnet/basic/object/client/device-client.c
@@ -383,7 +383,7 @@ bool Device_Object_Name(
     return status;
 }
 
-bool Device_Set_Object_Name(BACNET_CHARACTER_STRING *object_name)
+bool Device_Set_Object_Name(const BACNET_CHARACTER_STRING *object_name)
 {
     bool status = false; /*return value */
 
@@ -724,7 +724,7 @@ int Device_Object_List_Element_Encode(
  * Object.
  * @return True on success or else False if not found.
  */
-bool Device_Valid_Object_Name(BACNET_CHARACTER_STRING *object_name1,
+bool Device_Valid_Object_Name(const BACNET_CHARACTER_STRING *object_name1,
     BACNET_OBJECT_TYPE *object_type,
     uint32_t *object_instance)
 {

--- a/src/bacnet/basic/object/color_object.c
+++ b/src/bacnet/basic/object/color_object.c
@@ -188,7 +188,7 @@ bool Color_Present_Value(uint32_t object_instance, BACNET_XY_COLOR *value)
  *
  * @return  true if values are within range and present-value is set.
  */
-bool Color_Present_Value_Set(uint32_t object_instance, BACNET_XY_COLOR *value)
+bool Color_Present_Value_Set(uint32_t object_instance, const BACNET_XY_COLOR *value)
 {
     bool status = false;
     struct object_data *pObject;
@@ -214,7 +214,7 @@ bool Color_Present_Value_Set(uint32_t object_instance, BACNET_XY_COLOR *value)
  * @return  true if values are within range and present-value is set.
  */
 static bool Color_Present_Value_Write(uint32_t object_instance,
-    BACNET_XY_COLOR *value,
+    const BACNET_XY_COLOR *value,
     uint8_t priority,
     BACNET_ERROR_CLASS *error_class,
     BACNET_ERROR_CODE *error_code)
@@ -273,7 +273,8 @@ bool Color_Tracking_Value(uint32_t object_instance, BACNET_XY_COLOR *value)
  *
  * @return  true if values are within range and present-value is set.
  */
-bool Color_Tracking_Value_Set(uint32_t object_instance, BACNET_XY_COLOR *value)
+bool Color_Tracking_Value_Set(
+    uint32_t object_instance, const BACNET_XY_COLOR *value)
 {
     bool status = false;
     struct object_data *pObject;
@@ -315,7 +316,8 @@ bool Color_Command(uint32_t object_instance, BACNET_COLOR_COMMAND *value)
  * @param  value - color command data
  * @return  true if values are within range and value is set.
  */
-bool Color_Command_Set(uint32_t object_instance, BACNET_COLOR_COMMAND *value)
+bool Color_Command_Set(
+    uint32_t object_instance, const BACNET_COLOR_COMMAND *value)
 {
     bool status = false;
     struct object_data *pObject;
@@ -341,7 +343,7 @@ bool Color_Command_Set(uint32_t object_instance, BACNET_COLOR_COMMAND *value)
  * @return  true if values are within range and present-value is set.
  */
 static bool Color_Command_Write(uint32_t object_instance,
-    BACNET_COLOR_COMMAND *value,
+    const BACNET_COLOR_COMMAND *value,
     uint8_t priority,
     BACNET_ERROR_CLASS *error_class,
     BACNET_ERROR_CODE *error_code)
@@ -440,7 +442,8 @@ bool Color_Default_Color(uint32_t object_instance, BACNET_XY_COLOR *value)
  *
  * @return  true if values are within range and present-value is set.
  */
-bool Color_Default_Color_Set(uint32_t object_instance, BACNET_XY_COLOR *value)
+bool Color_Default_Color_Set(
+    uint32_t object_instance, const BACNET_XY_COLOR *value)
 {
     bool status = false;
     struct object_data *pObject;
@@ -466,7 +469,7 @@ bool Color_Default_Color_Set(uint32_t object_instance, BACNET_XY_COLOR *value)
  * @return  true if values are within range and present-value is set.
  */
 static bool Color_Default_Color_Write(uint32_t object_instance,
-    BACNET_XY_COLOR *value,
+    const BACNET_XY_COLOR *value,
     uint8_t priority,
     BACNET_ERROR_CLASS *error_class,
     BACNET_ERROR_CODE *error_code)
@@ -708,7 +711,7 @@ bool Color_Object_Name(
  *
  * @return  true if object-name was set
  */
-bool Color_Name_Set(uint32_t object_instance, char *new_name)
+bool Color_Name_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -747,15 +750,15 @@ const char *Color_Name_ASCII(uint32_t object_instance)
  *
  * @return description text or NULL if not found
  */
-char *Color_Description(uint32_t object_instance)
+const char *Color_Description(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if (pObject->Description) {
-            name = (char *)pObject->Description;
+            name = pObject->Description;
         } else {
             name = "";
         }
@@ -772,7 +775,7 @@ char *Color_Description(uint32_t object_instance)
  *
  * @return  true if object-name was set
  */
-bool Color_Description_Set(uint32_t object_instance, char *new_name)
+bool Color_Description_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -987,7 +990,7 @@ bool Color_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
     int len = 0;
     BACNET_APPLICATION_DATA_VALUE value;
     int apdu_size = 0;
-    uint8_t *apdu = NULL;
+    const uint8_t *apdu = NULL;
 
     /* decode the some of the request */
     apdu = wp_data->application_data;

--- a/src/bacnet/basic/object/color_object.h
+++ b/src/bacnet/basic/object/color_object.h
@@ -48,7 +48,7 @@ BACNET_STACK_EXPORT
 bool Color_Object_Name(
     uint32_t object_instance, BACNET_CHARACTER_STRING *object_name);
 BACNET_STACK_EXPORT
-bool Color_Name_Set(uint32_t object_instance, char *new_name);
+bool Color_Name_Set(uint32_t object_instance, const char *new_name);
 BACNET_STACK_EXPORT
 const char *Color_Name_ASCII(uint32_t object_instance);
 
@@ -59,7 +59,8 @@ BACNET_STACK_EXPORT
 bool Color_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data);
 
 BACNET_STACK_EXPORT
-bool Color_Present_Value_Set(uint32_t object_instance, BACNET_XY_COLOR *value);
+bool Color_Present_Value_Set(
+    uint32_t object_instance, const BACNET_XY_COLOR *value);
 BACNET_STACK_EXPORT
 bool Color_Present_Value(uint32_t object_instance, BACNET_XY_COLOR *value);
 BACNET_STACK_EXPORT
@@ -67,17 +68,20 @@ void Color_Write_Present_Value_Callback_Set(
     color_write_present_value_callback cb);
 
 BACNET_STACK_EXPORT
-bool Color_Tracking_Value_Set(uint32_t object_instance, BACNET_XY_COLOR *value);
+bool Color_Tracking_Value_Set(
+    uint32_t object_instance, const BACNET_XY_COLOR *value);
 BACNET_STACK_EXPORT
 bool Color_Tracking_Value(uint32_t object_instance, BACNET_XY_COLOR *value);
 
 BACNET_STACK_EXPORT
 bool Color_Command(uint32_t object_instance, BACNET_COLOR_COMMAND *value);
 BACNET_STACK_EXPORT
-bool Color_Command_Set(uint32_t object_instance, BACNET_COLOR_COMMAND *value);
+bool Color_Command_Set(
+    uint32_t object_instance, const BACNET_COLOR_COMMAND *value);
 
 BACNET_STACK_EXPORT
-bool Color_Default_Color_Set(uint32_t object_instance, BACNET_XY_COLOR *value);
+bool Color_Default_Color_Set(
+    uint32_t object_instance, const BACNET_XY_COLOR *value);
 BACNET_STACK_EXPORT
 bool Color_Default_Color(uint32_t object_instance, BACNET_XY_COLOR *value);
 
@@ -99,9 +103,9 @@ bool Color_Transition_Set(
     uint32_t object_instance, BACNET_COLOR_TRANSITION value);
 
 BACNET_STACK_EXPORT
-char *Color_Description(uint32_t instance);
+const char *Color_Description(uint32_t instance);
 BACNET_STACK_EXPORT
-bool Color_Description_Set(uint32_t instance, char *new_name);
+bool Color_Description_Set(uint32_t instance, const char *new_name);
 
 BACNET_STACK_EXPORT
 bool Color_Write_Enabled(uint32_t instance);

--- a/src/bacnet/basic/object/color_temperature.c
+++ b/src/bacnet/basic/object/color_temperature.c
@@ -410,7 +410,7 @@ bool Color_Temperature_Command(
  * @return  true if values are within range and value is set.
  */
 bool Color_Temperature_Command_Set(
-    uint32_t object_instance, BACNET_COLOR_COMMAND *value)
+    uint32_t object_instance, const BACNET_COLOR_COMMAND *value)
 {
     bool status = false;
     struct object_data *pObject;
@@ -945,7 +945,7 @@ bool Color_Temperature_Object_Name(
  *
  * @return  true if object-name was set
  */
-bool Color_Temperature_Name_Set(uint32_t object_instance, char *new_name)
+bool Color_Temperature_Name_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -984,15 +984,15 @@ const char *Color_Temperature_Name_ASCII(uint32_t object_instance)
  *
  * @return description text or NULL if not found
  */
-char *Color_Temperature_Description(uint32_t object_instance)
+const char *Color_Temperature_Description(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if (pObject->Description) {
-            name = (char *)pObject->Description;
+            name = pObject->Description;
         } else {
             name = "";
         }
@@ -1009,7 +1009,8 @@ char *Color_Temperature_Description(uint32_t object_instance)
  *
  * @return  true if object-name was set
  */
-bool Color_Temperature_Description_Set(uint32_t object_instance, char *new_name)
+bool Color_Temperature_Description_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -1406,7 +1407,7 @@ bool Color_Temperature_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
     int len = 0;
     BACNET_APPLICATION_DATA_VALUE value;
     int apdu_size = 0;
-    uint8_t *apdu = NULL;
+    const uint8_t *apdu = NULL;
 
     /* decode the some of the request */
     apdu = wp_data->application_data;

--- a/src/bacnet/basic/object/color_temperature.h
+++ b/src/bacnet/basic/object/color_temperature.h
@@ -45,7 +45,8 @@ BACNET_STACK_EXPORT
 bool Color_Temperature_Object_Name(
     uint32_t object_instance, BACNET_CHARACTER_STRING *object_name);
 BACNET_STACK_EXPORT
-bool Color_Temperature_Name_Set(uint32_t object_instance, char *new_name);
+bool Color_Temperature_Name_Set(
+    uint32_t object_instance, const char *new_name);
 BACNET_STACK_EXPORT
 const char *Color_Temperature_Name_ASCII(uint32_t object_instance);
 
@@ -87,7 +88,7 @@ bool Color_Temperature_Command(
     uint32_t object_instance, BACNET_COLOR_COMMAND *value);
 BACNET_STACK_EXPORT
 bool Color_Temperature_Command_Set(
-    uint32_t object_instance, BACNET_COLOR_COMMAND *value);
+    uint32_t object_instance, const BACNET_COLOR_COMMAND *value);
 
 BACNET_STACK_EXPORT
 bool Color_Temperature_Default_Color_Temperature_Set(
@@ -129,9 +130,10 @@ bool Color_Temperature_Transition_Set(
     uint32_t object_instance, BACNET_COLOR_TRANSITION value);
 
 BACNET_STACK_EXPORT
-char *Color_Temperature_Description(uint32_t instance);
+const char *Color_Temperature_Description(uint32_t instance);
 BACNET_STACK_EXPORT
-bool Color_Temperature_Description_Set(uint32_t instance, char *new_name);
+bool Color_Temperature_Description_Set(
+    uint32_t instance, const char *new_name);
 
 BACNET_STACK_EXPORT
 bool Color_Temperature_Write_Enabled(uint32_t instance);

--- a/src/bacnet/basic/object/command.h
+++ b/src/bacnet/basic/object/command.h
@@ -72,7 +72,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Command_Description_Set(
         uint32_t instance,
-        char *new_name);
+        const char *new_name);
 
     BACNET_STACK_EXPORT
     int Command_Read_Property(

--- a/src/bacnet/basic/object/csv.c
+++ b/src/bacnet/basic/object/csv.c
@@ -186,7 +186,7 @@ bool CharacterString_Value_Present_Value(
  * @return  true if values are within range and present-value is set.
  */
 bool CharacterString_Value_Present_Value_Set(
-    uint32_t object_instance, BACNET_CHARACTER_STRING *object_name)
+    uint32_t object_instance, const BACNET_CHARACTER_STRING *object_name)
 {
     bool status = false;
     unsigned index = 0; /* offset from instance lookup */
@@ -332,7 +332,7 @@ static char *CharacterString_Value_Description(uint32_t object_instance)
  * @return True on success, false otherwise.
  */
 bool CharacterString_Value_Description_Set(
-    uint32_t object_instance, char *new_descr)
+    uint32_t object_instance, const char *new_descr)
 {
     unsigned index = 0; /* offset from instance lookup */
     size_t i = 0; /* loop counter */
@@ -390,7 +390,8 @@ bool CharacterString_Value_Object_Name(
  *
  * @return True on success, false otherwise.
  */
-bool CharacterString_Value_Name_Set(uint32_t object_instance, char *new_name)
+bool CharacterString_Value_Name_Set(
+    uint32_t object_instance, const char *new_name)
 {
     unsigned index = 0; /* offset from instance lookup */
     size_t i = 0; /* loop counter */

--- a/src/bacnet/basic/object/csv.h
+++ b/src/bacnet/basic/object/csv.h
@@ -59,7 +59,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool CharacterString_Value_Name_Set(
         uint32_t object_instance,
-        char *new_name);
+        const char *new_name);
 
     BACNET_STACK_EXPORT
     bool CharacterString_Value_Present_Value(
@@ -68,11 +68,11 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool CharacterString_Value_Present_Value_Set(
         uint32_t object_instance,
-        BACNET_CHARACTER_STRING * value);
+        const BACNET_CHARACTER_STRING * value);
     BACNET_STACK_EXPORT
     bool CharacterString_Value_Description_Set(
         uint32_t object_instance,
-        char *text_string);
+        const char *text_string);
     BACNET_STACK_EXPORT
     bool CharacterString_Value_Out_Of_Service(
         uint32_t object_instance);

--- a/src/bacnet/basic/object/device.c
+++ b/src/bacnet/basic/object/device.c
@@ -574,7 +574,7 @@ bool Device_Objects_Property_List_Member(
 static uint32_t Object_Instance_Number = 260001;
 static BACNET_CHARACTER_STRING My_Object_Name;
 static BACNET_DEVICE_STATUS System_Status = STATUS_OPERATIONAL;
-static char *Vendor_Name = BACNET_VENDOR_NAME;
+static const char *Vendor_Name = BACNET_VENDOR_NAME;
 static uint16_t Vendor_Identifier = BACNET_VENDOR_ID;
 static char Model_Name[MAX_DEV_MOD_LEN + 1] = "GNU";
 static char Application_Software_Version[MAX_DEV_VER_LEN + 1] = "1.0";
@@ -783,7 +783,7 @@ bool Device_Object_Name(
     return status;
 }
 
-bool Device_Set_Object_Name(BACNET_CHARACTER_STRING *object_name)
+bool Device_Set_Object_Name(const BACNET_CHARACTER_STRING *object_name)
 {
     bool status = false; /*return value */
 
@@ -1124,7 +1124,7 @@ int Device_Object_List_Element_Encode(
  * Object.
  * @return True on success or else False if not found.
  */
-bool Device_Valid_Object_Name(BACNET_CHARACTER_STRING *object_name1,
+bool Device_Valid_Object_Name(const BACNET_CHARACTER_STRING *object_name1,
     BACNET_OBJECT_TYPE *object_type,
     uint32_t *object_instance)
 {
@@ -1519,7 +1519,7 @@ int Device_Read_Property_Local(BACNET_READ_PROPERTY_DATA *rpdata)
  * @return The length of the APDU on success, else BACNET_STATUS_ERROR
  */
 static int Read_Property_Common(
-    struct object_functions *pObject, BACNET_READ_PROPERTY_DATA *rpdata)
+    const struct object_functions *pObject, BACNET_READ_PROPERTY_DATA *rpdata)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     BACNET_CHARACTER_STRING char_string;
@@ -1852,7 +1852,7 @@ static bool Device_Write_Property_Object_Name(
     BACNET_OBJECT_TYPE object_type = OBJECT_NONE;
     uint32_t object_instance = 0;
     int apdu_size = 0;
-    uint8_t *apdu = NULL;
+    const uint8_t *apdu = NULL;
 
     if (!wp_data) {
         return false;

--- a/src/bacnet/basic/object/device.h
+++ b/src/bacnet/basic/object/device.h
@@ -312,7 +312,7 @@ extern "C" {
         void);
     BACNET_STACK_EXPORT
     void Device_UUID_Set(
-        uint8_t *new_uuid,
+        const uint8_t *new_uuid,
         size_t length);
     BACNET_STACK_EXPORT
     void Device_UUID_Get(
@@ -353,7 +353,7 @@ extern "C" {
         BACNET_CHARACTER_STRING * object_name);
     BACNET_STACK_EXPORT
     bool Device_Set_Object_Name(
-        BACNET_CHARACTER_STRING * object_name);
+        const BACNET_CHARACTER_STRING * object_name);
     /* Copy a child object name, given its ID. */
     BACNET_STACK_EXPORT
     bool Device_Object_Name_Copy(
@@ -443,7 +443,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     bool Device_Valid_Object_Name(
-        BACNET_CHARACTER_STRING * object_name,
+        const BACNET_CHARACTER_STRING * object_name,
         BACNET_OBJECT_TYPE *object_type,
         uint32_t * object_instance);
     BACNET_STACK_EXPORT
@@ -498,7 +498,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     uint16_t Add_Routed_Device(
         uint32_t Object_Instance,
-        BACNET_CHARACTER_STRING * Object_Name,
+        const BACNET_CHARACTER_STRING * Object_Name,
         const char *Description);
     BACNET_STACK_EXPORT
     DEVICE_OBJECT_DATA *Get_Routed_Device_Object(
@@ -511,16 +511,16 @@ extern "C" {
     bool Routed_Device_Address_Lookup(
         int idx,
         uint8_t address_len,
-        uint8_t * mac_adress);
+        const uint8_t * mac_adress);
     BACNET_STACK_EXPORT
     bool Routed_Device_GetNext(
-        BACNET_ADDRESS * dest,
-        int *DNET_list,
+        const BACNET_ADDRESS * dest,
+        const int *DNET_list,
         int *cursor);
     BACNET_STACK_EXPORT
     bool Routed_Device_Is_Valid_Network(
         uint16_t dest_net,
-        int *DNET_list);
+        const int *DNET_list);
 
     BACNET_STACK_EXPORT
     uint32_t Routed_Device_Index_To_Instance(

--- a/src/bacnet/basic/object/gateway/gw_device.c
+++ b/src/bacnet/basic/object/gateway/gw_device.c
@@ -89,7 +89,7 @@ uint16_t iCurrent_Device_Idx = 0;
  *         there isn't enough room to add this Device.
  */
 uint16_t Add_Routed_Device(uint32_t Object_Instance,
-    BACNET_CHARACTER_STRING *sObject_Name,
+    const BACNET_CHARACTER_STRING *sObject_Name,
     const char *sDescription)
 {
     int i = Num_Managed_Devices;
@@ -192,7 +192,7 @@ void routed_get_my_address(BACNET_ADDRESS *my_address)
  *         meaning MAC broadcast, so it's an automatic match).
  *         Else False if no match or invalid idx is given.
  */
-bool Routed_Device_Address_Lookup(int idx, uint8_t dlen, uint8_t *dadr)
+bool Routed_Device_Address_Lookup(int idx, uint8_t dlen, const uint8_t *dadr)
 {
     bool result = false;
     DEVICE_OBJECT_DATA *pDev;
@@ -245,7 +245,8 @@ bool Routed_Device_Address_Lookup(int idx, uint8_t dlen, uint8_t *dadr)
  * match). Else False if no match or invalid idx is given; the cursor will be
  * returned as -1 in these cases.
  */
-bool Routed_Device_GetNext(BACNET_ADDRESS *dest, int *DNET_list, int *cursor)
+bool Routed_Device_GetNext(
+    const BACNET_ADDRESS *dest, const int *DNET_list, int *cursor)
 {
     int dnet = DNET_list[0]; /* Get the DNET of our virtual network */
     int idx = *cursor;
@@ -315,7 +316,7 @@ bool Routed_Device_GetNext(BACNET_ADDRESS *dest, int *DNET_list, int *cursor)
  *          Device (the gateway), or is BACNET_BROADCAST_NETWORK,
  * which is an automatic match. Else False if not a reachable network.
  */
-bool Routed_Device_Is_Valid_Network(uint16_t dest_net, int *DNET_list)
+bool Routed_Device_Is_Valid_Network(uint16_t dest_net, const int *DNET_list)
 {
     int dnet = DNET_list[0]; /* Get the DNET of our virtual network */
     bool bSuccess = false;

--- a/src/bacnet/basic/object/lc.c
+++ b/src/bacnet/basic/object/lc.c
@@ -259,7 +259,7 @@ bool Load_Control_Object_Name(
  * @param  new_name - holds the object-name to be set
  * @return  true if object-name was set
  */
-bool Load_Control_Name_Set(uint32_t object_instance, char *new_name)
+bool Load_Control_Name_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false;
     struct object_data *pObject;
@@ -359,7 +359,8 @@ static float Requested_Shed_Level_Value(struct object_data *pObject)
  * @param dest - destination data
  * @param src - source data
  */
-static void Shed_Level_Copy(BACNET_SHED_LEVEL *dest, BACNET_SHED_LEVEL *src)
+static void Shed_Level_Copy(
+    BACNET_SHED_LEVEL *dest, const BACNET_SHED_LEVEL *src)
 {
     if (dest && src) {
         dest->type = src->type;
@@ -445,7 +446,7 @@ static bool Able_To_Meet_Shed_Request(struct object_data *pObject)
  * @param object_index - object index in the list
  * @param bdatetime - current date and time
  */
-void Load_Control_State_Machine(int object_index, BACNET_DATE_TIME *bdatetime)
+void Load_Control_State_Machine(int object_index, const BACNET_DATE_TIME *bdatetime)
 {
     int diff = 0; /* used for datetime comparison */
     float amount;
@@ -799,7 +800,7 @@ bool Load_Control_Manipulated_Variable_Reference(
  */
 bool Load_Control_Manipulated_Variable_Reference_Set(
     uint32_t object_instance,
-    BACNET_OBJECT_PROPERTY_REFERENCE *object_property_reference)
+    const BACNET_OBJECT_PROPERTY_REFERENCE *object_property_reference)
 {
     bool status = false;
     struct object_data *pObject;
@@ -908,7 +909,8 @@ static int Load_Control_Shed_Level_Descriptions_Encode(
  * @param value [in] The value to encode
  * @return The length of the apdu encoded
  */
-static int BACnet_Shed_Level_Encode(uint8_t *apdu, BACNET_SHED_LEVEL *value)
+static int BACnet_Shed_Level_Encode(
+    uint8_t *apdu, const BACNET_SHED_LEVEL *value)
 {
     int apdu_len = 0;
 
@@ -1095,7 +1097,7 @@ int Load_Control_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata)
  */
 static bool Load_Control_Requested_Shed_Level_Write(
     uint32_t object_instance,
-    BACNET_SHED_LEVEL *value,
+    const BACNET_SHED_LEVEL *value,
     uint8_t priority,
     BACNET_ERROR_CLASS *error_class,
     BACNET_ERROR_CODE *error_code)
@@ -1188,7 +1190,7 @@ static bool Load_Control_Requested_Shed_Level_Write(
  */
 static bool Load_Control_Start_Time_Write(
     uint32_t object_instance,
-    BACNET_DATE_TIME *value,
+    const BACNET_DATE_TIME *value,
     uint8_t priority,
     BACNET_ERROR_CLASS *error_class,
     BACNET_ERROR_CODE *error_code)
@@ -1602,7 +1604,7 @@ void Load_Control_Manipulated_Object_Read_Callback_Set(
 bool Load_Control_Shed_Level_Array_Set(
     uint32_t object_instance,
     uint32_t array_index,
-    struct shed_level_data *value)
+    const struct shed_level_data *value)
 {
     int key_index;
     struct shed_level_data *entry;

--- a/src/bacnet/basic/object/lc.h
+++ b/src/bacnet/basic/object/lc.h
@@ -92,7 +92,7 @@ BACNET_STACK_EXPORT
 bool Load_Control_Object_Name(
     uint32_t object_instance, BACNET_CHARACTER_STRING *object_name);
 BACNET_STACK_EXPORT
-bool Load_Control_Name_Set(uint32_t object_instance, char *new_name);
+bool Load_Control_Name_Set(uint32_t object_instance, const char *new_name);
 BACNET_STACK_EXPORT
 const char *Load_Control_Name_ASCII(uint32_t object_instance);
 
@@ -103,7 +103,7 @@ BACNET_STACK_EXPORT
 bool Load_Control_Shed_Level_Array_Set(
     uint32_t object_instance,
     uint32_t array_index,
-    struct shed_level_data *value);
+    const struct shed_level_data *value);
 BACNET_STACK_EXPORT
 bool Load_Control_Shed_Level_Array(
     uint32_t object_instance,
@@ -133,7 +133,7 @@ bool Load_Control_Manipulated_Variable_Reference(
 BACNET_STACK_EXPORT
 bool Load_Control_Manipulated_Variable_Reference_Set(
     uint32_t object_instance,
-    BACNET_OBJECT_PROPERTY_REFERENCE *object_property_reference);
+    const BACNET_OBJECT_PROPERTY_REFERENCE *object_property_reference);
 
 BACNET_STACK_EXPORT
 void Load_Control_Manipulated_Object_Write_Callback_Set(
@@ -158,7 +158,7 @@ bool Load_Control_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data);
 
 /* functions used for unit testing */
 BACNET_STACK_EXPORT
-void Load_Control_State_Machine(int object_index, BACNET_DATE_TIME *bdatetime);
+void Load_Control_State_Machine(int object_index, const BACNET_DATE_TIME *bdatetime);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/object/lo.c
+++ b/src/bacnet/basic/object/lo.c
@@ -198,7 +198,8 @@ unsigned Lighting_Output_Instance_To_Index(uint32_t object_instance)
  * @return the priority-array active status for the specific priority
  */
 static bool
-Priority_Array_Active(struct object_data *pObject, BACNET_ARRAY_INDEX priority)
+Priority_Array_Active(
+    const struct object_data *pObject, BACNET_ARRAY_INDEX priority)
 {
     bool active = false;
 
@@ -219,7 +220,8 @@ Priority_Array_Active(struct object_data *pObject, BACNET_ARRAY_INDEX priority)
  * @return The priority-array value for the specific priority
  */
 static float
-Priority_Array_Value(struct object_data *pObject, BACNET_ARRAY_INDEX priority)
+Priority_Array_Value(
+    const struct object_data *pObject, BACNET_ARRAY_INDEX priority)
 {
     float real_value = 0.0;
 
@@ -241,7 +243,7 @@ Priority_Array_Value(struct object_data *pObject, BACNET_ARRAY_INDEX priority)
  * @return The priority-array value for the specific priority
  */
 static float Priority_Array_Next_Value(
-    struct object_data *pObject, BACNET_ARRAY_INDEX priority)
+    const struct object_data *pObject, BACNET_ARRAY_INDEX priority)
 {
     float real_value = 0.0;
     unsigned p = 0;
@@ -316,7 +318,7 @@ static int Lighting_Output_Priority_Array_Encode(
  *
  * @return  active priority 1..16, or 0 if no priority is active
  */
-static unsigned Present_Value_Priority(struct object_data *pObject)
+static unsigned Present_Value_Priority(const struct object_data *pObject)
 {
     unsigned p = 0; /* loop counter */
     unsigned priority = 0; /* return value */
@@ -837,7 +839,7 @@ bool Lighting_Output_Object_Name(
  *
  * @return  true if object-name was set
  */
-bool Lighting_Output_Name_Set(uint32_t object_instance, char *new_name)
+bool Lighting_Output_Name_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -876,15 +878,15 @@ const char *Lighting_Output_Name_ASCII(uint32_t object_instance)
  *
  * @return description text or NULL if not found
  */
-char *Lighting_Output_Description(uint32_t object_instance)
+const char *Lighting_Output_Description(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if (pObject->Description) {
-            name = (char *)pObject->Description;
+            name = pObject->Description;
         } else {
             name = "";
         }
@@ -901,7 +903,8 @@ char *Lighting_Output_Description(uint32_t object_instance)
  *
  * @return  true if object-name was set
  */
-bool Lighting_Output_Description_Set(uint32_t object_instance, char *new_name)
+bool Lighting_Output_Description_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -924,7 +927,7 @@ bool Lighting_Output_Description_Set(uint32_t object_instance, char *new_name)
  * @return  true if lighting command was set
  */
 bool Lighting_Output_Lighting_Command_Set(
-    uint32_t object_instance, BACNET_LIGHTING_COMMAND *value)
+    uint32_t object_instance, const BACNET_LIGHTING_COMMAND *value)
 {
     bool status = false;
     struct object_data *pObject;
@@ -970,7 +973,7 @@ Lighting_Command_Stop(struct object_data *pObject, unsigned priority)
  */
 static bool Lighting_Output_Lighting_Command_Write(
     uint32_t object_instance,
-    BACNET_LIGHTING_COMMAND *value,
+    const BACNET_LIGHTING_COMMAND *value,
     uint8_t priority,
     BACNET_ERROR_CLASS *error_class,
     BACNET_ERROR_CODE *error_code)
@@ -1858,7 +1861,7 @@ bool Lighting_Output_Color_Reference(
  * @return  true if property value was set
  */
 bool Lighting_Output_Color_Reference_Set(
-    uint32_t object_instance, BACNET_OBJECT_ID *value)
+    uint32_t object_instance, const BACNET_OBJECT_ID *value)
 {
     bool status = false;
     struct object_data *pObject;
@@ -1922,7 +1925,7 @@ bool Lighting_Output_Override_Color_Reference(
  * @return  true if property value was set
  */
 bool Lighting_Output_Override_Color_Reference_Set(
-    uint32_t object_instance, BACNET_OBJECT_ID *value)
+    uint32_t object_instance, const BACNET_OBJECT_ID *value)
 {
     bool status = false;
     struct object_data *pObject;

--- a/src/bacnet/basic/object/lo.h
+++ b/src/bacnet/basic/object/lo.h
@@ -99,18 +99,18 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Lighting_Output_Name_Set(
         uint32_t object_instance,
-        char *new_name);
+        const char *new_name);
     BACNET_STACK_EXPORT
     const char *Lighting_Output_Name_ASCII(
         uint32_t object_instance);
 
     BACNET_STACK_EXPORT
-    char *Lighting_Output_Description(
+    const char *Lighting_Output_Description(
         uint32_t instance);
     BACNET_STACK_EXPORT
     bool Lighting_Output_Description_Set(
         uint32_t instance,
-        char *new_name);
+        const char *new_name);
 
     BACNET_STACK_EXPORT
     bool Lighting_Output_Out_Of_Service(
@@ -123,7 +123,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Lighting_Output_Lighting_Command_Set(
         uint32_t object_instance,
-        BACNET_LIGHTING_COMMAND *value);
+        const BACNET_LIGHTING_COMMAND *value);
     BACNET_STACK_EXPORT
     bool Lighting_Output_Lighting_Command(
         uint32_t object_instance,
@@ -219,7 +219,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Lighting_Output_Color_Reference_Set(
         uint32_t object_instance,
-        BACNET_OBJECT_ID *value);
+        const BACNET_OBJECT_ID *value);
 
     BACNET_STACK_EXPORT
     bool Lighting_Output_Override_Color_Reference(
@@ -228,7 +228,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Lighting_Output_Override_Color_Reference_Set(
         uint32_t object_instance,
-        BACNET_OBJECT_ID *value);
+        const BACNET_OBJECT_ID *value);
 
     BACNET_STACK_EXPORT
     void Lighting_Output_Timer(

--- a/src/bacnet/basic/object/lsz.c
+++ b/src/bacnet/basic/object/lsz.c
@@ -507,7 +507,7 @@ static int Life_Safety_Zone_Members_Encode(
  */
 bool Life_Safety_Zone_Members_Add(
     uint32_t object_instance,
-    BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *data)
+    const BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *data)
 {
     bool status = false;
     BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *entry;
@@ -553,7 +553,7 @@ void Life_Safety_Zone_Members_Clear(
 static bool Life_Safety_Zone_Members_Write(BACNET_WRITE_PROPERTY_DATA *wp_data)
 {
     int len = 0, apdu_len = 0, apdu_size = 0;
-    uint8_t *apdu = NULL;
+    const uint8_t *apdu = NULL;
     BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE data = { 0 };
 
     if (wp_data == NULL) {

--- a/src/bacnet/basic/object/lsz.h
+++ b/src/bacnet/basic/object/lsz.h
@@ -98,7 +98,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Life_Safety_Zone_Members_Add(
         uint32_t object_instance,
-        BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *data);
+        const BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *data);
     BACNET_STACK_EXPORT
     void Life_Safety_Zone_Members_Clear(
         uint32_t object_instance);

--- a/src/bacnet/basic/object/ms-input.c
+++ b/src/bacnet/basic/object/ms-input.c
@@ -215,16 +215,16 @@ uint32_t Multistate_Input_Max_States(uint32_t object_instance)
  * @param  state_index - state index number 1..N of the text requested
  * @return  C string retrieved
  */
-char *Multistate_Input_State_Text(
+const char *Multistate_Input_State_Text(
     uint32_t object_instance, uint32_t state_index)
 {
-    char *pName = NULL; /* return value */
-    struct object_data *pObject;
+    const char *pName = NULL; /* return value */
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if (state_index > 0) {
-            pName = (char *)state_name_by_index(pObject->State_Text,
+            pName = state_name_by_index(pObject->State_Text,
                 state_index);
         }
     }
@@ -246,7 +246,7 @@ static int Multistate_Input_State_Text_Encode(
     uint32_t object_instance, BACNET_ARRAY_INDEX index, uint8_t *apdu)
 {
     int apdu_len = BACNET_STATUS_ERROR;
-    char *pName = NULL; /* return value */
+    const char *pName = NULL; /* return value */
     BACNET_CHARACTER_STRING char_string = { 0 };
     uint32_t state_index = 1;
 
@@ -482,7 +482,7 @@ bool Multistate_Input_Object_Name(
  * @param  new_name - holds the object-name to be set
  * @return  true if object-name was set
  */
-bool Multistate_Input_Name_Set(uint32_t object_instance, char *new_name)
+bool Multistate_Input_Name_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -537,7 +537,7 @@ BACNET_RELIABILITY Multistate_Input_Reliability(uint32_t object_instance)
  * @param  object_instance - object-instance number of the object
  * @return  true the status flag is in Fault
  */
-static bool Multistate_Input_Object_Fault(struct object_data *pObject)
+static bool Multistate_Input_Object_Fault(const struct object_data *pObject)
 {
     bool fault = false;
 
@@ -597,14 +597,14 @@ static bool Multistate_Input_Fault(uint32_t object_instance)
  * @param  object_instance - object-instance number of the object
  * @return description text or NULL if not found
  */
-char *Multistate_Input_Description(uint32_t object_instance)
+const char *Multistate_Input_Description(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Multistate_Input_Object(object_instance);
     if (pObject) {
-        name = (char *)pObject->Description;
+        name = pObject->Description;
     }
 
     return name;
@@ -616,7 +616,8 @@ char *Multistate_Input_Description(uint32_t object_instance)
  * @param  new_name - holds the description to be set
  * @return  true if object-name was set
  */
-bool Multistate_Input_Description_Set(uint32_t object_instance, char *new_name)
+bool Multistate_Input_Description_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;

--- a/src/bacnet/basic/object/ms-input.h
+++ b/src/bacnet/basic/object/ms-input.h
@@ -70,7 +70,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Multistate_Input_Name_Set(
         uint32_t object_instance,
-        char *new_name);
+        const char *new_name);
     BACNET_STACK_EXPORT
     const char *Multistate_Input_Name_ASCII(
         uint32_t object_instance);
@@ -106,12 +106,12 @@ extern "C" {
         bool value);
 
     BACNET_STACK_EXPORT
-    char *Multistate_Input_Description(
+    const char *Multistate_Input_Description(
         uint32_t instance);
     BACNET_STACK_EXPORT
     bool Multistate_Input_Description_Set(
         uint32_t object_instance,
-        char *text_string);
+        const char *text_string);
 
     BACNET_STACK_EXPORT
     BACNET_RELIABILITY Multistate_Input_Reliability(
@@ -138,7 +138,7 @@ extern "C" {
     uint32_t Multistate_Input_Max_States(
         uint32_t instance);
     BACNET_STACK_EXPORT
-    char *Multistate_Input_State_Text(
+    const char *Multistate_Input_State_Text(
         uint32_t object_instance,
         uint32_t state_index);
 

--- a/src/bacnet/basic/object/mso.c
+++ b/src/bacnet/basic/object/mso.c
@@ -218,7 +218,7 @@ uint32_t Multistate_Output_Max_States(uint32_t object_instance)
  * @param  object_instance - object-instance number of the object
  * @return  present-value of the object
  */
-static uint32_t Object_Present_Value(struct object_data *pObject)
+static uint32_t Object_Present_Value(const struct object_data *pObject)
 {
     uint32_t value = 1;
     uint8_t priority = 0; /* loop counter */
@@ -599,7 +599,7 @@ bool Multistate_Output_Object_Name(
  * @param  new_name - holds the object-name to be set
  * @return  true if object-name was set
  */
-bool Multistate_Output_Name_Set(uint32_t object_instance, char *new_name)
+bool Multistate_Output_Name_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -638,16 +638,16 @@ const char *Multistate_Output_Name_ASCII(uint32_t object_instance)
  * @param  state_index - state index number 1..N of the text requested
  * @return  C string retrieved
  */
-char *Multistate_Output_State_Text(
+const char *Multistate_Output_State_Text(
     uint32_t object_instance, uint32_t state_index)
 {
-    char *pName = NULL; /* return value */
-    struct object_data *pObject;
+    const char *pName = NULL; /* return value */
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if (state_index > 0) {
-            pName = (char *)state_name_by_index(pObject->State_Text,
+            pName = state_name_by_index(pObject->State_Text,
                 state_index);
         }
     }
@@ -669,7 +669,7 @@ static int Multistate_Output_State_Text_Encode(
     uint32_t object_instance, BACNET_ARRAY_INDEX index, uint8_t *apdu)
 {
     int apdu_len = BACNET_STATUS_ERROR;
-    char *pName = NULL; /* return value */
+    const char *pName = NULL; /* return value */
     BACNET_CHARACTER_STRING char_string = { 0 };
     uint32_t state_index = 1;
 
@@ -741,7 +741,7 @@ BACNET_RELIABILITY Multistate_Output_Reliability(uint32_t object_instance)
  * @param  object_instance - object-instance number of the object
  * @return  true the status flag is in Fault
  */
-static bool Multistate_Output_Object_Fault(struct object_data *pObject)
+static bool Multistate_Output_Object_Fault(const struct object_data *pObject)
 {
     bool fault = false;
 
@@ -801,14 +801,14 @@ static bool Multistate_Output_Fault(uint32_t object_instance)
  * @param  object_instance - object-instance number of the object
  * @return description text or NULL if not found
  */
-char *Multistate_Output_Description(uint32_t object_instance)
+const char *Multistate_Output_Description(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
-        name = (char *)pObject->Description;
+        name = pObject->Description;
     }
 
     return name;
@@ -820,7 +820,8 @@ char *Multistate_Output_Description(uint32_t object_instance)
  * @param  new_name - holds the description to be set
  * @return  true if object-name was set
  */
-bool Multistate_Output_Description_Set(uint32_t object_instance, char *new_name)
+bool Multistate_Output_Description_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;

--- a/src/bacnet/basic/object/mso.h
+++ b/src/bacnet/basic/object/mso.h
@@ -65,7 +65,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Multistate_Output_Name_Set(
         uint32_t object_instance,
-        char *new_name);
+        const char *new_name);
     BACNET_STACK_EXPORT
     const char *Multistate_Output_Name_ASCII(
         uint32_t object_instance);
@@ -109,12 +109,12 @@ extern "C" {
         bool value);
 
     BACNET_STACK_EXPORT
-    char *Multistate_Output_Description(
+    const char *Multistate_Output_Description(
         uint32_t instance);
     BACNET_STACK_EXPORT
     bool Multistate_Output_Description_Set(
         uint32_t object_instance,
-        char *text_string);
+        const char *text_string);
 
     BACNET_STACK_EXPORT
     bool Multistate_Output_State_Text_List_Set(
@@ -133,7 +133,7 @@ extern "C" {
     uint32_t Multistate_Output_Max_States(
         uint32_t instance);
     BACNET_STACK_EXPORT
-    char *Multistate_Output_State_Text(
+    const char *Multistate_Output_State_Text(
         uint32_t object_instance,
         uint32_t state_index);
 

--- a/src/bacnet/basic/object/msv.c
+++ b/src/bacnet/basic/object/msv.c
@@ -217,17 +217,16 @@ uint32_t Multistate_Value_Max_States(uint32_t object_instance)
  * @param  state_index - state index number 1..N of the text requested
  * @return  C string retrieved
  */
-char *Multistate_Value_State_Text(
+const char *Multistate_Value_State_Text(
     uint32_t object_instance, uint32_t state_index)
 {
-    char *pName = NULL; /* return value */
-    struct object_data *pObject;
+    const char *pName = NULL; /* return value */
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if (state_index > 0) {
-            pName =
-                (char *)state_name_by_index(pObject->State_Text, state_index);
+            pName = state_name_by_index(pObject->State_Text, state_index);
         }
     }
 
@@ -248,7 +247,7 @@ static int Multistate_Value_State_Text_Encode(
     uint32_t object_instance, BACNET_ARRAY_INDEX index, uint8_t *apdu)
 {
     int apdu_len = BACNET_STATUS_ERROR;
-    char *pName = NULL; /* return value */
+    const char *pName = NULL; /* return value */
     BACNET_CHARACTER_STRING char_string = { 0 };
     uint32_t state_index = 1;
 
@@ -482,7 +481,7 @@ bool Multistate_Value_Object_Name(
  * @param  new_name - holds the object-name to be set
  * @return  true if object-name was set
  */
-bool Multistate_Value_Name_Set(uint32_t object_instance, char *new_name)
+bool Multistate_Value_Name_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -537,7 +536,7 @@ BACNET_RELIABILITY Multistate_Value_Reliability(uint32_t object_instance)
  * @param  object_instance - object-instance number of the object
  * @return  true the status flag is in Fault
  */
-static bool Multistate_Value_Object_Fault(struct object_data *pObject)
+static bool Multistate_Value_Object_Fault(const struct object_data *pObject)
 {
     bool fault = false;
 
@@ -597,14 +596,14 @@ static bool Multistate_Value_Fault(uint32_t object_instance)
  * @param  object_instance - object-instance number of the object
  * @return description text or NULL if not found
  */
-char *Multistate_Value_Description(uint32_t object_instance)
+const char *Multistate_Value_Description(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Multistate_Value_Object(object_instance);
     if (pObject) {
-        name = (char *)pObject->Description;
+        name = pObject->Description;
     }
 
     return name;
@@ -616,7 +615,8 @@ char *Multistate_Value_Description(uint32_t object_instance)
  * @param  new_name - holds the description to be set
  * @return  true if object-name was set
  */
-bool Multistate_Value_Description_Set(uint32_t object_instance, char *new_name)
+bool Multistate_Value_Description_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;

--- a/src/bacnet/basic/object/msv.h
+++ b/src/bacnet/basic/object/msv.h
@@ -69,7 +69,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Multistate_Value_Name_Set(
         uint32_t object_instance,
-        char *new_name);
+        const char *new_name);
     BACNET_STACK_EXPORT
     const char *Multistate_Value_Name_ASCII(
         uint32_t object_instance);
@@ -105,12 +105,12 @@ extern "C" {
         bool value);
 
     BACNET_STACK_EXPORT
-    char *Multistate_Value_Description(
+    const char *Multistate_Value_Description(
         uint32_t instance);
     BACNET_STACK_EXPORT
     bool Multistate_Value_Description_Set(
         uint32_t object_instance,
-        char *text_string);
+        const char *text_string);
 
     BACNET_STACK_EXPORT
     bool Multistate_Value_State_Text_List_Set(
@@ -129,7 +129,7 @@ extern "C" {
     uint32_t Multistate_Value_Max_States(
         uint32_t instance);
     BACNET_STACK_EXPORT
-    char *Multistate_Value_State_Text(
+    const char *Multistate_Value_State_Text(
         uint32_t object_instance,
         uint32_t state_index);
 

--- a/src/bacnet/basic/object/netport.c
+++ b/src/bacnet/basic/object/netport.c
@@ -92,7 +92,7 @@ struct mstp_port {
 
 struct object_data {
     uint32_t Instance_Number;
-    char *Object_Name;
+    const char *Object_Name;
     BACNET_RELIABILITY Reliability;
     bool Out_Of_Service : 1;
     bool Changes_Pending : 1;
@@ -314,7 +314,7 @@ bool Network_Port_Object_Name(
  *
  * @return  true if object-name was set
  */
-bool Network_Port_Name_Set(uint32_t object_instance, char *new_name)
+bool Network_Port_Name_Set(uint32_t object_instance, const char *new_name)
 {
     unsigned index = 0; /* offset from instance lookup */
     bool status = false;
@@ -746,7 +746,7 @@ bool Network_Port_MAC_Address(
  * @return  true if object-name was set
  */
 bool Network_Port_MAC_Address_Set(
-    uint32_t object_instance, uint8_t *mac_src, uint8_t mac_len)
+    uint32_t object_instance, const uint8_t *mac_src, uint8_t mac_len)
 {
     unsigned index = 0; /* offset from instance lookup */
     bool status = false;
@@ -2109,7 +2109,7 @@ bool Network_Port_Remote_BBMD_IP6_Address(
  * @return  true if ip-address was set
  */
 bool Network_Port_Remote_BBMD_IP6_Address_Set(
-    uint32_t object_instance, uint8_t *addr)
+    uint32_t object_instance, const uint8_t *addr)
 {
     unsigned index = 0; /* offset from instance lookup */
     bool status = false;
@@ -2326,7 +2326,7 @@ bool Network_Port_IPv6_Address(
  * @return  true if ip-address was set
  */
 bool Network_Port_IPv6_Address_Set(
-    uint32_t object_instance, uint8_t *ip_address)
+    uint32_t object_instance, const uint8_t *ip_address)
 {
     unsigned index = 0; /* offset from instance lookup */
     bool status = false;
@@ -2437,7 +2437,7 @@ bool Network_Port_IPv6_Gateway(
  * @return  true if ip-address was set
  */
 bool Network_Port_IPv6_Gateway_Set(
-    uint32_t object_instance, uint8_t *ip_address)
+    uint32_t object_instance, const uint8_t *ip_address)
 {
     unsigned index = 0; /* offset from instance lookup */
     bool status = false;
@@ -2529,7 +2529,7 @@ static int Network_Port_IPv6_DNS_Server_Encode(
  * @return  true if ip-address was set
  */
 bool Network_Port_IPv6_DNS_Server_Set(
-    uint32_t object_instance, unsigned dns_index, uint8_t *ip_address)
+    uint32_t object_instance, unsigned dns_index, const uint8_t *ip_address)
 {
     unsigned index = 0; /* offset from instance lookup */
     bool status = false;
@@ -2588,7 +2588,7 @@ bool Network_Port_IPv6_Multicast_Address(
  * @return  true if ip-address was set
  */
 bool Network_Port_IPv6_Multicast_Address_Set(
-    uint32_t object_instance, uint8_t *ip_address)
+    uint32_t object_instance, const uint8_t *ip_address)
 {
     unsigned index = 0; /* offset from instance lookup */
     bool status = false;
@@ -2646,7 +2646,7 @@ bool Network_Port_IPv6_DHCP_Server(
  * @return  true if ip-address was set
  */
 bool Network_Port_IPv6_DHCP_Server_Set(
-    uint32_t object_instance, uint8_t *ip_address)
+    uint32_t object_instance, const uint8_t *ip_address)
 {
     unsigned index = 0; /* offset from instance lookup */
     bool status = false;
@@ -2837,7 +2837,7 @@ bool Network_Port_IPv6_Gateway_Zone_Index_Set(
  */
 static bool Network_Port_FD_BBMD_Address_Write(
     uint32_t object_instance,
-    BACNET_HOST_N_PORT *value,
+    const BACNET_HOST_N_PORT *value,
     BACNET_ERROR_CLASS *error_class,
     BACNET_ERROR_CODE *error_code)
 {

--- a/src/bacnet/basic/object/netport.h
+++ b/src/bacnet/basic/object/netport.h
@@ -40,7 +40,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Network_Port_Name_Set(
         uint32_t object_instance,
-        char *new_name);
+        const char *new_name);
     BACNET_STACK_EXPORT
     const char *Network_Port_Object_Name_ASCII(
         uint32_t object_instance);
@@ -51,7 +51,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Network_Port_Description_Set(
         uint32_t instance,
-        char *new_name);
+        const char *new_name);
 
     BACNET_STACK_EXPORT
     BACNET_RELIABILITY Network_Port_Reliability(
@@ -105,7 +105,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Network_Port_MAC_Address_Set(
         uint32_t object_instance,
-        uint8_t *mac_src,
+        const uint8_t *mac_src,
         uint8_t mac_len);
 
     BACNET_STACK_EXPORT
@@ -308,7 +308,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Network_Port_Remote_BBMD_IP6_Address_Set(
         uint32_t object_instance,
-        uint8_t *addr);
+        const uint8_t *addr);
     BACNET_STACK_EXPORT
     uint16_t Network_Port_Remote_BBMD_BIP6_Port(
         uint32_t object_instance);
@@ -340,7 +340,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Network_Port_IPv6_Address_Set(
         uint32_t object_instance,
-        uint8_t *ip_address);
+        const uint8_t *ip_address);
 
     BACNET_STACK_EXPORT
     bool Network_Port_IPv6_Multicast_Address(
@@ -349,7 +349,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Network_Port_IPv6_Multicast_Address_Set(
         uint32_t object_instance,
-        uint8_t *ip_address);
+        const uint8_t *ip_address);
 
     BACNET_STACK_EXPORT
     uint8_t Network_Port_IPv6_Subnet_Prefix(
@@ -366,7 +366,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Network_Port_IPv6_Gateway_Set(
         uint32_t object_instance,
-        uint8_t *ip_address);
+        const uint8_t *ip_address);
 
     BACNET_STACK_EXPORT
     bool Network_Port_IPv6_DNS_Server(
@@ -377,7 +377,7 @@ extern "C" {
     bool Network_Port_IPv6_DNS_Server_Set(
         uint32_t object_instance,
         unsigned dns_index,
-        uint8_t *ip_address);
+        const uint8_t *ip_address);
 
     BACNET_STACK_EXPORT
     bool Network_Port_IPv6_DHCP_Server(
@@ -386,7 +386,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool Network_Port_IPv6_DHCP_Server_Set(
         uint32_t object_instance,
-        uint8_t *ip_address);
+        const uint8_t *ip_address);
 
     BACNET_STACK_EXPORT
     bool Network_Port_IPv6_Zone_Index(

--- a/src/bacnet/basic/object/osv.c
+++ b/src/bacnet/basic/object/osv.c
@@ -114,7 +114,9 @@ unsigned OctetString_Value_Instance_To_Index(uint32_t object_instance)
  * @return  true if values are within range and present-value is set.
  */
 bool OctetString_Value_Present_Value_Set(
-    uint32_t object_instance, BACNET_OCTET_STRING *value, uint8_t priority)
+    uint32_t object_instance,
+    const BACNET_OCTET_STRING *value,
+    uint8_t priority)
 {
     unsigned index = 0;
     bool status = false;

--- a/src/bacnet/basic/object/osv.h
+++ b/src/bacnet/basic/object/osv.h
@@ -53,7 +53,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     bool OctetString_Value_Present_Value_Set(uint32_t object_instance,
-        BACNET_OCTET_STRING * value,
+        const BACNET_OCTET_STRING * value,
         uint8_t priority);
     BACNET_STACK_EXPORT
     BACNET_OCTET_STRING *OctetString_Value_Present_Value(uint32_t
@@ -71,7 +71,7 @@ extern "C" {
     char *OctetString_Value_Description(uint32_t instance);
     BACNET_STACK_EXPORT
     bool OctetString_Value_Description_Set(uint32_t instance,
-        char *new_name);
+        const char *new_name);
 
     BACNET_STACK_EXPORT
     bool OctetString_Value_Out_Of_Service(uint32_t instance);

--- a/src/bacnet/basic/object/piv.h
+++ b/src/bacnet/basic/object/piv.h
@@ -70,7 +70,7 @@ extern "C" {
     char *PositiveInteger_Value_Description(uint32_t instance);
     BACNET_STACK_EXPORT
     bool PositiveInteger_Value_Description_Set(uint32_t instance,
-        char *new_name);
+        const char *new_name);
 
     BACNET_STACK_EXPORT
     bool PositiveInteger_Value_Out_Of_Service(uint32_t instance);

--- a/src/bacnet/basic/object/schedule.c
+++ b/src/bacnet/basic/object/schedule.c
@@ -459,7 +459,8 @@ bool Schedule_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
  * @param date - date to check
  * @return true if the calendar entry is within the effective period
  */
-bool Schedule_In_Effective_Period(SCHEDULE_DESCR *desc, BACNET_DATE *date)
+bool Schedule_In_Effective_Period(
+    const SCHEDULE_DESCR *desc, const BACNET_DATE *date)
 {
     bool res = false;
 
@@ -480,7 +481,7 @@ bool Schedule_In_Effective_Period(SCHEDULE_DESCR *desc, BACNET_DATE *date)
  * @param time - time of the day
  */
 void Schedule_Recalculate_PV(
-    SCHEDULE_DESCR *desc, BACNET_WEEKDAY wday, BACNET_TIME *time)
+    SCHEDULE_DESCR *desc, BACNET_WEEKDAY wday, const BACNET_TIME *time)
 {
     int i;
     desc->Present_Value.tag = BACNET_APPLICATION_TAG_NULL;

--- a/src/bacnet/basic/object/schedule.h
+++ b/src/bacnet/basic/object/schedule.h
@@ -107,12 +107,12 @@ extern "C" {
     /* utility functions for calculating current Present Value
      * if Exception Schedule is to be added, these functions must take that into account */
     BACNET_STACK_EXPORT
-    bool Schedule_In_Effective_Period(SCHEDULE_DESCR * desc,
-        BACNET_DATE * date);
+    bool Schedule_In_Effective_Period(const SCHEDULE_DESCR * desc,
+        const BACNET_DATE * date);
     BACNET_STACK_EXPORT
     void Schedule_Recalculate_PV(SCHEDULE_DESCR * desc,
         BACNET_WEEKDAY wday,
-        BACNET_TIME * time);
+        const BACNET_TIME * time);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/object/structured_view.c
+++ b/src/bacnet/basic/object/structured_view.c
@@ -195,7 +195,7 @@ bool Structured_View_Object_Name(
  *
  * @return  true if object-name was set
  */
-bool Structured_View_Name_Set(uint32_t object_instance, char *new_name)
+bool Structured_View_Name_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -234,15 +234,15 @@ const char *Structured_View_Name_ASCII(uint32_t object_instance)
  *
  * @return description text or NULL if not found
  */
-char *Structured_View_Description(uint32_t object_instance)
+const char *Structured_View_Description(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if (pObject->Description) {
-            name = (char *)pObject->Description;
+            name = pObject->Description;
         } else {
             name = "";
         }
@@ -259,7 +259,8 @@ char *Structured_View_Description(uint32_t object_instance)
  *
  * @return  true if object-name was set
  */
-bool Structured_View_Description_Set(uint32_t object_instance, char *new_name)
+bool Structured_View_Description_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -317,15 +318,15 @@ bool Structured_View_Node_Type_Set(
  * @param  object_instance - object-instance number of the object
  * @return Node_Subtype text or NULL if not found
  */
-char *Structured_View_Node_Subtype(uint32_t object_instance)
+const char *Structured_View_Node_Subtype(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if (pObject->Description) {
-            name = (char *)pObject->Node_Subtype;
+            name = pObject->Node_Subtype;
         } else {
             name = "";
         }
@@ -340,7 +341,8 @@ char *Structured_View_Node_Subtype(uint32_t object_instance)
  * @param  new_name - holds the Node_Subtype to be set
  * @return  true if Node_Subtype was set
  */
-bool Structured_View_Node_Subtype_Set(uint32_t object_instance, char *new_name)
+bool Structured_View_Node_Subtype_Set(
+    uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -460,7 +462,7 @@ Structured_View_Represents(uint32_t object_instance)
  * @return  true if Represents was set
  */
 bool Structured_View_Represents_Set(
-    uint32_t object_instance, BACNET_DEVICE_OBJECT_REFERENCE *represents)
+    uint32_t object_instance, const BACNET_DEVICE_OBJECT_REFERENCE *represents)
 {
     bool status = false; /* return value */
     struct object_data *pObject;

--- a/src/bacnet/basic/object/structured_view.h
+++ b/src/bacnet/basic/object/structured_view.h
@@ -49,7 +49,7 @@ BACNET_STACK_EXPORT
 bool Structured_View_Object_Name(
     uint32_t object_instance, BACNET_CHARACTER_STRING *object_name);
 BACNET_STACK_EXPORT
-bool Structured_View_Name_Set(uint32_t object_instance, char *new_name);
+bool Structured_View_Name_Set(uint32_t object_instance, const char *new_name);
 BACNET_STACK_EXPORT
 const char *Structured_View_Name_ASCII(uint32_t object_instance);
 
@@ -57,9 +57,9 @@ BACNET_STACK_EXPORT
 int Structured_View_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata);
 
 BACNET_STACK_EXPORT
-char *Structured_View_Description(uint32_t object_instance);
+const char *Structured_View_Description(uint32_t object_instance);
 BACNET_STACK_EXPORT
-bool Structured_View_Description_Set(uint32_t object_instance, char *new_name);
+bool Structured_View_Description_Set(uint32_t object_instance, const char *new_name);
 
 BACNET_STACK_EXPORT
 BACNET_NODE_TYPE Structured_View_Node_Type(uint32_t object_instance);
@@ -68,9 +68,9 @@ bool Structured_View_Node_Type_Set(
     uint32_t object_instance, BACNET_NODE_TYPE node_type);
 
 BACNET_STACK_EXPORT
-char *Structured_View_Node_Subtype(uint32_t object_instance);
+const char *Structured_View_Node_Subtype(uint32_t object_instance);
 BACNET_STACK_EXPORT
-bool Structured_View_Node_Subtype_Set(uint32_t object_instance, char *new_name);
+bool Structured_View_Node_Subtype_Set(uint32_t object_instance, const char *new_name);
 
 BACNET_STACK_EXPORT
 BACNET_SUBORDINATE_DATA *
@@ -110,7 +110,8 @@ BACNET_DEVICE_OBJECT_REFERENCE *
 Structured_View_Represents(uint32_t object_instance);
 BACNET_STACK_EXPORT
 bool Structured_View_Represents_Set(
-    uint32_t object_instance, BACNET_DEVICE_OBJECT_REFERENCE *represents);
+    uint32_t object_instance,
+    const BACNET_DEVICE_OBJECT_REFERENCE *represents);
 
 BACNET_STACK_EXPORT
 uint32_t Structured_View_Create(uint32_t object_instance);

--- a/src/bacnet/basic/object/time_value.c
+++ b/src/bacnet/basic/object/time_value.c
@@ -179,7 +179,7 @@ bool Time_Value_Present_Value(uint32_t object_instance, BACNET_TIME *value)
  * @param  value - floating point analog value
  */
 static void Time_Value_Present_Value_COV_Detect(
-    struct object_data *pObject, BACNET_TIME *value)
+    struct object_data *pObject, const BACNET_TIME *value)
 {
     if (pObject && value) {
         if (datetime_compare_time(&pObject->Present_Value, value) != 0) {
@@ -196,7 +196,8 @@ static void Time_Value_Present_Value_COV_Detect(
  *
  * @return  true if values are within range and present-value is set.
  */
-bool Time_Value_Present_Value_Set(uint32_t object_instance, BACNET_TIME *value)
+bool Time_Value_Present_Value_Set(
+    uint32_t object_instance, const BACNET_TIME *value)
 {
     bool status = false;
     struct object_data *pObject;
@@ -342,7 +343,7 @@ bool Time_Value_Object_Name(
  *
  * @return  true if object-name was set
  */
-bool Time_Value_Name_Set(uint32_t object_instance, char *new_name)
+bool Time_Value_Name_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;
@@ -382,15 +383,15 @@ const char *Time_Value_Name_ASCII(uint32_t object_instance)
  *
  * @return description text or NULL if not found
  */
-char *Time_Value_Description(uint32_t object_instance)
+const char *Time_Value_Description(uint32_t object_instance)
 {
-    char *name = NULL;
-    struct object_data *pObject;
+    const char *name = NULL;
+    const struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if (pObject->Description) {
-            name = (char *)pObject->Description;
+            name = pObject->Description;
         } else {
             name = "";
         }
@@ -407,7 +408,7 @@ char *Time_Value_Description(uint32_t object_instance)
  *
  * @return  true if object-name was set
  */
-bool Time_Value_Description_Set(uint32_t object_instance, char *new_name)
+bool Time_Value_Description_Set(uint32_t object_instance, const char *new_name)
 {
     bool status = false; /* return value */
     struct object_data *pObject;

--- a/src/bacnet/basic/object/time_value.h
+++ b/src/bacnet/basic/object/time_value.h
@@ -47,7 +47,7 @@ BACNET_STACK_EXPORT
 bool Time_Value_Object_Name(
     uint32_t object_instance, BACNET_CHARACTER_STRING *object_name);
 BACNET_STACK_EXPORT
-bool Time_Value_Name_Set(uint32_t object_instance, char *new_name);
+bool Time_Value_Name_Set(uint32_t object_instance, const char *new_name);
 BACNET_STACK_EXPORT
 const char *Time_Value_Name_ASCII(uint32_t object_instance);
 
@@ -58,7 +58,8 @@ BACNET_STACK_EXPORT
 bool Time_Value_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data);
 
 BACNET_STACK_EXPORT
-bool Time_Value_Present_Value_Set(uint32_t object_instance, BACNET_TIME *value);
+bool Time_Value_Present_Value_Set(
+    uint32_t object_instance, const BACNET_TIME *value);
 BACNET_STACK_EXPORT
 bool Time_Value_Present_Value(uint32_t object_instance, BACNET_TIME *value);
 BACNET_STACK_EXPORT
@@ -74,9 +75,9 @@ BACNET_STACK_EXPORT
 bool Time_Value_Out_Of_Service_Set(uint32_t object_instance, bool oos_flag);
 
 BACNET_STACK_EXPORT
-char *Time_Value_Description(uint32_t object_instance);
+const char *Time_Value_Value_Description(uint32_t object_instance);
 BACNET_STACK_EXPORT
-bool Time_Value_Description_Set(uint32_t object_instance, char *new_name);
+bool Time_Value_Description_Set(uint32_t object_instance, const char *new_name);
 
 BACNET_STACK_EXPORT
 bool Time_Value_Write_Enabled(uint32_t instance);

--- a/src/bacnet/basic/object/trendlog.c
+++ b/src/bacnet/basic/object/trendlog.c
@@ -910,7 +910,7 @@ bool TL_Is_Enabled(int iLog)
  * Convert a BACnet time into a local time in seconds since the local epoch  *
  *****************************************************************************/
 
-bacnet_time_t TL_BAC_Time_To_Local(BACNET_DATE_TIME *bdatetime)
+bacnet_time_t TL_BAC_Time_To_Local(const BACNET_DATE_TIME *bdatetime)
 {
     return datetime_seconds_since_epoch(bdatetime);
 }
@@ -1498,7 +1498,7 @@ int TL_encode_entry(uint8_t *apdu, int iLog, int iEntry)
 
 static int local_read_property(uint8_t *value,
     uint8_t *status,
-    BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *Source,
+    const BACNET_DEVICE_OBJECT_PROPERTY_REFERENCE *Source,
     BACNET_ERROR_CLASS *error_class,
     BACNET_ERROR_CODE *error_code)
 {

--- a/src/bacnet/basic/object/trendlog.h
+++ b/src/bacnet/basic/object/trendlog.h
@@ -158,7 +158,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     bacnet_time_t TL_BAC_Time_To_Local(
-        BACNET_DATE_TIME * SourceTime);
+        const BACNET_DATE_TIME * SourceTime);
 
     BACNET_STACK_EXPORT
     void TL_Local_Time_To_BAC(

--- a/src/bacnet/basic/service/h_cov.c
+++ b/src/bacnet/basic/service/h_cov.c
@@ -121,7 +121,7 @@ static void cov_address_remove_unused(void)
  *
  * @return index number 0..N, or -1 if unable to add
  */
-static int cov_address_add(BACNET_ADDRESS *dest)
+static int cov_address_add(const BACNET_ADDRESS *dest)
 {
     int index = -1;
     unsigned i = 0;
@@ -187,7 +187,9 @@ COVIncrement [4] REAL OPTIONAL
 */
 
 static int cov_encode_subscription(
-    uint8_t *apdu, int max_apdu, BACNET_COV_SUBSCRIPTION *cov_subscription)
+    uint8_t *apdu,
+    int max_apdu,
+    const BACNET_COV_SUBSCRIPTION *cov_subscription)
 {
     int len = 0;
     int apdu_len = 0;
@@ -323,8 +325,8 @@ void handler_cov_init(void)
     }
 }
 
-static bool cov_list_subscribe(BACNET_ADDRESS *src,
-    BACNET_SUBSCRIBE_COV_DATA *cov_data,
+static bool cov_list_subscribe(const BACNET_ADDRESS *src,
+    const BACNET_SUBSCRIBE_COV_DATA *cov_data,
     BACNET_ERROR_CLASS *error_class,
     BACNET_ERROR_CODE *error_code)
 {
@@ -333,7 +335,7 @@ static bool cov_list_subscribe(BACNET_ADDRESS *src,
     int first_invalid_index = -1;
     bool found = true;
     bool address_match = false;
-    BACNET_ADDRESS *dest = NULL;
+    const BACNET_ADDRESS *dest = NULL;
 
     /* unable to subscribe - resources? */
     /* unable to cancel subscription - other? */
@@ -717,8 +719,8 @@ void handler_cov_task(void)
     handler_cov_fsm();
 }
 
-static bool cov_subscribe(BACNET_ADDRESS *src,
-    BACNET_SUBSCRIBE_COV_DATA *cov_data,
+static bool cov_subscribe(const BACNET_ADDRESS *src,
+    const BACNET_SUBSCRIBE_COV_DATA *cov_data,
     BACNET_ERROR_CLASS *error_class,
     BACNET_ERROR_CODE *error_code)
 {

--- a/src/bacnet/basic/service/h_dcc.c
+++ b/src/bacnet/basic/service/h_dcc.c
@@ -29,7 +29,7 @@ static char My_Password[32] = "filister";
 /** Sets (non-volatile hold) the password to be used for DCC requests.
  * @param new_password [in] The new DCC password, of up to 31 characters.
  */
-void handler_dcc_password_set(char *new_password)
+void handler_dcc_password_set(const char *new_password)
 {
     size_t i = 0; /* loop counter */
 

--- a/src/bacnet/basic/service/h_dcc.h
+++ b/src/bacnet/basic/service/h_dcc.h
@@ -28,7 +28,7 @@ extern "C" {
         BACNET_CONFIRMED_SERVICE_DATA * service_data);
     BACNET_STACK_EXPORT
     void handler_dcc_password_set(
-        char *new_password);
+        const char *new_password);
     BACNET_STACK_EXPORT
     char *handler_dcc_password(void);
 

--- a/src/bacnet/basic/service/h_rpm_a.c
+++ b/src/bacnet/basic/service/h_rpm_a.c
@@ -39,7 +39,9 @@
  * @return The number of bytes decoded, or -1 on error
  */
 int rpm_ack_decode_service_request(
-    uint8_t *apdu, int apdu_len, BACNET_READ_ACCESS_DATA *read_access_data)
+    const uint8_t *apdu,
+    int apdu_len,
+    BACNET_READ_ACCESS_DATA *read_access_data)
 {
     int decoded_len = 0; /* return value */
     uint32_t error_value = 0; /* decoded error value */

--- a/src/bacnet/basic/service/h_rpm_a.h
+++ b/src/bacnet/basic/service/h_rpm_a.h
@@ -33,7 +33,7 @@ extern "C" {
         BACNET_CONFIRMED_SERVICE_ACK_DATA * service_data);
     BACNET_STACK_EXPORT
     int rpm_ack_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         int apdu_len,
         BACNET_READ_ACCESS_DATA * read_access_data);
     BACNET_STACK_EXPORT

--- a/src/bacnet/basic/service/h_ts.c
+++ b/src/bacnet/basic/service/h_ts.c
@@ -34,7 +34,7 @@ static BACNET_DATE_TIME Next_Sync_Time;
 #endif
 
 #if PRINT_ENABLED
-static void show_bacnet_date_time(BACNET_DATE *bdate, BACNET_TIME *btime)
+static void show_bacnet_date_time(const BACNET_DATE *bdate, const BACNET_TIME *btime)
 {
     /* show the date received */
     fprintf(stderr, "%u", (unsigned)bdate->year);

--- a/src/bacnet/basic/service/h_whohas.c
+++ b/src/bacnet/basic/service/h_whohas.c
@@ -25,7 +25,7 @@
  *  or object ID, if the Device has a match.
  *  @param data [in] The decoded who-has payload from the request.
  */
-static void match_name_or_object(BACNET_WHO_HAS_DATA *data)
+static void match_name_or_object(const BACNET_WHO_HAS_DATA *data)
 {
     BACNET_OBJECT_TYPE object_type = OBJECT_NONE;
     uint32_t object_instance = 0;

--- a/src/bacnet/basic/service/h_whois.c
+++ b/src/bacnet/basic/service/h_whois.c
@@ -100,9 +100,9 @@ void handler_who_is_unicast(
  *          back to the src, else False if should broadcast
  * response(s).
  */
-static void check_who_is_for_routing(uint8_t *service_request,
+static void check_who_is_for_routing(const uint8_t *service_request,
     uint16_t service_len,
-    BACNET_ADDRESS *src,
+    const BACNET_ADDRESS *src,
     bool is_unicast)
 {
     int len = 0;

--- a/src/bacnet/basic/service/h_wp.c
+++ b/src/bacnet/basic/service/h_wp.c
@@ -146,7 +146,7 @@ void handler_write_property(uint8_t *service_request,
  *
  * @return True on success, false otherwise.
  */
-bool WPValidateString(BACNET_APPLICATION_DATA_VALUE *pValue,
+bool WPValidateString(const BACNET_APPLICATION_DATA_VALUE *pValue,
     int iMaxLen,
     bool bEmptyAllowed,
     BACNET_ERROR_CLASS *pErrorClass,
@@ -193,7 +193,7 @@ bool WPValidateString(BACNET_APPLICATION_DATA_VALUE *pValue,
  * validation fails. Cuts out reams of repeated code in the object code.
  */
 
-bool WPValidateArgType(BACNET_APPLICATION_DATA_VALUE *pValue,
+bool WPValidateArgType(const BACNET_APPLICATION_DATA_VALUE *pValue,
     uint8_t ucExpectedTag,
     BACNET_ERROR_CLASS *pErrorClass,
     BACNET_ERROR_CODE *pErrorCode)

--- a/src/bacnet/basic/service/h_wp.h
+++ b/src/bacnet/basic/service/h_wp.h
@@ -34,7 +34,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     bool WPValidateString(
-        BACNET_APPLICATION_DATA_VALUE * pValue,
+        const BACNET_APPLICATION_DATA_VALUE * pValue,
         int iMaxLen,
         bool bEmptyAllowed,
         BACNET_ERROR_CLASS * pErrorClass,
@@ -42,7 +42,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     bool WPValidateArgType(
-        BACNET_APPLICATION_DATA_VALUE * pValue,
+        const BACNET_APPLICATION_DATA_VALUE * pValue,
         uint8_t ucExpectedType,
         BACNET_ERROR_CLASS * pErrorClass,
         BACNET_ERROR_CODE * pErrorCode);

--- a/src/bacnet/basic/service/h_wpm.c
+++ b/src/bacnet/basic/service/h_wpm.c
@@ -41,7 +41,7 @@
  * @return number of bytes decoded, or BACNET_STATUS_REJECT,
  *  or BACNET_STATUS_ERROR
  */
-static int write_property_multiple_decode(uint8_t *apdu,
+static int write_property_multiple_decode(const uint8_t *apdu,
     uint16_t apdu_len,
     BACNET_WRITE_PROPERTY_DATA *wp_data,
     write_property_function device_write_property)

--- a/src/bacnet/basic/service/s_ack_alarm.c
+++ b/src/bacnet/basic/service/s_ack_alarm.c
@@ -40,7 +40,7 @@
  */
 uint8_t Send_Alarm_Acknowledgement_Address(uint8_t *pdu,
     uint16_t pdu_size,
-    BACNET_ALARM_ACK_DATA *data,
+    const BACNET_ALARM_ACK_DATA *data,
     BACNET_ADDRESS *dest)
 {
     int len = 0;
@@ -100,7 +100,7 @@ uint8_t Send_Alarm_Acknowledgement_Address(uint8_t *pdu,
  *         or no tsm slot is available.
  */
 uint8_t Send_Alarm_Acknowledgement(
-    uint32_t device_id, BACNET_ALARM_ACK_DATA *data)
+    uint32_t device_id, const BACNET_ALARM_ACK_DATA *data)
 {
     BACNET_ADDRESS dest = { 0 };
     unsigned max_apdu = 0;

--- a/src/bacnet/basic/service/s_ack_alarm.h
+++ b/src/bacnet/basic/service/s_ack_alarm.h
@@ -28,11 +28,11 @@ extern "C" {
 
 BACNET_STACK_EXPORT
 uint8_t Send_Alarm_Acknowledgement_Address(uint8_t *pdu, uint16_t pdu_size,
-    BACNET_ALARM_ACK_DATA *data, BACNET_ADDRESS *dest);
+    const BACNET_ALARM_ACK_DATA *data, BACNET_ADDRESS *dest);
 
 BACNET_STACK_EXPORT
 uint8_t Send_Alarm_Acknowledgement(uint32_t device_id,
-                                   BACNET_ALARM_ACK_DATA* data);
+                                   const BACNET_ALARM_ACK_DATA* data);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/s_awfs.c
+++ b/src/bacnet/basic/service/s_awfs.c
@@ -29,7 +29,7 @@
 uint8_t Send_Atomic_Write_File_Stream(uint32_t device_id,
     uint32_t file_instance,
     int fileStartPosition,
-    BACNET_OCTET_STRING *fileData)
+    const BACNET_OCTET_STRING *fileData)
 {
     BACNET_ADDRESS dest;
     BACNET_ADDRESS my_address;

--- a/src/bacnet/basic/service/s_awfs.h
+++ b/src/bacnet/basic/service/s_awfs.h
@@ -29,7 +29,7 @@ BACNET_STACK_EXPORT
 uint8_t Send_Atomic_Write_File_Stream(uint32_t device_id,
                                       uint32_t file_instance,
                                       int fileStartPosition,
-                                      BACNET_OCTET_STRING* fileData);
+                                      const BACNET_OCTET_STRING* fileData);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/s_cevent.c
+++ b/src/bacnet/basic/service/s_cevent.c
@@ -32,7 +32,7 @@
  */
 uint8_t Send_CEvent_Notify_Address(uint8_t *pdu,
     uint16_t pdu_size,
-    BACNET_EVENT_NOTIFICATION_DATA *data,
+    const BACNET_EVENT_NOTIFICATION_DATA *data,
     BACNET_ADDRESS *dest)
 {
     int len = 0;
@@ -102,7 +102,7 @@ uint8_t Send_CEvent_Notify_Address(uint8_t *pdu,
  *         or no tsm slot is available.
  */
 uint8_t Send_CEvent_Notify(
-    uint32_t device_id, BACNET_EVENT_NOTIFICATION_DATA *data)
+    uint32_t device_id, const BACNET_EVENT_NOTIFICATION_DATA *data)
 {
     BACNET_ADDRESS dest = { 0 };
     unsigned max_apdu = 0;

--- a/src/bacnet/basic/service/s_cevent.h
+++ b/src/bacnet/basic/service/s_cevent.h
@@ -28,10 +28,10 @@ extern "C" {
 
 BACNET_STACK_EXPORT
 uint8_t Send_CEvent_Notify(uint32_t device_id,
-                           BACNET_EVENT_NOTIFICATION_DATA* data);
+                           const BACNET_EVENT_NOTIFICATION_DATA* data);
 BACNET_STACK_EXPORT
 uint8_t Send_CEvent_Notify_Address(uint8_t *pdu, uint16_t pdu_size,
-    BACNET_EVENT_NOTIFICATION_DATA *data, BACNET_ADDRESS *dest);
+    const BACNET_EVENT_NOTIFICATION_DATA *data, BACNET_ADDRESS *dest);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/s_cov.c
+++ b/src/bacnet/basic/service/s_cov.c
@@ -41,7 +41,7 @@ int ucov_notify_encode_pdu(uint8_t *buffer,
     unsigned buffer_len,
     BACNET_ADDRESS *dest,
     BACNET_NPDU_DATA *npdu_data,
-    BACNET_COV_DATA *cov_data)
+    const BACNET_COV_DATA *cov_data)
 {
     int len = 0;
     int pdu_len = 0;
@@ -75,7 +75,7 @@ int ucov_notify_encode_pdu(uint8_t *buffer,
  * @return Size of the message sent (bytes), or a negative value on error.
  */
 int Send_UCOV_Notify(
-    uint8_t *buffer, unsigned buffer_len, BACNET_COV_DATA *cov_data)
+    uint8_t *buffer, unsigned buffer_len, const BACNET_COV_DATA *cov_data)
 {
     int pdu_len = 0;
     BACNET_ADDRESS dest;
@@ -98,7 +98,7 @@ int Send_UCOV_Notify(
  *         no slot is available from the tsm for sending.
  */
 uint8_t Send_COV_Subscribe(
-    uint32_t device_id, BACNET_SUBSCRIBE_COV_DATA *cov_data)
+    uint32_t device_id, const BACNET_SUBSCRIBE_COV_DATA *cov_data)
 {
     BACNET_ADDRESS dest;
     BACNET_ADDRESS my_address;

--- a/src/bacnet/basic/service/s_cov.h
+++ b/src/bacnet/basic/service/s_cov.h
@@ -32,18 +32,18 @@ extern "C" {
     int Send_UCOV_Notify(
         uint8_t * buffer,
         unsigned buffer_len,
-        BACNET_COV_DATA * cov_data);
+        const BACNET_COV_DATA * cov_data);
     BACNET_STACK_EXPORT
     int ucov_notify_encode_pdu(
         uint8_t * buffer,
         unsigned buffer_len,
         BACNET_ADDRESS * dest,
         BACNET_NPDU_DATA * npdu_data,
-        BACNET_COV_DATA * cov_data);
+        const BACNET_COV_DATA * cov_data);
     BACNET_STACK_EXPORT
     uint8_t Send_COV_Subscribe(
         uint32_t device_id,
-        BACNET_SUBSCRIBE_COV_DATA * cov_data);
+        const BACNET_SUBSCRIBE_COV_DATA * cov_data);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/s_dcc.c
+++ b/src/bacnet/basic/service/s_dcc.c
@@ -39,7 +39,7 @@
 uint8_t Send_Device_Communication_Control_Request(uint32_t device_id,
     uint16_t timeDuration, /* 0=optional */
     BACNET_COMMUNICATION_ENABLE_DISABLE state,
-    char *password)
+    const char *password)
 { /* NULL=optional */
     BACNET_ADDRESS dest;
     BACNET_ADDRESS my_address;

--- a/src/bacnet/basic/service/s_dcc.h
+++ b/src/bacnet/basic/service/s_dcc.h
@@ -28,7 +28,8 @@ extern "C" {
 BACNET_STACK_EXPORT
 uint8_t Send_Device_Communication_Control_Request(
     uint32_t device_id, uint16_t timeDuration,
-    BACNET_COMMUNICATION_ENABLE_DISABLE state, char *password);
+    BACNET_COMMUNICATION_ENABLE_DISABLE state,
+    const char *password);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/s_get_event.c
+++ b/src/bacnet/basic/service/s_get_event.c
@@ -39,7 +39,7 @@
 
 uint8_t Send_Get_Event_Information_Address(BACNET_ADDRESS *dest,
     uint16_t max_apdu,
-    BACNET_OBJECT_ID *lastReceivedObjectIdentifier)
+    const BACNET_OBJECT_ID *lastReceivedObjectIdentifier)
 {
     int len = 0;
     int pdu_len = 0;
@@ -92,7 +92,7 @@ uint8_t Send_Get_Event_Information_Address(BACNET_ADDRESS *dest,
 }
 
 uint8_t Send_Get_Event_Information(
-    uint32_t device_id, BACNET_OBJECT_ID *lastReceivedObjectIdentifier)
+    uint32_t device_id, const BACNET_OBJECT_ID *lastReceivedObjectIdentifier)
 {
     BACNET_ADDRESS dest = { 0 };
     unsigned max_apdu = 0;

--- a/src/bacnet/basic/service/s_get_event.h
+++ b/src/bacnet/basic/service/s_get_event.h
@@ -28,10 +28,10 @@ extern "C" {
 BACNET_STACK_EXPORT
 uint8_t Send_Get_Event_Information_Address(
     BACNET_ADDRESS *dest, uint16_t max_apdu,
-    BACNET_OBJECT_ID *lastReceivedObjectIdentifier);
+    const BACNET_OBJECT_ID *lastReceivedObjectIdentifier);
 BACNET_STACK_EXPORT
 uint8_t Send_Get_Event_Information(
-    uint32_t device_id, BACNET_OBJECT_ID *lastReceivedObjectIdentifier);
+    uint32_t device_id, const BACNET_OBJECT_ID *lastReceivedObjectIdentifier);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/s_getevent.c
+++ b/src/bacnet/basic/service/s_getevent.c
@@ -31,7 +31,7 @@
  * @param target_address [in] BACnet address of target or broadcast
  */
 uint8_t Send_GetEvent(BACNET_ADDRESS *target_address,
-    BACNET_OBJECT_ID *lastReceivedObjectIdentifier)
+    const BACNET_OBJECT_ID *lastReceivedObjectIdentifier)
 {
     int len = 0;
     int pdu_len = 0;

--- a/src/bacnet/basic/service/s_getevent.h
+++ b/src/bacnet/basic/service/s_getevent.h
@@ -27,7 +27,7 @@ extern "C" {
 
 BACNET_STACK_EXPORT
 uint8_t Send_GetEvent(BACNET_ADDRESS* target_address,
-                      BACNET_OBJECT_ID* lastReceivedObjectIdentifier);
+                      const BACNET_OBJECT_ID* lastReceivedObjectIdentifier);
 BACNET_STACK_EXPORT
 uint8_t Send_GetEvent_Global(void);
 

--- a/src/bacnet/basic/service/s_iam.c
+++ b/src/bacnet/basic/service/s_iam.c
@@ -138,7 +138,7 @@ void Send_I_Am(uint8_t *buffer)
  * @return The length of the message in buffer[].
  */
 int iam_unicast_encode_pdu(uint8_t *buffer,
-    BACNET_ADDRESS *src,
+    const BACNET_ADDRESS *src,
     BACNET_ADDRESS *dest,
     BACNET_NPDU_DATA *npdu_data)
 {
@@ -174,7 +174,7 @@ int iam_unicast_encode_pdu(uint8_t *buffer,
  * @param buffer [in] The buffer to use for building and sending the message.
  * @param src [in] The source address information from service handler.
  */
-void Send_I_Am_Unicast(uint8_t *buffer, BACNET_ADDRESS *src)
+void Send_I_Am_Unicast(uint8_t *buffer, const BACNET_ADDRESS *src)
 {
     int pdu_len = 0;
     BACNET_ADDRESS dest;

--- a/src/bacnet/basic/service/s_iam.h
+++ b/src/bacnet/basic/service/s_iam.h
@@ -36,10 +36,10 @@ int iam_encode_pdu(uint8_t* buffer, BACNET_ADDRESS* dest,
 BACNET_STACK_EXPORT
 void Send_I_Am(uint8_t* buffer);
 BACNET_STACK_EXPORT
-int iam_unicast_encode_pdu(uint8_t* buffer, BACNET_ADDRESS* src,
+int iam_unicast_encode_pdu(uint8_t* buffer, const BACNET_ADDRESS* src,
                            BACNET_ADDRESS* dest, BACNET_NPDU_DATA* npdu_data);
 BACNET_STACK_EXPORT
-void Send_I_Am_Unicast(uint8_t* buffer, BACNET_ADDRESS* src);
+void Send_I_Am_Unicast(uint8_t* buffer, const BACNET_ADDRESS* src);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/s_ihave.c
+++ b/src/bacnet/basic/service/s_ihave.c
@@ -37,7 +37,7 @@
 void Send_I_Have(uint32_t device_id,
     BACNET_OBJECT_TYPE object_type,
     uint32_t object_instance,
-    BACNET_CHARACTER_STRING *object_name)
+    const BACNET_CHARACTER_STRING *object_name)
 {
     int len = 0;
     int pdu_len = 0;

--- a/src/bacnet/basic/service/s_ihave.h
+++ b/src/bacnet/basic/service/s_ihave.h
@@ -30,7 +30,7 @@ extern "C" {
         uint32_t device_id,
         BACNET_OBJECT_TYPE object_type,
         uint32_t object_instance,
-        BACNET_CHARACTER_STRING * object_name);
+        const BACNET_CHARACTER_STRING * object_name);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/s_lso.c
+++ b/src/bacnet/basic/service/s_lso.c
@@ -30,7 +30,7 @@
 /* returns the invoke ID for confirmed request, or zero on failure */
 
 uint8_t Send_Life_Safety_Operation_Data(
-    uint32_t device_id, BACNET_LSO_DATA *data)
+    uint32_t device_id, const BACNET_LSO_DATA *data)
 {
     BACNET_ADDRESS dest;
     BACNET_ADDRESS my_address;

--- a/src/bacnet/basic/service/s_lso.h
+++ b/src/bacnet/basic/service/s_lso.h
@@ -28,7 +28,7 @@ extern "C" {
 
 BACNET_STACK_EXPORT
 uint8_t Send_Life_Safety_Operation_Data(uint32_t device_id,
-                                        BACNET_LSO_DATA* data);
+                                        const BACNET_LSO_DATA* data);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/s_rd.c
+++ b/src/bacnet/basic/service/s_rd.c
@@ -36,7 +36,9 @@
  * @return The invokeID of the transmitted message, or 0 on failure.
  */
 uint8_t Send_Reinitialize_Device_Request(
-    uint32_t device_id, BACNET_REINITIALIZED_STATE state, char *password)
+    uint32_t device_id,
+    BACNET_REINITIALIZED_STATE state,
+    const char *password)
 {
     BACNET_ADDRESS dest;
     BACNET_ADDRESS my_address;

--- a/src/bacnet/basic/service/s_rd.h
+++ b/src/bacnet/basic/service/s_rd.h
@@ -28,7 +28,7 @@ extern "C" {
 BACNET_STACK_EXPORT
 uint8_t Send_Reinitialize_Device_Request(uint32_t device_id,
                                          BACNET_REINITIALIZED_STATE state,
-                                         char *password);
+                                         const char *password);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/s_readrange.c
+++ b/src/bacnet/basic/service/s_readrange.c
@@ -29,7 +29,7 @@
 
 /* returns invoke id of 0 if device is not bound or no tsm available */
 uint8_t Send_ReadRange_Request(uint32_t device_id, /* destination device */
-    BACNET_READ_RANGE_DATA *read_access_data)
+    const BACNET_READ_RANGE_DATA *read_access_data)
 {
     BACNET_ADDRESS dest;
     BACNET_ADDRESS my_address;

--- a/src/bacnet/basic/service/s_readrange.h
+++ b/src/bacnet/basic/service/s_readrange.h
@@ -28,7 +28,7 @@ extern "C" {
 
 BACNET_STACK_EXPORT
 uint8_t Send_ReadRange_Request(uint32_t device_id,
-                               BACNET_READ_RANGE_DATA* read_access_data);
+                               const BACNET_READ_RANGE_DATA* read_access_data);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/s_ts.c
+++ b/src/bacnet/basic/service/s_ts.c
@@ -34,7 +34,7 @@
  * @param btime - #BACNET_TIME
  */
 void Send_TimeSync_Remote(
-    BACNET_ADDRESS *dest, BACNET_DATE *bdate, BACNET_TIME *btime)
+    BACNET_ADDRESS *dest, const BACNET_DATE *bdate, const BACNET_TIME *btime)
 {
     int len = 0;
     int pdu_len = 0;
@@ -75,7 +75,7 @@ void Send_TimeSync_Remote(
  * @param bdate - #BACNET_DATE
  * @param btime - #BACNET_TIME
  */
-void Send_TimeSync(BACNET_DATE *bdate, BACNET_TIME *btime)
+void Send_TimeSync(const BACNET_DATE *bdate, const BACNET_TIME *btime)
 {
     BACNET_ADDRESS dest;
 
@@ -91,7 +91,7 @@ void Send_TimeSync(BACNET_DATE *bdate, BACNET_TIME *btime)
  * @param btime - #BACNET_TIME
  */
 void Send_TimeSyncUTC_Remote(
-    BACNET_ADDRESS *dest, BACNET_DATE *bdate, BACNET_TIME *btime)
+    BACNET_ADDRESS *dest, const BACNET_DATE *bdate, const BACNET_TIME *btime)
 {
     int len = 0;
     int pdu_len = 0;
@@ -133,7 +133,7 @@ void Send_TimeSyncUTC_Remote(
  * @param bdate - #BACNET_DATE
  * @param btime - #BACNET_TIME
  */
-void Send_TimeSyncUTC(BACNET_DATE *bdate, BACNET_TIME *btime)
+void Send_TimeSyncUTC(const BACNET_DATE *bdate, const BACNET_TIME *btime)
 {
     BACNET_ADDRESS dest;
 

--- a/src/bacnet/basic/service/s_ts.h
+++ b/src/bacnet/basic/service/s_ts.h
@@ -27,22 +27,22 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     void Send_TimeSync(
-        BACNET_DATE * bdate,
-        BACNET_TIME * btime);
+        const BACNET_DATE * bdate,
+        const BACNET_TIME * btime);
     BACNET_STACK_EXPORT
     void Send_TimeSync_Remote(
         BACNET_ADDRESS * dest,
-        BACNET_DATE * bdate,
-        BACNET_TIME * btime);
+        const BACNET_DATE * bdate,
+        const BACNET_TIME * btime);
     BACNET_STACK_EXPORT
     void Send_TimeSyncUTC(
-        BACNET_DATE * bdate,
-        BACNET_TIME * btime);
+        const BACNET_DATE * bdate,
+        const BACNET_TIME * btime);
     BACNET_STACK_EXPORT
     void Send_TimeSyncUTC_Remote(
         BACNET_ADDRESS * dest,
-        BACNET_DATE * bdate,
-        BACNET_TIME * btime);
+        const BACNET_DATE * bdate,
+        const BACNET_TIME * btime);
     BACNET_STACK_EXPORT
     void Send_TimeSyncUTC_Device(void);
     BACNET_STACK_EXPORT

--- a/src/bacnet/basic/service/s_uevent.c
+++ b/src/bacnet/basic/service/s_uevent.c
@@ -24,7 +24,7 @@
  * @return Size of the message sent (bytes), or a negative value on error.
  */
 int Send_UEvent_Notify(
-    uint8_t *buffer, BACNET_EVENT_NOTIFICATION_DATA *data, BACNET_ADDRESS *dest)
+    uint8_t *buffer, const BACNET_EVENT_NOTIFICATION_DATA *data, BACNET_ADDRESS *dest)
 {
     int len = 0;
     int pdu_len = 0;

--- a/src/bacnet/basic/service/s_uevent.h
+++ b/src/bacnet/basic/service/s_uevent.h
@@ -28,7 +28,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     int Send_UEvent_Notify(
         uint8_t * buffer,
-        BACNET_EVENT_NOTIFICATION_DATA * data,
+        const BACNET_EVENT_NOTIFICATION_DATA * data,
         BACNET_ADDRESS * dest);
 
 #ifdef __cplusplus

--- a/src/bacnet/basic/service/s_upt.c
+++ b/src/bacnet/basic/service/s_upt.c
@@ -27,7 +27,7 @@
 /** @file s_upt.c  Send an Unconfirmed Private Transfer request. */
 
 int Send_UnconfirmedPrivateTransfer(
-    BACNET_ADDRESS *dest, BACNET_PRIVATE_TRANSFER_DATA *private_data)
+    BACNET_ADDRESS *dest, const BACNET_PRIVATE_TRANSFER_DATA *private_data)
 {
     int len = 0;
     int pdu_len = 0;

--- a/src/bacnet/basic/service/s_upt.h
+++ b/src/bacnet/basic/service/s_upt.h
@@ -27,8 +27,9 @@ extern "C" {
 #endif /* __cplusplus */
 
 BACNET_STACK_EXPORT
-int Send_UnconfirmedPrivateTransfer(BACNET_ADDRESS* dest,
-                                    BACNET_PRIVATE_TRANSFER_DATA* private_data);
+int Send_UnconfirmedPrivateTransfer(
+    BACNET_ADDRESS* dest,
+    const BACNET_PRIVATE_TRANSFER_DATA* private_data);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/s_wp.c
+++ b/src/bacnet/basic/service/s_wp.c
@@ -31,7 +31,7 @@ uint8_t Send_Write_Property_Request_Data(uint32_t device_id,
     BACNET_OBJECT_TYPE object_type,
     uint32_t object_instance,
     BACNET_PROPERTY_ID object_property,
-    uint8_t *application_data,
+    const uint8_t *application_data,
     int application_data_len,
     uint8_t priority,
     uint32_t array_index)
@@ -124,7 +124,7 @@ uint8_t Send_Write_Property_Request(uint32_t device_id,
     BACNET_OBJECT_TYPE object_type,
     uint32_t object_instance,
     BACNET_PROPERTY_ID object_property,
-    BACNET_APPLICATION_DATA_VALUE *object_value,
+    const BACNET_APPLICATION_DATA_VALUE *object_value,
     uint8_t priority,
     uint32_t array_index)
 {

--- a/src/bacnet/basic/service/s_wp.h
+++ b/src/bacnet/basic/service/s_wp.h
@@ -31,7 +31,7 @@ extern "C" {
         BACNET_OBJECT_TYPE object_type,
         uint32_t object_instance,
         BACNET_PROPERTY_ID object_property,
-        BACNET_APPLICATION_DATA_VALUE * object_value,
+        const BACNET_APPLICATION_DATA_VALUE * object_value,
         uint8_t priority,
         uint32_t array_index);
     BACNET_STACK_EXPORT
@@ -40,7 +40,7 @@ extern "C" {
         BACNET_OBJECT_TYPE object_type,
         uint32_t object_instance,
         BACNET_PROPERTY_ID object_property,
-        uint8_t * application_data,
+        const uint8_t * application_data,
         int application_data_len,
         uint8_t priority,
         uint32_t array_index);

--- a/src/bacnet/basic/sys/fifo.c
+++ b/src/bacnet/basic/sys/fifo.c
@@ -272,7 +272,7 @@ bool FIFO_Put(FIFO_BUFFER *b, uint8_t data_byte)
  *
  * @return true if space available and added, false if not added
  */
-bool FIFO_Add(FIFO_BUFFER *b, uint8_t *buffer, unsigned count)
+bool FIFO_Add(FIFO_BUFFER *b, const uint8_t *buffer, unsigned count)
 {
     bool status = false; /* return value */
     unsigned index;

--- a/src/bacnet/basic/sys/fifo.h
+++ b/src/bacnet/basic/sys/fifo.h
@@ -102,7 +102,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool FIFO_Add(
         FIFO_BUFFER * b,
-        uint8_t * data_bytes,
+        const uint8_t * data_bytes,
         unsigned count);
 
     BACNET_STACK_EXPORT

--- a/src/bacnet/basic/sys/filename.c
+++ b/src/bacnet/basic/sys/filename.c
@@ -9,9 +9,9 @@
 #include <string.h>
 #include "bacnet/basic/sys/filename.h"
 
-char *filename_remove_path(const char *filename_in)
+const char *filename_remove_path(const char *filename_in)
 {
-    char *filename_out = (char *)filename_in;
+    const char *filename_out = filename_in;
 
     /* allow the device ID to be set */
     if (filename_in) {
@@ -24,7 +24,7 @@ char *filename_remove_path(const char *filename_in)
             filename_out++;
         } else {
             /* no slash in filename */
-            filename_out = (char *)filename_in;
+            filename_out = filename_in;
         }
     }
 

--- a/src/bacnet/basic/sys/filename.h
+++ b/src/bacnet/basic/sys/filename.h
@@ -15,7 +15,7 @@ extern "C" {
 #endif /* __cplusplus */
 
     BACNET_STACK_EXPORT
-    char *filename_remove_path(
+    const char *filename_remove_path(
         const char *filename_in);
 
 #ifdef __cplusplus

--- a/src/bacnet/basic/sys/mstimer.c
+++ b/src/bacnet/basic/sys/mstimer.c
@@ -133,7 +133,7 @@ void mstimer_restart(struct mstimer *t)
  * @param t A pointer to the timer
  * @return Non-zero if the timer has expired, zero otherwise.
  */
-int mstimer_expired(struct mstimer *t)
+int mstimer_expired(const struct mstimer *t)
 {
     if (t->interval) {
         return ((unsigned long)((mstimer_now()) - (t->start + t->interval)) <
@@ -168,7 +168,7 @@ void mstimer_expire(struct mstimer *t)
  * @return The time until the timer expires
  *
  */
-unsigned long mstimer_remaining(struct mstimer *t)
+unsigned long mstimer_remaining(const struct mstimer *t)
 {
     return t->start + t->interval - mstimer_now();
 }
@@ -183,7 +183,7 @@ unsigned long mstimer_remaining(struct mstimer *t)
  * @return The time elapsed since the last start of the timer
  *
  */
-unsigned long mstimer_elapsed(struct mstimer *t)
+unsigned long mstimer_elapsed(const struct mstimer *t)
 {
     return mstimer_now() - t->start;
 }
@@ -198,7 +198,7 @@ unsigned long mstimer_elapsed(struct mstimer *t)
  * @return The interval value
  *
  */
-unsigned long mstimer_interval(struct mstimer *t)
+unsigned long mstimer_interval(const struct mstimer *t)
 {
     return t->interval;
 }

--- a/src/bacnet/basic/sys/mstimer.h
+++ b/src/bacnet/basic/sys/mstimer.h
@@ -45,15 +45,15 @@ void mstimer_reset(struct mstimer *t);
 BACNET_STACK_EXPORT
 void mstimer_restart(struct mstimer *t);
 BACNET_STACK_EXPORT
-int mstimer_expired(struct mstimer *t);
+int mstimer_expired(const struct mstimer *t);
 BACNET_STACK_EXPORT
 void mstimer_expire(struct mstimer *t);
 BACNET_STACK_EXPORT
-unsigned long mstimer_remaining(struct mstimer *t);
+unsigned long mstimer_remaining(const struct mstimer *t);
 BACNET_STACK_EXPORT
-unsigned long mstimer_elapsed(struct mstimer *t);
+unsigned long mstimer_elapsed(const struct mstimer *t);
 BACNET_STACK_EXPORT
-unsigned long mstimer_interval(struct mstimer *t);
+unsigned long mstimer_interval(const struct mstimer *t);
 /* optional callback timer support for embedded systems */
 BACNET_STACK_EXPORT
 void mstimer_callback(

--- a/src/bacnet/basic/sys/ringbuf.c
+++ b/src/bacnet/basic/sys/ringbuf.c
@@ -150,7 +150,8 @@ volatile void *Ringbuf_Peek(RING_BUFFER const *b)
  * @param  data_element - find the next element from this one
  * @return pointer to the data, or NULL if nothing in the list
  */
-volatile void *Ringbuf_Peek_Next(RING_BUFFER const *b, uint8_t *data_element)
+volatile void *Ringbuf_Peek_Next(
+    RING_BUFFER const *b, const uint8_t *data_element)
 {
     unsigned index; /* list index */
     volatile uint8_t *this_element;
@@ -211,7 +212,7 @@ bool Ringbuf_Pop(RING_BUFFER *b, uint8_t *data_element)
  * @return true if data was copied, false if list is empty
  */
 bool Ringbuf_Pop_Element(
-    RING_BUFFER *b, uint8_t *this_element, uint8_t *data_element)
+    RING_BUFFER *b, const uint8_t *this_element, uint8_t *data_element)
 {
     bool status = false; /* return value */
     volatile uint8_t *ring_data = NULL; /* used to help point ring data */
@@ -262,7 +263,7 @@ bool Ringbuf_Pop_Element(
  * @param  data_element - one element that is copied to the ring buffer
  * @return true on successful add, false if not added
  */
-bool Ringbuf_Put(RING_BUFFER *b, uint8_t *data_element)
+bool Ringbuf_Put(RING_BUFFER *b, const uint8_t *data_element)
 {
     bool status = false; /* return value */
     volatile uint8_t *ring_data = NULL; /* used to help point ring data */
@@ -296,7 +297,7 @@ bool Ringbuf_Put(RING_BUFFER *b, uint8_t *data_element)
  * @param  data_element - one element to copy to the front of the ring
  * @return true on successful add, false if not added
  */
-bool Ringbuf_Put_Front(RING_BUFFER *b, uint8_t *data_element)
+bool Ringbuf_Put_Front(RING_BUFFER *b, const uint8_t *data_element)
 {
     bool status = false; /* return value */
     volatile uint8_t *ring_data = NULL; /* used to help point ring data */
@@ -351,7 +352,7 @@ volatile void *Ringbuf_Data_Peek(RING_BUFFER *b)
  * @return true if the buffer has space and the data element points to the
  *              same memory previously peeked.
  */
-bool Ringbuf_Data_Put(RING_BUFFER *b, volatile uint8_t *data_element)
+bool Ringbuf_Data_Put(RING_BUFFER *b, const volatile uint8_t *data_element)
 {
     bool status = false;
     volatile uint8_t *ring_data = NULL; /* used to help point ring data */

--- a/src/bacnet/basic/sys/ringbuf.h
+++ b/src/bacnet/basic/sys/ringbuf.h
@@ -76,23 +76,24 @@ extern "C" {
         uint8_t * data_element);
     BACNET_STACK_EXPORT
     bool Ringbuf_Pop_Element(RING_BUFFER * b,
-        uint8_t * this_element,
+        const uint8_t * this_element,
         uint8_t * data_element);
     BACNET_STACK_EXPORT
     bool Ringbuf_Put_Front(RING_BUFFER * b,
-        uint8_t * data_element);
+        const uint8_t * data_element);
     /* head */
     BACNET_STACK_EXPORT
     bool Ringbuf_Put(RING_BUFFER * b,
-        uint8_t * data_element);
+        const uint8_t * data_element);
     /* pair of functions to use head memory directly */
     BACNET_STACK_EXPORT
     volatile void *Ringbuf_Data_Peek(RING_BUFFER * b);
     BACNET_STACK_EXPORT
     volatile void *Ringbuf_Peek_Next(RING_BUFFER const *b,
-        uint8_t * data_element);
+        const uint8_t * data_element);
     BACNET_STACK_EXPORT
-    bool Ringbuf_Data_Put(RING_BUFFER * b, volatile uint8_t *data_element);
+    bool Ringbuf_Data_Put(
+        RING_BUFFER * b, const volatile uint8_t *data_element);
     /* Note: element_count must be a power of two */
     BACNET_STACK_EXPORT
     bool Ringbuf_Init(RING_BUFFER * b,

--- a/src/bacnet/basic/sys/sbuf.c
+++ b/src/bacnet/basic/sys/sbuf.c
@@ -34,12 +34,12 @@ char *sbuf_data(STATIC_BUFFER const *b)
     return (b ? b->data : NULL);
 }
 
-unsigned sbuf_size(STATIC_BUFFER *b)
+unsigned sbuf_size(STATIC_BUFFER const *b)
 {
     return (b ? b->size : 0);
 }
 
-unsigned sbuf_count(STATIC_BUFFER *b)
+unsigned sbuf_count(STATIC_BUFFER const *b)
 {
     return (b ? b->count : 0);
 }
@@ -47,7 +47,7 @@ unsigned sbuf_count(STATIC_BUFFER *b)
 /* returns true if successful, false if not enough room to append data */
 bool sbuf_put(STATIC_BUFFER *b, /* static buffer structure */
     unsigned offset, /* where to start */
-    char *data, /* data to place in buffer */
+    const char *data, /* data to place in buffer */
     unsigned data_size)
 { /* how many bytes to add */
     bool status = false; /* return value */
@@ -70,7 +70,7 @@ bool sbuf_put(STATIC_BUFFER *b, /* static buffer structure */
 
 /* returns true if successful, false if not enough room to append data */
 bool sbuf_append(STATIC_BUFFER *b, /* static buffer structure */
-    char *data, /* data to place in buffer */
+    const char *data, /* data to place in buffer */
     unsigned data_size)
 { /* how many bytes to add */
     unsigned count = 0;

--- a/src/bacnet/basic/sys/sbuf.h
+++ b/src/bacnet/basic/sys/sbuf.h
@@ -40,23 +40,23 @@ extern "C" {
     /* returns the max size of the data block */
     BACNET_STACK_EXPORT
     unsigned sbuf_size(
-        STATIC_BUFFER * b);
+        STATIC_BUFFER const *b);
     /* returns the number of bytes used in the data block */
     BACNET_STACK_EXPORT
     unsigned sbuf_count(
-        STATIC_BUFFER * b);
+        STATIC_BUFFER const *b);
     /* returns true if successful, false if not enough room to append data */
     BACNET_STACK_EXPORT
     bool sbuf_put(
         STATIC_BUFFER * b,      /* static buffer structure */
         unsigned offset,        /* where to start */
-        char *data,     /* data to add */
+        const char *data,       /* data to add */
         unsigned data_size);    /* how many to add */
     /* returns true if successful, false if not enough room to append data */
     BACNET_STACK_EXPORT
     bool sbuf_append(
         STATIC_BUFFER * b,      /* static buffer structure */
-        char *data,     /* data to append */
+        const char *data,       /* data to append */
         unsigned data_size);    /* how many to append */
     /* returns true if successful, false if count is bigger than size */
     BACNET_STACK_EXPORT

--- a/src/bacnet/basic/tsm/tsm.c
+++ b/src/bacnet/basic/tsm/tsm.c
@@ -209,9 +209,9 @@ uint8_t tsm_next_free_invokeID(void)
  * @param apdu_len  Bytes valid in the received message.
  */
 void tsm_set_confirmed_unsegmented_transaction(uint8_t invokeID,
-    BACNET_ADDRESS *dest,
-    BACNET_NPDU_DATA *ndpu_data,
-    uint8_t *apdu,
+    const BACNET_ADDRESS *dest,
+    const BACNET_NPDU_DATA *ndpu_data,
+    const uint8_t *apdu,
     uint16_t apdu_len)
 {
     uint16_t j = 0;

--- a/src/bacnet/basic/tsm/tsm.h
+++ b/src/bacnet/basic/tsm/tsm.h
@@ -117,9 +117,9 @@ extern "C" {
     BACNET_STACK_EXPORT
     void tsm_set_confirmed_unsegmented_transaction(
         uint8_t invokeID,
-        BACNET_ADDRESS * dest,
-        BACNET_NPDU_DATA * ndpu_data,
-        uint8_t * apdu,
+        const BACNET_ADDRESS * dest,
+        const BACNET_NPDU_DATA * ndpu_data,
+        const uint8_t * apdu,
         uint16_t apdu_len);
 /* returns true if transaction is found */
     BACNET_STACK_EXPORT

--- a/src/bacnet/calendar_entry.c
+++ b/src/bacnet/calendar_entry.c
@@ -27,7 +27,7 @@
  * @param value Pointer to the property data to be encoded.
  * @return bytes encoded or zero on error.
  */
-int bacnet_calendar_entry_encode(uint8_t *apdu, BACNET_CALENDAR_ENTRY *value)
+int bacnet_calendar_entry_encode(uint8_t *apdu, const BACNET_CALENDAR_ENTRY *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -68,7 +68,7 @@ int bacnet_calendar_entry_encode(uint8_t *apdu, BACNET_CALENDAR_ENTRY *value)
  * @return  number of bytes encoded, or 0 if unable to encode.
  */
 int bacnet_calendar_entry_context_encode(
-    uint8_t *apdu, uint8_t tag_number, BACNET_CALENDAR_ENTRY *value)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_CALENDAR_ENTRY *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -99,7 +99,7 @@ int bacnet_calendar_entry_context_encode(
  * @return number of bytes decoded, or BACNET_STATUS_REJECT
  */
 int bacnet_calendar_entry_decode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_CALENDAR_ENTRY *entry)
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_CALENDAR_ENTRY *entry)
 {
     int apdu_len = 0;
     int len = 0;
@@ -174,7 +174,7 @@ int bacnet_calendar_entry_decode(
  *
  * @return number of bytes decoded, or BACNET_STATUS_REJECT
  */
-int bacnet_calendar_entry_context_decode(uint8_t *apdu,
+int bacnet_calendar_entry_context_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     uint8_t tag_number,
     BACNET_CALENDAR_ENTRY *value)
@@ -211,7 +211,7 @@ int bacnet_calendar_entry_context_decode(uint8_t *apdu,
  * @param month - month to compare
  * @return true if the same month including special values, else false
  */
-static bool month_match(BACNET_DATE *date, uint8_t month)
+static bool month_match(const BACNET_DATE *date, uint8_t month)
 {
     if (month == 0xff) {
         return true;
@@ -231,7 +231,7 @@ static bool month_match(BACNET_DATE *date, uint8_t month)
  * @param weekofmonth - week of the month to compare
  * @return true if the same week of the month including special values
  */
-static bool weekofmonth_match(BACNET_DATE *date, uint8_t weekofmonth)
+static bool weekofmonth_match(const BACNET_DATE *date, uint8_t weekofmonth)
 {
     bool st = false;
     uint8_t day_to_end_month;
@@ -272,7 +272,7 @@ static bool weekofmonth_match(BACNET_DATE *date, uint8_t weekofmonth)
  * @param dayofweek - day of the week to compare
  * @return true if the same day of the week including special values
  */
-static bool dayofweek_match(BACNET_DATE *date, uint8_t dayofweek)
+static bool dayofweek_match(const BACNET_DATE *date, uint8_t dayofweek)
 {
     if (dayofweek == 0xff) {
         return true;
@@ -291,7 +291,7 @@ static bool dayofweek_match(BACNET_DATE *date, uint8_t dayofweek)
  * @return true if a BACnetCalendarEntry includes the BACnetDate value
  */
 bool bacapp_date_in_calendar_entry(
-    BACNET_DATE *date, BACNET_CALENDAR_ENTRY *entry)
+    const BACNET_DATE *date, const BACNET_CALENDAR_ENTRY *entry)
 {
     if (!entry) {
         return false;
@@ -332,7 +332,7 @@ bool bacapp_date_in_calendar_entry(
  * @return true if both BACnetCalendarEntry are the same
  */
 bool bacnet_calendar_entry_same(
-    BACNET_CALENDAR_ENTRY *value1, BACNET_CALENDAR_ENTRY *value2)
+    const BACNET_CALENDAR_ENTRY *value1, const BACNET_CALENDAR_ENTRY *value2)
 {
     if (!value1 || !value2) {
         return false;

--- a/src/bacnet/calendar_entry.h
+++ b/src/bacnet/calendar_entry.h
@@ -48,28 +48,29 @@ typedef struct BACnetCalendarEntry_T {
 
 
 BACNET_STACK_EXPORT
-int bacnet_calendar_entry_encode(uint8_t *apdu, BACNET_CALENDAR_ENTRY *value);
+int bacnet_calendar_entry_encode(
+    uint8_t *apdu, const BACNET_CALENDAR_ENTRY *value);
 
 BACNET_STACK_EXPORT
 int bacnet_calendar_entry_context_encode(
-    uint8_t *apdu, uint8_t tag_number, BACNET_CALENDAR_ENTRY *value);
+    uint8_t *apdu, uint8_t tag_number, const BACNET_CALENDAR_ENTRY *value);
 
 BACNET_STACK_EXPORT
 int bacnet_calendar_entry_decode(
-    uint8_t *apdu, uint32_t apdu_max_len, BACNET_CALENDAR_ENTRY *entry);
+    const uint8_t *apdu, uint32_t apdu_max_len, BACNET_CALENDAR_ENTRY *entry);
 
 BACNET_STACK_EXPORT
 int bacnet_calendar_entry_context_decode(
-    uint8_t *apdu, uint32_t apdu_max_len, uint8_t tag_number,
+    const uint8_t *apdu, uint32_t apdu_max_len, uint8_t tag_number,
     BACNET_CALENDAR_ENTRY *value);
 
 BACNET_STACK_EXPORT
-bool bacapp_date_in_calendar_entry(BACNET_DATE *date,
-    BACNET_CALENDAR_ENTRY *entry);
+bool bacapp_date_in_calendar_entry(const BACNET_DATE *date,
+    const BACNET_CALENDAR_ENTRY *entry);
 
 BACNET_STACK_EXPORT
 bool bacnet_calendar_entry_same(
-    BACNET_CALENDAR_ENTRY *value1, BACNET_CALENDAR_ENTRY *value2);
+    const BACNET_CALENDAR_ENTRY *value1, const BACNET_CALENDAR_ENTRY *value2);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/cov.c
+++ b/src/bacnet/cov.c
@@ -27,11 +27,11 @@ Unconfirmed COV Notification
  * @param data  Pointer to the data to encode.
  * @return number of bytes encoded, or zero on error.
  */
-int cov_notify_encode_apdu(uint8_t *apdu, BACNET_COV_DATA *data)
+int cov_notify_encode_apdu(uint8_t *apdu, const BACNET_COV_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
-    BACNET_PROPERTY_VALUE *value = NULL; /* value in list */
+    const BACNET_PROPERTY_VALUE *value = NULL; /* value in list */
 
     if (!data) {
         return 0;
@@ -95,7 +95,7 @@ int cov_notify_encode_apdu(uint8_t *apdu, BACNET_COV_DATA *data)
  * @return number of bytes encoded, or zero if unable to encode or too large
  */
 size_t cov_notify_service_request_encode(
-    uint8_t *apdu, size_t apdu_size, BACNET_COV_DATA *data)
+    uint8_t *apdu, size_t apdu_size, const BACNET_COV_DATA *data)
 {
     size_t apdu_len = 0; /* total length of the apdu, return value */
 
@@ -122,7 +122,7 @@ size_t cov_notify_service_request_encode(
 int ccov_notify_encode_apdu(uint8_t *apdu,
     unsigned apdu_size,
     uint8_t invoke_id,
-    BACNET_COV_DATA *data)
+    const BACNET_COV_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* return value */
@@ -157,7 +157,7 @@ int ccov_notify_encode_apdu(uint8_t *apdu,
  * @return number of bytes encoded, or zero if unable to encode or too large
  */
 int ucov_notify_encode_apdu(
-    uint8_t *apdu, unsigned apdu_size, BACNET_COV_DATA *data)
+    uint8_t *apdu, unsigned apdu_size, const BACNET_COV_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* return value */
@@ -201,7 +201,7 @@ int ucov_notify_encode_apdu(
  * @return Bytes decoded or BACNET_STATUS_ERROR on error.
  */
 int cov_notify_decode_service_request(
-    uint8_t *apdu, unsigned apdu_size, BACNET_COV_DATA *data)
+    const uint8_t *apdu, unsigned apdu_size, BACNET_COV_DATA *data)
 {
     int len = 0; /* return value */
     int value_len = 0, tag_len = 0;
@@ -330,7 +330,8 @@ SubscribeCOV-Request ::= SEQUENCE {
  * @param data  Pointer to the data to encode.
  * @return number of bytes encoded, or zero on error.
  */
-int cov_subscribe_apdu_encode(uint8_t *apdu, BACNET_SUBSCRIBE_COV_DATA *data)
+int cov_subscribe_apdu_encode(
+    uint8_t *apdu, const BACNET_SUBSCRIBE_COV_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -380,7 +381,7 @@ int cov_subscribe_apdu_encode(uint8_t *apdu, BACNET_SUBSCRIBE_COV_DATA *data)
  * @return number of bytes encoded, or zero if unable to encode or too large
  */
 size_t cov_subscribe_service_request_encode(
-    uint8_t *apdu, size_t apdu_size, BACNET_SUBSCRIBE_COV_DATA *data)
+    uint8_t *apdu, size_t apdu_size, const BACNET_SUBSCRIBE_COV_DATA *data)
 {
     size_t apdu_len = 0; /* total length of the apdu, return value */
 
@@ -406,7 +407,7 @@ size_t cov_subscribe_service_request_encode(
 int cov_subscribe_encode_apdu(uint8_t *apdu,
     unsigned apdu_size,
     uint8_t invoke_id,
-    BACNET_SUBSCRIBE_COV_DATA *data)
+    const BACNET_SUBSCRIBE_COV_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -450,7 +451,7 @@ int cov_subscribe_encode_apdu(uint8_t *apdu,
  * @return Bytes decoded or Zero/BACNET_STATUS_ERROR on error.
  */
 int cov_subscribe_decode_service_request(
-    uint8_t *apdu, unsigned apdu_size, BACNET_SUBSCRIBE_COV_DATA *data)
+    const uint8_t *apdu, unsigned apdu_size, BACNET_SUBSCRIBE_COV_DATA *data)
 {
     int len = 0; /* return value */
     int value_len = 0;
@@ -570,7 +571,7 @@ BACnetPropertyReference ::= SEQUENCE {
  * @return bytes encoded or zero on error.
  */
 int cov_subscribe_property_apdu_encode(
-    uint8_t *apdu, BACNET_SUBSCRIBE_COV_DATA *data)
+    uint8_t *apdu, const BACNET_SUBSCRIBE_COV_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -649,7 +650,7 @@ int cov_subscribe_property_apdu_encode(
  * @return number of bytes encoded, or zero if unable to encode or too large
  */
 size_t cov_subscribe_property_service_request_encode(
-    uint8_t *apdu, size_t apdu_size, BACNET_SUBSCRIBE_COV_DATA *data)
+    uint8_t *apdu, size_t apdu_size, const BACNET_SUBSCRIBE_COV_DATA *data)
 {
     size_t apdu_len = 0; /* total length of the apdu, return value */
 
@@ -674,7 +675,7 @@ size_t cov_subscribe_property_service_request_encode(
 int cov_subscribe_property_encode_apdu(uint8_t *apdu,
     unsigned apdu_size,
     uint8_t invoke_id,
-    BACNET_SUBSCRIBE_COV_DATA *data)
+    const BACNET_SUBSCRIBE_COV_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -714,7 +715,7 @@ int cov_subscribe_property_encode_apdu(uint8_t *apdu,
  * @return Bytes decoded or Zero/BACNET_STATUS_ERROR on error.
  */
 int cov_subscribe_property_decode_service_request(
-    uint8_t *apdu, unsigned apdu_len, BACNET_SUBSCRIBE_COV_DATA *data)
+    const uint8_t *apdu, unsigned apdu_len, BACNET_SUBSCRIBE_COV_DATA *data)
 {
     int len = 0; /* return value */
     uint8_t tag_number = 0;
@@ -1105,7 +1106,7 @@ bool cov_value_list_encode_signed_int(BACNET_PROPERTY_VALUE *value_list,
  * @return true if values were encoded
  */
 bool cov_value_list_encode_character_string(BACNET_PROPERTY_VALUE *value_list,
-    BACNET_CHARACTER_STRING *value,
+    const BACNET_CHARACTER_STRING *value,
     bool in_alarm,
     bool fault,
     bool overridden,
@@ -1161,7 +1162,7 @@ bool cov_value_list_encode_character_string(BACNET_PROPERTY_VALUE *value_list,
  * @return true if values were encoded
  */
 bool cov_value_list_encode_bit_string(BACNET_PROPERTY_VALUE *value_list,
-    BACNET_BIT_STRING *value,
+    const BACNET_BIT_STRING *value,
     bool in_alarm,
     bool fault,
     bool overridden,

--- a/src/bacnet/cov.h
+++ b/src/bacnet/cov.h
@@ -54,18 +54,18 @@ extern "C" {
 
 BACNET_STACK_EXPORT
 size_t cov_notify_service_request_encode(
-    uint8_t *apdu, size_t apdu_size, BACNET_COV_DATA *data);
+    uint8_t *apdu, size_t apdu_size, const BACNET_COV_DATA *data);
 
 BACNET_STACK_EXPORT
-int cov_notify_encode_apdu(uint8_t *apdu, BACNET_COV_DATA *data);
+int cov_notify_encode_apdu(uint8_t *apdu, const BACNET_COV_DATA *data);
 
 BACNET_STACK_EXPORT
 int ucov_notify_encode_apdu(
-    uint8_t *apdu, unsigned max_apdu_len, BACNET_COV_DATA *data);
+    uint8_t *apdu, unsigned max_apdu_len, const BACNET_COV_DATA *data);
 
 BACNET_STACK_EXPORT
 int ucov_notify_decode_apdu(
-    uint8_t *apdu, unsigned apdu_len, BACNET_COV_DATA *data);
+    const uint8_t *apdu, unsigned apdu_len, BACNET_COV_DATA *data);
 
 BACNET_STACK_EXPORT
 int ucov_notify_send(
@@ -75,10 +75,10 @@ BACNET_STACK_EXPORT
 int ccov_notify_encode_apdu(uint8_t *apdu,
     unsigned max_apdu_len,
     uint8_t invoke_id,
-    BACNET_COV_DATA *data);
+    const BACNET_COV_DATA *data);
 
 BACNET_STACK_EXPORT
-int ccov_notify_decode_apdu(uint8_t *apdu,
+int ccov_notify_decode_apdu(const uint8_t *apdu,
     unsigned apdu_len,
     uint8_t *invoke_id,
     BACNET_COV_DATA *data);
@@ -86,47 +86,47 @@ int ccov_notify_decode_apdu(uint8_t *apdu,
 /* common for both confirmed and unconfirmed */
 BACNET_STACK_EXPORT
 int cov_notify_decode_service_request(
-    uint8_t *apdu, unsigned apdu_len, BACNET_COV_DATA *data);
+    const uint8_t *apdu, unsigned apdu_len, BACNET_COV_DATA *data);
 
 BACNET_STACK_EXPORT
 int cov_subscribe_property_decode_service_request(
-    uint8_t *apdu, unsigned apdu_len, BACNET_SUBSCRIBE_COV_DATA *data);
+    const uint8_t *apdu, unsigned apdu_len, BACNET_SUBSCRIBE_COV_DATA *data);
 
 BACNET_STACK_EXPORT
 int cov_subscribe_property_apdu_encode(
-    uint8_t *apdu, BACNET_SUBSCRIBE_COV_DATA *data);
+    uint8_t *apdu, const BACNET_SUBSCRIBE_COV_DATA *data);
 
 BACNET_STACK_EXPORT
 size_t cov_subscribe_property_service_request_encode(
-    uint8_t *apdu, size_t apdu_size, BACNET_SUBSCRIBE_COV_DATA *data);
+    uint8_t *apdu, size_t apdu_size, const BACNET_SUBSCRIBE_COV_DATA *data);
 
 BACNET_STACK_EXPORT
 int cov_subscribe_property_encode_apdu(uint8_t *apdu,
     unsigned max_apdu_len,
     uint8_t invoke_id,
-    BACNET_SUBSCRIBE_COV_DATA *data);
+    const BACNET_SUBSCRIBE_COV_DATA *data);
 
 BACNET_STACK_EXPORT
 int cov_subscribe_decode_service_request(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     unsigned apdu_len,
     BACNET_SUBSCRIBE_COV_DATA *data);
 
 BACNET_STACK_EXPORT
 int cov_subscribe_apdu_encode(uint8_t *apdu,
-    BACNET_SUBSCRIBE_COV_DATA *data);
+    const BACNET_SUBSCRIBE_COV_DATA *data);
 
 BACNET_STACK_EXPORT
 size_t cov_subscribe_service_request_encode(
     uint8_t *apdu,
     size_t apdu_size,
-    BACNET_SUBSCRIBE_COV_DATA *data);
+    const BACNET_SUBSCRIBE_COV_DATA *data);
 
 BACNET_STACK_EXPORT
 int cov_subscribe_encode_apdu(uint8_t *apdu,
     unsigned max_apdu_len,
     uint8_t invoke_id,
-    BACNET_SUBSCRIBE_COV_DATA *data);
+    const BACNET_SUBSCRIBE_COV_DATA *data);
 
 BACNET_STACK_EXPORT
 void cov_property_value_list_link(
@@ -168,14 +168,14 @@ bool cov_value_list_encode_signed_int(BACNET_PROPERTY_VALUE *value_list,
     bool out_of_service);
 BACNET_STACK_EXPORT
 bool cov_value_list_encode_character_string(BACNET_PROPERTY_VALUE *value_list,
-    BACNET_CHARACTER_STRING *value,
+    const BACNET_CHARACTER_STRING *value,
     bool in_alarm,
     bool fault,
     bool overridden,
     bool out_of_service);
     BACNET_STACK_EXPORT
     bool cov_value_list_encode_bit_string(BACNET_PROPERTY_VALUE *value_list,
-        BACNET_BIT_STRING *value,
+        const BACNET_BIT_STRING *value,
         bool in_alarm,
         bool fault,
         bool overridden,

--- a/src/bacnet/create_object.c
+++ b/src/bacnet/create_object.c
@@ -134,7 +134,7 @@ size_t create_object_service_request_encode(
  * @return Bytes decoded or BACNET_STATUS_REJECT on error.
  */
 int create_object_decode_service_request(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_CREATE_OBJECT_DATA *data)
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_CREATE_OBJECT_DATA *data)
 {
     int len = 0;
     int apdu_len = 0;
@@ -239,7 +239,7 @@ int create_object_decode_service_request(
  * @return number of bytes encoded
  */
 int create_object_ack_service_encode(
-    uint8_t *apdu, BACNET_CREATE_OBJECT_DATA *data)
+    uint8_t *apdu, const BACNET_CREATE_OBJECT_DATA *data)
 {
     /* BACnetObjectIdentifier */
     return encode_application_object_id(
@@ -257,7 +257,7 @@ int create_object_ack_service_encode(
  * @return number of bytes encoded
  */
 int create_object_ack_encode(
-    uint8_t *apdu, uint8_t invoke_id, BACNET_CREATE_OBJECT_DATA *data)
+    uint8_t *apdu, uint8_t invoke_id, const BACNET_CREATE_OBJECT_DATA *data)
 {
     int apdu_len = 3; /* total length of the apdu, return value */
 
@@ -285,7 +285,7 @@ int create_object_ack_encode(
  * @return Bytes encoded or #BACNET_STATUS_ERROR on error.
  */
 int create_object_ack_service_decode(
-    uint8_t *apdu, uint16_t apdu_size, BACNET_CREATE_OBJECT_DATA *data)
+    const uint8_t *apdu, uint16_t apdu_size, BACNET_CREATE_OBJECT_DATA *data)
 {
     int apdu_len = 0;
     BACNET_OBJECT_TYPE object_type = OBJECT_NONE;
@@ -318,7 +318,7 @@ int create_object_ack_service_decode(
  * @return Bytes encoded or zero on error.
  */
 int create_object_error_ack_service_encode(
-    uint8_t *apdu, BACNET_CREATE_OBJECT_DATA *data)
+    uint8_t *apdu, const BACNET_CREATE_OBJECT_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -357,7 +357,7 @@ int create_object_error_ack_service_encode(
  * @return number of bytes encoded
  */
 int create_object_error_ack_encode(
-    uint8_t *apdu, uint8_t invoke_id, BACNET_CREATE_OBJECT_DATA *data)
+    uint8_t *apdu, uint8_t invoke_id, const BACNET_CREATE_OBJECT_DATA *data)
 {
     int len = 3;
 
@@ -386,7 +386,7 @@ int create_object_error_ack_encode(
  * @return Bytes encoded or BACNET_STATUS_REJECT on error.
  */
 int create_object_error_ack_service_decode(
-    uint8_t *apdu, uint16_t apdu_size, BACNET_CREATE_OBJECT_DATA *data)
+    const uint8_t *apdu, uint16_t apdu_size, BACNET_CREATE_OBJECT_DATA *data)
 {
     int len = 0, apdu_len = 0;
     BACNET_ERROR_CLASS error_class = ERROR_CLASS_SERVICES;

--- a/src/bacnet/create_object.h
+++ b/src/bacnet/create_object.h
@@ -60,27 +60,27 @@ int create_object_encode_service_ack_encode(
     uint8_t *apdu, BACNET_CREATE_OBJECT_DATA *data);
 BACNET_STACK_EXPORT
 int create_object_decode_service_request(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_CREATE_OBJECT_DATA *data);
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_CREATE_OBJECT_DATA *data);
 
 BACNET_STACK_EXPORT
 int create_object_ack_service_encode(
-    uint8_t *apdu, BACNET_CREATE_OBJECT_DATA *data);
+    uint8_t *apdu, const BACNET_CREATE_OBJECT_DATA *data);
 BACNET_STACK_EXPORT
 int create_object_ack_service_decode(
-    uint8_t *apdu, uint16_t apdu_size, BACNET_CREATE_OBJECT_DATA *data);
+    const uint8_t *apdu, uint16_t apdu_size, BACNET_CREATE_OBJECT_DATA *data);
 BACNET_STACK_EXPORT
 int create_object_ack_encode(
-    uint8_t *apdu, uint8_t invoke_id, BACNET_CREATE_OBJECT_DATA *data);
+    uint8_t *apdu, uint8_t invoke_id, const BACNET_CREATE_OBJECT_DATA *data);
 
 BACNET_STACK_EXPORT
 int create_object_error_ack_service_encode(
-    uint8_t *apdu, BACNET_CREATE_OBJECT_DATA *data);
+    uint8_t *apdu, const BACNET_CREATE_OBJECT_DATA *data);
 BACNET_STACK_EXPORT
 int create_object_error_ack_service_decode(
-    uint8_t *apdu, uint16_t apdu_size, BACNET_CREATE_OBJECT_DATA *data);
+    const uint8_t *apdu, uint16_t apdu_size, BACNET_CREATE_OBJECT_DATA *data);
 BACNET_STACK_EXPORT
 int create_object_error_ack_encode(
-    uint8_t *apdu, uint8_t invoke_id, BACNET_CREATE_OBJECT_DATA *data);
+    uint8_t *apdu, uint8_t invoke_id, const BACNET_CREATE_OBJECT_DATA *data);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/credential_authentication_factor.c
+++ b/src/bacnet/credential_authentication_factor.c
@@ -11,7 +11,7 @@
 #include "bacnet/bacdcode.h"
 
 int bacapp_encode_credential_authentication_factor(
-    uint8_t *apdu, BACNET_CREDENTIAL_AUTHENTICATION_FACTOR *caf)
+    uint8_t *apdu, const BACNET_CREDENTIAL_AUTHENTICATION_FACTOR *caf)
 {
     int len;
     int apdu_len = 0;
@@ -35,7 +35,9 @@ int bacapp_encode_credential_authentication_factor(
 }
 
 int bacapp_encode_context_credential_authentication_factor(
-    uint8_t *apdu, uint8_t tag, BACNET_CREDENTIAL_AUTHENTICATION_FACTOR *caf)
+    uint8_t *apdu,
+    uint8_t tag,
+    const BACNET_CREDENTIAL_AUTHENTICATION_FACTOR *caf)
 {
     int len;
     int apdu_len = 0;
@@ -53,7 +55,7 @@ int bacapp_encode_context_credential_authentication_factor(
 }
 
 int bacapp_decode_credential_authentication_factor(
-    uint8_t *apdu, BACNET_CREDENTIAL_AUTHENTICATION_FACTOR *caf)
+    const uint8_t *apdu, BACNET_CREDENTIAL_AUTHENTICATION_FACTOR *caf)
 {
     int len;
     int apdu_len = 0;
@@ -89,7 +91,9 @@ int bacapp_decode_credential_authentication_factor(
 }
 
 int bacapp_decode_context_credential_authentication_factor(
-    uint8_t *apdu, uint8_t tag, BACNET_CREDENTIAL_AUTHENTICATION_FACTOR *caf)
+    const uint8_t *apdu,
+    uint8_t tag,
+    BACNET_CREDENTIAL_AUTHENTICATION_FACTOR *caf)
 {
     int len = 0;
     int section_length;

--- a/src/bacnet/credential_authentication_factor.h
+++ b/src/bacnet/credential_authentication_factor.h
@@ -30,19 +30,19 @@ extern "C" {
     BACNET_STACK_EXPORT
     int bacapp_encode_credential_authentication_factor(
         uint8_t * apdu,
-        BACNET_CREDENTIAL_AUTHENTICATION_FACTOR * caf);
+        const BACNET_CREDENTIAL_AUTHENTICATION_FACTOR * caf);
     BACNET_STACK_EXPORT
     int bacapp_encode_context_credential_authentication_factor(
         uint8_t * apdu,
         uint8_t tag,
-        BACNET_CREDENTIAL_AUTHENTICATION_FACTOR * caf);
+        const BACNET_CREDENTIAL_AUTHENTICATION_FACTOR * caf);
     BACNET_STACK_EXPORT
     int bacapp_decode_credential_authentication_factor(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         BACNET_CREDENTIAL_AUTHENTICATION_FACTOR * caf);
     BACNET_STACK_EXPORT
     int bacapp_decode_context_credential_authentication_factor(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint8_t tag,
         BACNET_CREDENTIAL_AUTHENTICATION_FACTOR * caf);
 

--- a/src/bacnet/dailyschedule.c
+++ b/src/bacnet/dailyschedule.c
@@ -18,7 +18,7 @@
  * @param day [in] Value to encode
  * @return Number of bytes encoded, or  BACNET_STATUS_ERROR if an error occurs
  */
-int bacnet_dailyschedule_context_decode(uint8_t *apdu,
+int bacnet_dailyschedule_context_decode(const uint8_t *apdu,
     int apdu_size,
     uint8_t tag_number,
     BACNET_DAILY_SCHEDULE *day)
@@ -51,7 +51,7 @@ int bacnet_dailyschedule_context_decode(uint8_t *apdu,
  * @return Number of bytes encoded, or BACNET_STATUS_ERROR if an error occurs
  */
 int bacnet_dailyschedule_context_encode(
-    uint8_t *apdu, uint8_t tag_number, BACNET_DAILY_SCHEDULE *day)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_DAILY_SCHEDULE *day)
 {
     if (day == NULL) {
         return BACNET_STATUS_ERROR;

--- a/src/bacnet/dailyschedule.h
+++ b/src/bacnet/dailyschedule.h
@@ -39,7 +39,7 @@ extern "C" {
     /** Decode DailySchedule (sequence of times and values) */
     BACNET_STACK_EXPORT
     int bacnet_dailyschedule_context_decode(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         int max_apdu_len,
         uint8_t tag_number,
         BACNET_DAILY_SCHEDULE * day);
@@ -49,7 +49,7 @@ extern "C" {
     int bacnet_dailyschedule_context_encode(
         uint8_t * apdu,
         uint8_t tag_number,
-        BACNET_DAILY_SCHEDULE * day);
+        const BACNET_DAILY_SCHEDULE * day);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/datalink/bacsec.c
+++ b/src/bacnet/datalink/bacsec.c
@@ -141,7 +141,8 @@ int encode_security_wrapper(
 }
 #endif
 
-int encode_challenge_request(uint8_t *apdu, BACNET_CHALLENGE_REQUEST *bc_req)
+int encode_challenge_request(
+    uint8_t *apdu, const BACNET_CHALLENGE_REQUEST *bc_req)
 {
     int curr = 0;
 
@@ -152,7 +153,8 @@ int encode_challenge_request(uint8_t *apdu, BACNET_CHALLENGE_REQUEST *bc_req)
     return curr;
 }
 
-int encode_security_payload(uint8_t *apdu, BACNET_SECURITY_PAYLOAD *payload)
+int encode_security_payload(
+    uint8_t *apdu, const BACNET_SECURITY_PAYLOAD *payload)
 {
     encode_unsigned16(&apdu[0], payload->payload_length);
     memcpy(&apdu[2], payload->payload, payload->payload_length);
@@ -160,7 +162,7 @@ int encode_security_payload(uint8_t *apdu, BACNET_SECURITY_PAYLOAD *payload)
     return (int)(2 + payload->payload_length);
 }
 
-int encode_security_response(uint8_t *apdu, BACNET_SECURITY_RESPONSE *resp)
+int encode_security_response(uint8_t *apdu, const BACNET_SECURITY_RESPONSE *resp)
 {
     int curr = 0;
     int i;
@@ -232,7 +234,7 @@ int encode_security_response(uint8_t *apdu, BACNET_SECURITY_RESPONSE *resp)
     return curr;
 }
 
-int encode_request_key_update(uint8_t *apdu, BACNET_REQUEST_KEY_UPDATE *req)
+int encode_request_key_update(uint8_t *apdu, const BACNET_REQUEST_KEY_UPDATE *req)
 {
     int curr = 0;
 
@@ -247,7 +249,7 @@ int encode_request_key_update(uint8_t *apdu, BACNET_REQUEST_KEY_UPDATE *req)
     return curr;
 }
 
-int encode_key_entry(uint8_t *apdu, BACNET_KEY_ENTRY *entry)
+int encode_key_entry(uint8_t *apdu, const BACNET_KEY_ENTRY *entry)
 {
     int curr = 0;
 
@@ -259,7 +261,7 @@ int encode_key_entry(uint8_t *apdu, BACNET_KEY_ENTRY *entry)
     return curr;
 }
 
-int encode_update_key_set(uint8_t *apdu, BACNET_UPDATE_KEY_SET *key_set)
+int encode_update_key_set(uint8_t *apdu, const BACNET_UPDATE_KEY_SET *key_set)
 {
     int curr = 0;
     int i, res;
@@ -330,7 +332,7 @@ int encode_update_key_set(uint8_t *apdu, BACNET_UPDATE_KEY_SET *key_set)
 }
 
 int encode_update_distribution_key(
-    uint8_t *apdu, BACNET_UPDATE_DISTRIBUTION_KEY *dist_key)
+    uint8_t *apdu, const BACNET_UPDATE_DISTRIBUTION_KEY *dist_key)
 {
     int curr = 0;
     int res;
@@ -345,7 +347,7 @@ int encode_update_distribution_key(
 }
 
 int encode_request_master_key(
-    uint8_t *apdu, BACNET_REQUEST_MASTER_KEY *req_master_key)
+    uint8_t *apdu, const BACNET_REQUEST_MASTER_KEY *req_master_key)
 {
     int curr = 0;
 
@@ -356,7 +358,7 @@ int encode_request_master_key(
     return (int)(curr + req_master_key->no_supported_algorithms);
 }
 
-int encode_set_master_key(uint8_t *apdu, BACNET_SET_MASTER_KEY *set_master_key)
+int encode_set_master_key(uint8_t *apdu, const BACNET_SET_MASTER_KEY *set_master_key)
 {
     return encode_key_entry(apdu, &set_master_key->key);
 }
@@ -473,7 +475,7 @@ int decode_security_wrapper_safe(int bytes_before,
 }
 #endif
 
-int decode_challenge_request_safe(uint8_t *apdu,
+int decode_challenge_request_safe(const uint8_t *apdu,
     uint32_t apdu_len_remaining,
     BACNET_CHALLENGE_REQUEST *bc_req)
 {
@@ -489,7 +491,7 @@ int decode_challenge_request_safe(uint8_t *apdu,
     return curr; /* always 9! */
 }
 
-int decode_security_payload_safe(uint8_t *apdu,
+int decode_security_payload_safe(const uint8_t *apdu,
     uint32_t apdu_len_remaining,
     BACNET_SECURITY_PAYLOAD *payload)
 {
@@ -505,7 +507,9 @@ int decode_security_payload_safe(uint8_t *apdu,
 }
 
 int decode_security_response_safe(
-    uint8_t *apdu, uint32_t apdu_len_remaining, BACNET_SECURITY_RESPONSE *resp)
+    const uint8_t *apdu,
+    uint32_t apdu_len_remaining,
+    BACNET_SECURITY_RESPONSE *resp)
 {
     int curr = 0;
     int i;
@@ -613,7 +617,9 @@ int decode_security_response_safe(
 }
 
 int decode_request_key_update_safe(
-    uint8_t *apdu, uint32_t apdu_len_remaining, BACNET_REQUEST_KEY_UPDATE *req)
+    const uint8_t *apdu,
+    uint32_t apdu_len_remaining,
+    BACNET_REQUEST_KEY_UPDATE *req)
 {
     int curr = 0;
 
@@ -632,7 +638,7 @@ int decode_request_key_update_safe(
 }
 
 int decode_key_entry_safe(
-    uint8_t *apdu, uint32_t apdu_len_remaining, BACNET_KEY_ENTRY *entry)
+    const uint8_t *apdu, uint32_t apdu_len_remaining, BACNET_KEY_ENTRY *entry)
 {
     int curr = 0;
 
@@ -652,7 +658,9 @@ int decode_key_entry_safe(
 }
 
 int decode_update_key_set_safe(
-    uint8_t *apdu, uint32_t apdu_len_remaining, BACNET_UPDATE_KEY_SET *key_set)
+    const uint8_t *apdu,
+    uint32_t apdu_len_remaining,
+    BACNET_UPDATE_KEY_SET *key_set)
 {
     int curr = 0;
     int i, res;
@@ -743,7 +751,7 @@ int decode_update_key_set_safe(
     return curr;
 }
 
-int decode_update_distribution_key_safe(uint8_t *apdu,
+int decode_update_distribution_key_safe(const uint8_t *apdu,
     uint32_t apdu_len_remaining,
     BACNET_UPDATE_DISTRIBUTION_KEY *dist_key)
 {
@@ -762,7 +770,7 @@ int decode_update_distribution_key_safe(uint8_t *apdu,
     return curr + res;
 }
 
-int decode_request_master_key_safe(uint8_t *apdu,
+int decode_request_master_key_safe(const uint8_t *apdu,
     uint32_t apdu_len_remaining,
     BACNET_REQUEST_MASTER_KEY *req_master_key)
 {
@@ -781,7 +789,7 @@ int decode_request_master_key_safe(uint8_t *apdu,
     return (int)(curr + req_master_key->no_supported_algorithms);
 }
 
-int decode_set_master_key_safe(uint8_t *apdu,
+int decode_set_master_key_safe(const uint8_t *apdu,
     uint32_t apdu_len_remaining,
     BACNET_SET_MASTER_KEY *set_master_key)
 {

--- a/src/bacnet/datalink/bacsec.h
+++ b/src/bacnet/datalink/bacsec.h
@@ -228,31 +228,31 @@ extern "C" {
     /*     BACNET_SECURITY_WRAPPER * wrapper); */
     BACNET_STACK_EXPORT
     int encode_challenge_request(uint8_t * apdu,
-        BACNET_CHALLENGE_REQUEST * bc_req);
+        const BACNET_CHALLENGE_REQUEST * bc_req);
     BACNET_STACK_EXPORT
     int encode_security_payload(uint8_t * apdu,
-        BACNET_SECURITY_PAYLOAD * payload);
+        const BACNET_SECURITY_PAYLOAD * payload);
     BACNET_STACK_EXPORT
     int encode_security_response(uint8_t * apdu,
-        BACNET_SECURITY_RESPONSE * resp);
+        const BACNET_SECURITY_RESPONSE * resp);
     BACNET_STACK_EXPORT
     int encode_request_key_update(uint8_t * apdu,
-        BACNET_REQUEST_KEY_UPDATE * req);
+        const BACNET_REQUEST_KEY_UPDATE * req);
     BACNET_STACK_EXPORT
     int encode_key_entry(uint8_t * apdu,
-        BACNET_KEY_ENTRY * entry);
+        const BACNET_KEY_ENTRY * entry);
     BACNET_STACK_EXPORT
     int encode_update_key_set(uint8_t * apdu,
-        BACNET_UPDATE_KEY_SET * key_set);
+        const BACNET_UPDATE_KEY_SET * key_set);
     BACNET_STACK_EXPORT
     int encode_update_distribution_key(uint8_t * apdu,
-        BACNET_UPDATE_DISTRIBUTION_KEY * dist_key);
+        const BACNET_UPDATE_DISTRIBUTION_KEY * dist_key);
     BACNET_STACK_EXPORT
     int encode_request_master_key(uint8_t * apdu,
-        BACNET_REQUEST_MASTER_KEY * req_master_key);
+        const BACNET_REQUEST_MASTER_KEY * req_master_key);
     BACNET_STACK_EXPORT
     int encode_set_master_key(uint8_t * apdu,
-        BACNET_SET_MASTER_KEY * set_master_key);
+        const BACNET_SET_MASTER_KEY * set_master_key);
 
 /* safe decoders */
     /* BACNET_STACK_EXPORT */
@@ -261,39 +261,39 @@ extern "C" {
     /*     uint32_t apdu_len_remaining, */
     /*     BACNET_SECURITY_WRAPPER * wrapper); */
     BACNET_STACK_EXPORT
-    int decode_challenge_request_safe(uint8_t * apdu,
+    int decode_challenge_request_safe(const uint8_t * apdu,
         uint32_t apdu_len_remaining,
         BACNET_CHALLENGE_REQUEST * bc_req);
     BACNET_STACK_EXPORT
-    int decode_security_payload_safe(uint8_t * apdu,
+    int decode_security_payload_safe(const uint8_t * apdu,
         uint32_t apdu_len_remaining,
         BACNET_SECURITY_PAYLOAD * payload);
     BACNET_STACK_EXPORT
-    int decode_security_response_safe(uint8_t * apdu,
+    int decode_security_response_safe(const uint8_t * apdu,
         uint32_t apdu_len_remaining,
         BACNET_SECURITY_RESPONSE * resp);
     BACNET_STACK_EXPORT
-    int decode_request_key_update_safe(uint8_t * apdu,
+    int decode_request_key_update_safe(const uint8_t * apdu,
         uint32_t apdu_len_remaining,
         BACNET_REQUEST_KEY_UPDATE * req);
     BACNET_STACK_EXPORT
-    int decode_key_entry_safe(uint8_t * apdu,
+    int decode_key_entry_safe(const uint8_t * apdu,
         uint32_t apdu_len_remaining,
         BACNET_KEY_ENTRY * entry);
     BACNET_STACK_EXPORT
-    int decode_update_key_set_safe(uint8_t * apdu,
+    int decode_update_key_set_safe(const uint8_t * apdu,
         uint32_t apdu_len_remaining,
         BACNET_UPDATE_KEY_SET * key_set);
     BACNET_STACK_EXPORT
-    int decode_update_distribution_key_safe(uint8_t * apdu,
+    int decode_update_distribution_key_safe(const uint8_t * apdu,
         uint32_t apdu_len_remaining,
         BACNET_UPDATE_DISTRIBUTION_KEY * dist_key);
     BACNET_STACK_EXPORT
-    int decode_request_master_key_safe(uint8_t * apdu,
+    int decode_request_master_key_safe(const uint8_t * apdu,
         uint32_t apdu_len_remaining,
         BACNET_REQUEST_MASTER_KEY * req_master_key);
     BACNET_STACK_EXPORT
-    int decode_set_master_key_safe(uint8_t * apdu,
+    int decode_set_master_key_safe(const uint8_t * apdu,
         uint32_t apdu_len_remaining,
         BACNET_SET_MASTER_KEY * set_master_key);
 

--- a/src/bacnet/datalink/bip.h
+++ b/src/bacnet/datalink/bip.h
@@ -33,7 +33,7 @@ extern "C" {
     bool bip_init(char *ifname);
 
     BACNET_STACK_EXPORT
-    void bip_set_interface(char *ifname);
+    void bip_set_interface(const char *ifname);
 
     BACNET_STACK_EXPORT
     void bip_cleanup(void);
@@ -56,7 +56,8 @@ extern "C" {
 
     /* implement in ports module */
     BACNET_STACK_EXPORT
-    int bip_send_mpdu(BACNET_IP_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len);
+    int bip_send_mpdu(
+        const BACNET_IP_ADDRESS *dest, const uint8_t *mtu, uint16_t mtu_len);
 
     BACNET_STACK_EXPORT
     uint16_t bip_receive(BACNET_ADDRESS *src,
@@ -76,7 +77,7 @@ extern "C" {
     uint16_t bip_get_port(void);
 
     BACNET_STACK_EXPORT
-    bool bip_set_addr(BACNET_IP_ADDRESS *addr);
+    bool bip_set_addr(const BACNET_IP_ADDRESS *addr);
 
     BACNET_STACK_EXPORT
     bool bip_get_addr(BACNET_IP_ADDRESS *addr);
@@ -85,7 +86,7 @@ extern "C" {
     bool bip_get_addr_by_name(const char *host_name, BACNET_IP_ADDRESS *addr);
 
     BACNET_STACK_EXPORT
-    bool bip_set_broadcast_addr(BACNET_IP_ADDRESS *addr);
+    bool bip_set_broadcast_addr(const BACNET_IP_ADDRESS *addr);
 
     BACNET_STACK_EXPORT
     bool bip_get_broadcast_addr(BACNET_IP_ADDRESS *addr);

--- a/src/bacnet/datalink/bip6.h
+++ b/src/bacnet/datalink/bip6.h
@@ -66,11 +66,11 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     bool bip6_address_match_self(
-        BACNET_IP6_ADDRESS *addr);
+        const BACNET_IP6_ADDRESS *addr);
 
     BACNET_STACK_EXPORT
     bool bip6_set_addr(
-        BACNET_IP6_ADDRESS *addr);
+        const BACNET_IP6_ADDRESS *addr);
     BACNET_STACK_EXPORT
     bool bip6_get_addr(
         BACNET_IP6_ADDRESS *addr);
@@ -84,7 +84,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     bool bip6_set_broadcast_addr(
-        BACNET_IP6_ADDRESS *addr);
+        const BACNET_IP6_ADDRESS *addr);
     /* returns network byte order */
     BACNET_STACK_EXPORT
     bool bip6_get_broadcast_addr(
@@ -92,8 +92,8 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     int bip6_send_mpdu(
-        BACNET_IP6_ADDRESS *addr,
-        uint8_t * mtu,
+        const BACNET_IP6_ADDRESS *addr,
+        const uint8_t * mtu,
         uint16_t mtu_len);
     BACNET_STACK_EXPORT
     bool bip6_send_pdu_queue_empty(

--- a/src/bacnet/datalink/bvlc.c
+++ b/src/bacnet/datalink/bvlc.c
@@ -56,7 +56,7 @@ int bvlc_encode_header(
  *
  * @return number of bytes decoded
  */
-int bvlc_decode_header(uint8_t *pdu,
+int bvlc_decode_header(const uint8_t *pdu,
     uint16_t pdu_len,
     uint8_t *message_type,
     uint16_t *message_length)
@@ -127,7 +127,8 @@ int bvlc_encode_result(uint8_t *pdu, uint16_t pdu_size, uint16_t result_code)
  *
  * @return number of bytes decoded
  */
-int bvlc_decode_result(uint8_t *pdu, uint16_t pdu_len, uint16_t *result_code)
+int bvlc_decode_result(
+    const uint8_t *pdu, uint16_t pdu_len, uint16_t *result_code)
 {
     int bytes_consumed = 0;
     const uint16_t length = 2;
@@ -150,7 +151,7 @@ int bvlc_decode_result(uint8_t *pdu, uint16_t pdu_len, uint16_t *result_code)
  */
 bool bvlc_broadcast_distribution_mask_copy(
     BACNET_IP_BROADCAST_DISTRIBUTION_MASK *dst,
-    BACNET_IP_BROADCAST_DISTRIBUTION_MASK *src)
+    const BACNET_IP_BROADCAST_DISTRIBUTION_MASK *src)
 {
     bool status = false;
     unsigned int i = 0;
@@ -172,8 +173,8 @@ bool bvlc_broadcast_distribution_mask_copy(
  * @return true if the masks are different
  */
 bool bvlc_broadcast_distribution_mask_different(
-    BACNET_IP_BROADCAST_DISTRIBUTION_MASK *dst,
-    BACNET_IP_BROADCAST_DISTRIBUTION_MASK *src)
+    const BACNET_IP_BROADCAST_DISTRIBUTION_MASK *dst,
+    const BACNET_IP_BROADCAST_DISTRIBUTION_MASK *src)
 {
     bool status = false;
     unsigned int i = 0;
@@ -196,8 +197,8 @@ bool bvlc_broadcast_distribution_mask_different(
  * @return true if the addresses are different
  */
 bool bvlc_broadcast_distribution_table_entry_different(
-    BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *dst,
-    BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *src)
+    const BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *dst,
+    const BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *src)
 {
     bool status = false;
 
@@ -220,7 +221,7 @@ bool bvlc_broadcast_distribution_table_entry_different(
  */
 bool bvlc_broadcast_distribution_table_entry_copy(
     BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *dst,
-    BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *src)
+    const BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *src)
 {
     bool status = false;
 
@@ -327,7 +328,7 @@ void bvlc_broadcast_distribution_table_link_array(
  */
 bool bvlc_broadcast_distribution_table_entry_append(
     BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_list,
-    BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_new)
+    const BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_new)
 {
     BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry = NULL;
     bool status = false;
@@ -363,8 +364,8 @@ bool bvlc_broadcast_distribution_table_entry_append(
  */
 bool bvlc_broadcast_distribution_table_entry_set(
     BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry,
-    BACNET_IP_ADDRESS *addr,
-    BACNET_IP_BROADCAST_DISTRIBUTION_MASK *mask)
+    const BACNET_IP_ADDRESS *addr,
+    const BACNET_IP_BROADCAST_DISTRIBUTION_MASK *mask)
 {
     bool status = false;
 
@@ -405,7 +406,8 @@ bool bvlc_broadcast_distribution_mask_from_host(
  * @return true if the broadcast distribution was retrieved
  */
 bool bvlc_broadcast_distribution_mask_to_host(
-    uint32_t *broadcast_mask, BACNET_IP_BROADCAST_DISTRIBUTION_MASK *mask)
+    uint32_t *broadcast_mask,
+    const BACNET_IP_BROADCAST_DISTRIBUTION_MASK *mask)
 {
     bool status = false;
 
@@ -449,7 +451,7 @@ void bvlc_broadcast_distribution_mask_set(
  * @param addr3 - broadcast distribution mask octet
  */
 void bvlc_broadcast_distribution_mask_get(
-    BACNET_IP_BROADCAST_DISTRIBUTION_MASK *mask,
+    const BACNET_IP_BROADCAST_DISTRIBUTION_MASK *mask,
     uint8_t *addr0,
     uint8_t *addr1,
     uint8_t *addr2,
@@ -485,7 +487,7 @@ void bvlc_broadcast_distribution_mask_get(
  */
 bool bvlc_broadcast_distribution_table_entry_forward_address(
     BACNET_IP_ADDRESS *addr,
-    BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry)
+    const BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry)
 {
     bool status = false;
 
@@ -582,7 +584,7 @@ int bvlc_broadcast_distribution_table_encode(uint8_t *apdu,
  * @param bdt_head - head of a BDT linked list
  * @return length of the APDU buffer decoded, or ERROR, REJECT, or ABORT
  */
-int bvlc_broadcast_distribution_table_decode(uint8_t *apdu,
+int bvlc_broadcast_distribution_table_decode(const uint8_t *apdu,
     uint16_t apdu_len,
     BACNET_ERROR_CODE *error_code,
     BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_head)
@@ -769,7 +771,7 @@ int bvlc_encode_write_broadcast_distribution_table(uint8_t *pdu,
  *
  * @return number of bytes decoded
  */
-int bvlc_decode_write_broadcast_distribution_table(uint8_t *pdu,
+int bvlc_decode_write_broadcast_distribution_table(const uint8_t *pdu,
     uint16_t pdu_len,
     BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_list)
 {
@@ -899,7 +901,7 @@ int bvlc_encode_read_broadcast_distribution_table_ack(uint8_t *pdu,
  *
  * @return number of bytes decoded
  */
-int bvlc_decode_read_broadcast_distribution_table_ack(uint8_t *pdu,
+int bvlc_decode_read_broadcast_distribution_table_ack(const uint8_t *pdu,
     uint16_t pdu_len,
     BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_list)
 {
@@ -956,8 +958,8 @@ int bvlc_decode_read_broadcast_distribution_table_ack(uint8_t *pdu,
  */
 int bvlc_encode_forwarded_npdu(uint8_t *pdu,
     uint16_t pdu_size,
-    BACNET_IP_ADDRESS *bip_address,
-    uint8_t *npdu,
+    const BACNET_IP_ADDRESS *bip_address,
+    const uint8_t *npdu,
     uint16_t npdu_len)
 {
     int bytes_encoded = 0;
@@ -997,7 +999,7 @@ int bvlc_encode_forwarded_npdu(uint8_t *pdu,
  *
  * @return number of bytes decoded
  */
-int bvlc_decode_forwarded_npdu(uint8_t *pdu,
+int bvlc_decode_forwarded_npdu(const uint8_t *pdu,
     uint16_t pdu_len,
     BACNET_IP_ADDRESS *bip_address,
     uint8_t *npdu,
@@ -1076,7 +1078,7 @@ int bvlc_encode_register_foreign_device(
  * @return number of bytes decoded
  */
 int bvlc_decode_register_foreign_device(
-    uint8_t *pdu, uint16_t pdu_len, uint16_t *ttl_seconds)
+    const uint8_t *pdu, uint16_t pdu_len, uint16_t *ttl_seconds)
 {
     int bytes_consumed = 0;
     const uint16_t length = 2;
@@ -1187,8 +1189,8 @@ int bvlc_encode_read_foreign_device_table(uint8_t *pdu, uint16_t pdu_size)
  * @return true if the entries are different
  */
 bool bvlc_foreign_device_table_entry_different(
-    BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *entry1,
-    BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *entry2)
+    const BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *entry1,
+    const BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *entry2)
 {
     if (entry1 && entry2) {
         if (bvlc_address_different(
@@ -1208,7 +1210,7 @@ bool bvlc_foreign_device_table_entry_different(
  */
 bool bvlc_foreign_device_table_entry_copy(
     BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *entry1,
-    BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *entry2)
+    const BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *entry2)
 {
     bool status = false;
 
@@ -1257,7 +1259,8 @@ void bvlc_foreign_device_table_maintenance_timer(
  * @return true if the Foreign Device entry was found and removed.
  */
 bool bvlc_foreign_device_table_entry_delete(
-    BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *fdt_list, BACNET_IP_ADDRESS *addr)
+    BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *fdt_list,
+    const BACNET_IP_ADDRESS *addr)
 {
     BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *fdt_entry = NULL;
     bool status = false;
@@ -1287,7 +1290,7 @@ bool bvlc_foreign_device_table_entry_delete(
  */
 bool bvlc_foreign_device_table_entry_add(
     BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *fdt_list,
-    BACNET_IP_ADDRESS *addr,
+    const BACNET_IP_ADDRESS *addr,
     uint16_t ttl_seconds)
 {
     BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *fdt_entry = NULL;
@@ -1471,7 +1474,7 @@ int bvlc_encode_read_foreign_device_table_ack(uint8_t *pdu,
  *
  * @return number of bytes decoded
  */
-int bvlc_decode_read_foreign_device_table_ack(uint8_t *pdu,
+int bvlc_decode_read_foreign_device_table_ack(const uint8_t *pdu,
     uint16_t pdu_len,
     BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *fdt_list)
 {
@@ -1521,7 +1524,7 @@ int bvlc_decode_read_foreign_device_table_ack(uint8_t *pdu,
  *                                        of the table entry to be deleted.
  */
 int bvlc_encode_delete_foreign_device(
-    uint8_t *pdu, uint16_t pdu_size, BACNET_IP_ADDRESS *ip_address)
+    uint8_t *pdu, uint16_t pdu_size, const BACNET_IP_ADDRESS *ip_address)
 {
     int bytes_encoded = 0;
     const uint16_t length = 0x000A;
@@ -1552,7 +1555,7 @@ int bvlc_encode_delete_foreign_device(
  * @return number of bytes decoded
  */
 int bvlc_decode_delete_foreign_device(
-    uint8_t *pdu, uint16_t pdu_len, BACNET_IP_ADDRESS *ip_address)
+    const uint8_t *pdu, uint16_t pdu_len, BACNET_IP_ADDRESS *ip_address)
 {
     int bytes_consumed = 0;
     const uint16_t length = BIP_ADDRESS_MAX;
@@ -1586,7 +1589,7 @@ int bvlc_decode_delete_foreign_device(
  * BACnet NPDU from Originating Device:  Variable length
  */
 int bvlc_encode_distribute_broadcast_to_network(
-    uint8_t *pdu, uint16_t pdu_size, uint8_t *npdu, uint16_t npdu_len)
+    uint8_t *pdu, uint16_t pdu_size, const uint8_t *npdu, uint16_t npdu_len)
 {
     int bytes_encoded = 0;
     uint16_t length = 1 + 1 + 2;
@@ -1620,7 +1623,7 @@ int bvlc_encode_distribute_broadcast_to_network(
  *
  * @return number of bytes decoded
  */
-int bvlc_decode_distribute_broadcast_to_network(uint8_t *pdu,
+int bvlc_decode_distribute_broadcast_to_network(const uint8_t *pdu,
     uint16_t pdu_len,
     uint8_t *npdu,
     uint16_t npdu_size,
@@ -1661,7 +1664,7 @@ int bvlc_decode_distribute_broadcast_to_network(uint8_t *pdu,
  * BACnet NPDU:   Variable length
  */
 int bvlc_encode_original_unicast(
-    uint8_t *pdu, uint16_t pdu_size, uint8_t *npdu, uint16_t npdu_len)
+    uint8_t *pdu, uint16_t pdu_size, const uint8_t *npdu, uint16_t npdu_len)
 {
     int bytes_encoded = 0;
     uint16_t length = 4;
@@ -1695,7 +1698,7 @@ int bvlc_encode_original_unicast(
  *
  * @return number of bytes decoded
  */
-int bvlc_decode_original_unicast(uint8_t *pdu,
+int bvlc_decode_original_unicast(const uint8_t *pdu,
     uint16_t pdu_len,
     uint8_t *npdu,
     uint16_t npdu_size,
@@ -1736,7 +1739,7 @@ int bvlc_decode_original_unicast(uint8_t *pdu,
  * BACnet NPDU:   Variable length
  */
 int bvlc_encode_original_broadcast(
-    uint8_t *pdu, uint16_t pdu_size, uint8_t *npdu, uint16_t npdu_len)
+    uint8_t *pdu, uint16_t pdu_size, const uint8_t *npdu, uint16_t npdu_len)
 {
     int bytes_encoded = 0;
     uint16_t length = 4;
@@ -1770,7 +1773,7 @@ int bvlc_encode_original_broadcast(
  *
  * @return number of bytes decoded
  */
-int bvlc_decode_original_broadcast(uint8_t *pdu,
+int bvlc_decode_original_broadcast(const uint8_t *pdu,
     uint16_t pdu_len,
     uint8_t *npdu,
     uint16_t npdu_size,
@@ -1811,7 +1814,7 @@ int bvlc_decode_original_broadcast(uint8_t *pdu,
  * Security Wrapper:            Variable length
  */
 int bvlc_encode_secure_bvll(
-    uint8_t *pdu, uint16_t pdu_size, uint8_t *sbuf, uint16_t sbuf_len)
+    uint8_t *pdu, uint16_t pdu_size, const uint8_t *sbuf, uint16_t sbuf_len)
 {
     int bytes_encoded = 0;
     uint16_t length = 1 + 1 + 2;
@@ -1845,7 +1848,7 @@ int bvlc_encode_secure_bvll(
  *
  * @return number of bytes decoded
  */
-int bvlc_decode_secure_bvll(uint8_t *pdu,
+int bvlc_decode_secure_bvll(const uint8_t *pdu,
     uint16_t pdu_len,
     uint8_t *sbuf,
     uint16_t sbuf_size,
@@ -1914,7 +1917,7 @@ int bvlc_encode_address(
  * @return number of bytes decoded
  */
 int bvlc_decode_address(
-    uint8_t *pdu, uint16_t pdu_len, BACNET_IP_ADDRESS *bip_address)
+    const uint8_t *pdu, uint16_t pdu_len, BACNET_IP_ADDRESS *bip_address)
 {
     int bytes_consumed = 0;
     uint16_t length = BIP_ADDRESS_MAX;
@@ -2068,7 +2071,7 @@ bool bvlc_address_set(BACNET_IP_ADDRESS *addr,
  *
  * @return true if the address is set
  */
-bool bvlc_address_get(BACNET_IP_ADDRESS *addr,
+bool bvlc_address_get(const BACNET_IP_ADDRESS *addr,
     uint8_t *addr0,
     uint8_t *addr1,
     uint8_t *addr2,
@@ -2201,7 +2204,7 @@ void bvlc_address_from_network(BACNET_IP_ADDRESS *dst, uint32_t addr)
  * @return true if a valid address was set
  */
 bool bvlc_ip_address_to_bacnet_local(
-    BACNET_ADDRESS *addr, BACNET_IP_ADDRESS *ipaddr)
+    BACNET_ADDRESS *addr, const BACNET_IP_ADDRESS *ipaddr)
 {
     bool status = false;
 
@@ -2239,7 +2242,7 @@ bool bvlc_ip_address_to_bacnet_local(
  * @return true if a valid address was set
  */
 bool bvlc_ip_address_from_bacnet_local(
-    BACNET_IP_ADDRESS *ipaddr, BACNET_ADDRESS *addr)
+    BACNET_IP_ADDRESS *ipaddr, const BACNET_ADDRESS *addr)
 {
     bool status = false;
 
@@ -2266,7 +2269,7 @@ bool bvlc_ip_address_from_bacnet_local(
  * @return true if a valid address was set
  */
 bool bvlc_ip_address_to_bacnet_remote(
-    BACNET_ADDRESS *addr, uint16_t dnet, BACNET_IP_ADDRESS *ipaddr)
+    BACNET_ADDRESS *addr, uint16_t dnet, const BACNET_IP_ADDRESS *ipaddr)
 {
     bool status = false;
 
@@ -2298,7 +2301,7 @@ bool bvlc_ip_address_to_bacnet_remote(
  * @return true if a valid address was set
  */
 bool bvlc_ip_address_from_bacnet_remote(
-    BACNET_IP_ADDRESS *ipaddr, uint16_t *dnet, BACNET_ADDRESS *addr)
+    BACNET_IP_ADDRESS *ipaddr, uint16_t *dnet, const BACNET_ADDRESS *addr)
 {
     bool status = false;
 
@@ -2335,7 +2338,7 @@ bool bvlc_ip_address_from_bacnet_remote(
  */
 int bvlc_encode_broadcast_distribution_mask(uint8_t *pdu,
     uint16_t pdu_size,
-    BACNET_IP_BROADCAST_DISTRIBUTION_MASK *bd_mask)
+    const BACNET_IP_BROADCAST_DISTRIBUTION_MASK *bd_mask)
 {
     int bytes_encoded = 0;
     unsigned i = 0;
@@ -2363,7 +2366,7 @@ int bvlc_encode_broadcast_distribution_mask(uint8_t *pdu,
  *
  * @return number of bytes decoded
  */
-int bvlc_decode_broadcast_distribution_mask(uint8_t *pdu,
+int bvlc_decode_broadcast_distribution_mask(const uint8_t *pdu,
     uint16_t pdu_len,
     BACNET_IP_BROADCAST_DISTRIBUTION_MASK *bd_mask)
 {
@@ -2398,7 +2401,7 @@ int bvlc_decode_broadcast_distribution_mask(uint8_t *pdu,
  */
 int bvlc_encode_broadcast_distribution_table_entry(uint8_t *pdu,
     uint16_t pdu_size,
-    BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry)
+    const BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry)
 {
     int bytes_encoded = 0;
     int len = 0;
@@ -2437,7 +2440,7 @@ int bvlc_encode_broadcast_distribution_table_entry(uint8_t *pdu,
  *
  * @return number of bytes decoded
  */
-int bvlc_decode_broadcast_distribution_table_entry(uint8_t *pdu,
+int bvlc_decode_broadcast_distribution_table_entry(const uint8_t *pdu,
     uint16_t pdu_len,
     BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry)
 {
@@ -2479,7 +2482,7 @@ int bvlc_decode_broadcast_distribution_table_entry(uint8_t *pdu,
  */
 int bvlc_encode_foreign_device_table_entry(uint8_t *pdu,
     uint16_t pdu_size,
-    BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *fdt_entry)
+    const BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *fdt_entry)
 {
     int bytes_encoded = 0;
     int len = 0;
@@ -2521,7 +2524,7 @@ int bvlc_encode_foreign_device_table_entry(uint8_t *pdu,
  *
  * @return number of bytes decoded
  */
-int bvlc_decode_foreign_device_table_entry(uint8_t *pdu,
+int bvlc_decode_foreign_device_table_entry(const uint8_t *pdu,
     uint16_t pdu_len,
     BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *fdt_entry)
 {
@@ -2598,7 +2601,7 @@ const char *bvlc_result_code_name(uint16_t result_code)
  * @return length of the APDU buffer
  */
 int bvlc_foreign_device_bbmd_host_address_encode(
-    uint8_t *apdu, uint16_t apdu_size, BACNET_IP_ADDRESS *ip_address)
+    uint8_t *apdu, uint16_t apdu_size, const BACNET_IP_ADDRESS *ip_address)
 {
     BACNET_HOST_N_PORT address = { 0 };
     int apdu_len = 0;
@@ -2623,7 +2626,7 @@ int bvlc_foreign_device_bbmd_host_address_encode(
  * @param ip_address - IP address and port number
  * @return length of the APDU buffer decoded, or ERROR, REJECT, or ABORT
  */
-int bvlc_foreign_device_bbmd_host_address_decode(uint8_t *apdu,
+int bvlc_foreign_device_bbmd_host_address_decode(const uint8_t *apdu,
     uint16_t apdu_len,
     BACNET_ERROR_CODE *error_code,
     BACNET_IP_ADDRESS *ip_address)

--- a/src/bacnet/datalink/bvlc.h
+++ b/src/bacnet/datalink/bvlc.h
@@ -155,7 +155,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     int bvlc_decode_address(
-        uint8_t *pdu, uint16_t pdu_len, BACNET_IP_ADDRESS *ip_address);
+        const uint8_t *pdu, uint16_t pdu_len, BACNET_IP_ADDRESS *ip_address);
 
     BACNET_STACK_EXPORT
     bool bvlc_address_copy(BACNET_IP_ADDRESS *dst, const BACNET_IP_ADDRESS *src);
@@ -182,7 +182,7 @@ extern "C" {
         uint8_t addr3);
 
     BACNET_STACK_EXPORT
-    bool bvlc_address_get(BACNET_IP_ADDRESS *addr,
+    bool bvlc_address_get(const BACNET_IP_ADDRESS *addr,
         uint8_t *addr0,
         uint8_t *addr1,
         uint8_t *addr2,
@@ -190,37 +190,37 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     bool bvlc_ip_address_to_bacnet_local(
-        BACNET_ADDRESS *addr, BACNET_IP_ADDRESS *ipaddr);
+        BACNET_ADDRESS *addr, const BACNET_IP_ADDRESS *ipaddr);
 
     BACNET_STACK_EXPORT
     bool bvlc_ip_address_from_bacnet_local(
-        BACNET_IP_ADDRESS *ipaddr, BACNET_ADDRESS *addr);
+        BACNET_IP_ADDRESS *ipaddr, const BACNET_ADDRESS *addr);
 
     BACNET_STACK_EXPORT
     bool bvlc_ip_address_to_bacnet_remote(
-        BACNET_ADDRESS *addr, uint16_t dnet, BACNET_IP_ADDRESS *ipaddr);
+        BACNET_ADDRESS *addr, uint16_t dnet, const BACNET_IP_ADDRESS *ipaddr);
 
     BACNET_STACK_EXPORT
     bool bvlc_ip_address_from_bacnet_remote(
-        BACNET_IP_ADDRESS *ipaddr, uint16_t *dnet, BACNET_ADDRESS *addr);
+        BACNET_IP_ADDRESS *ipaddr, uint16_t *dnet, const BACNET_ADDRESS *addr);
 
     BACNET_STACK_EXPORT
     int bvlc_encode_broadcast_distribution_mask(uint8_t *pdu,
         uint16_t pdu_size,
-        BACNET_IP_BROADCAST_DISTRIBUTION_MASK *bd_mask);
+        const BACNET_IP_BROADCAST_DISTRIBUTION_MASK *bd_mask);
 
     BACNET_STACK_EXPORT
-    int bvlc_decode_broadcast_distribution_mask(uint8_t *pdu,
+    int bvlc_decode_broadcast_distribution_mask(const uint8_t *pdu,
         uint16_t pdu_len,
         BACNET_IP_BROADCAST_DISTRIBUTION_MASK *bd_mask);
 
     BACNET_STACK_EXPORT
     int bvlc_encode_broadcast_distribution_table_entry(uint8_t *pdu,
         uint16_t pdu_size,
-        BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry);
+        const BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry);
 
     BACNET_STACK_EXPORT
-    int bvlc_decode_broadcast_distribution_table_entry(uint8_t *pdu,
+    int bvlc_decode_broadcast_distribution_table_entry(const uint8_t *pdu,
         uint16_t pdu_len,
         BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry);
 
@@ -243,39 +243,39 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     bool bvlc_broadcast_distribution_table_entry_different(
-        BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *dst,
-        BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *src);
+        const BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *dst,
+        const BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *src);
 
     BACNET_STACK_EXPORT
     bool bvlc_broadcast_distribution_table_entry_copy(
         BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *dst,
-        BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *src);
+        const BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *src);
 
     BACNET_STACK_EXPORT
     bool bvlc_broadcast_distribution_mask_different(
-        BACNET_IP_BROADCAST_DISTRIBUTION_MASK *dst,
-        BACNET_IP_BROADCAST_DISTRIBUTION_MASK *src);
+        const BACNET_IP_BROADCAST_DISTRIBUTION_MASK *dst,
+        const BACNET_IP_BROADCAST_DISTRIBUTION_MASK *src);
 
     BACNET_STACK_EXPORT
     bool bvlc_broadcast_distribution_mask_copy(
         BACNET_IP_BROADCAST_DISTRIBUTION_MASK *dst,
-        BACNET_IP_BROADCAST_DISTRIBUTION_MASK *src);
+        const BACNET_IP_BROADCAST_DISTRIBUTION_MASK *src);
 
     BACNET_STACK_EXPORT
     bool bvlc_broadcast_distribution_table_entry_append(
         BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_list,
-        BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry);
+        const BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry);
 
     BACNET_STACK_EXPORT
     bool bvlc_broadcast_distribution_table_entry_set(
         BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry,
-        BACNET_IP_ADDRESS *addr,
-        BACNET_IP_BROADCAST_DISTRIBUTION_MASK *mask);
+        const BACNET_IP_ADDRESS *addr,
+        const BACNET_IP_BROADCAST_DISTRIBUTION_MASK *mask);
 
     BACNET_STACK_EXPORT
     bool bvlc_broadcast_distribution_table_entry_forward_address(
         BACNET_IP_ADDRESS *addr,
-        BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry);
+        const BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry);
 
     BACNET_STACK_EXPORT
     bool bvlc_address_mask(
@@ -288,7 +288,8 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     bool bvlc_broadcast_distribution_mask_to_host(
-        uint32_t *broadcast_mask, BACNET_IP_BROADCAST_DISTRIBUTION_MASK *mask);
+        uint32_t *broadcast_mask,
+        const BACNET_IP_BROADCAST_DISTRIBUTION_MASK *mask);
 
     BACNET_STACK_EXPORT
     void bvlc_broadcast_distribution_mask_set(
@@ -300,14 +301,14 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     void bvlc_broadcast_distribution_mask_get(
-        BACNET_IP_BROADCAST_DISTRIBUTION_MASK *mask,
+        const BACNET_IP_BROADCAST_DISTRIBUTION_MASK *mask,
         uint8_t *addr0,
         uint8_t *addr1,
         uint8_t *addr2,
         uint8_t *addr3);
 
     BACNET_STACK_EXPORT
-    int bvlc_broadcast_distribution_table_decode(uint8_t *apdu,
+    int bvlc_broadcast_distribution_table_decode(const uint8_t *apdu,
         uint16_t apdu_len,
         BACNET_ERROR_CODE *error_code,
         BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_head);
@@ -323,7 +324,7 @@ extern "C" {
         BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_list);
 
     BACNET_STACK_EXPORT
-    int bvlc_decode_write_broadcast_distribution_table(uint8_t *pdu,
+    int bvlc_decode_write_broadcast_distribution_table(const uint8_t *pdu,
         uint16_t pdu_len,
         BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_list);
 
@@ -337,7 +338,7 @@ extern "C" {
         BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_list);
 
     BACNET_STACK_EXPORT
-    int bvlc_decode_read_broadcast_distribution_table_ack(uint8_t *pdu,
+    int bvlc_decode_read_broadcast_distribution_table_ack(const uint8_t *pdu,
         uint16_t pdu_len,
         BACNET_IP_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_list);
 
@@ -347,7 +348,10 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     int bvlc_decode_header(
-        uint8_t *pdu, uint16_t pdu_len, uint8_t *message_type, uint16_t *length);
+        const uint8_t *pdu,
+        uint16_t pdu_len,
+        uint8_t *message_type,
+        uint16_t *length);
 
 
     BACNET_STACK_EXPORT
@@ -368,32 +372,32 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     bool bvlc_foreign_device_table_entry_different(
-        BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *dst,
-        BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *src);
+        const BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *dst,
+        const BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *src);
 
     BACNET_STACK_EXPORT
     bool bvlc_foreign_device_table_entry_copy(
         BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *dst,
-        BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *src);
+        const BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *src);
 
     BACNET_STACK_EXPORT
     bool bvlc_foreign_device_table_entry_delete(
         BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *fdt_list,
-        BACNET_IP_ADDRESS *ip_address);
+        const BACNET_IP_ADDRESS *ip_address);
 
     BACNET_STACK_EXPORT
     bool bvlc_foreign_device_table_entry_add(
         BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *fdt_list,
-        BACNET_IP_ADDRESS *ip_address,
+        const BACNET_IP_ADDRESS *ip_address,
         uint16_t ttl_seconds);
 
     BACNET_STACK_EXPORT
     int bvlc_encode_foreign_device_table_entry(uint8_t *pdu,
         uint16_t pdu_size,
-        BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *fdt_entry);
+        const BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *fdt_entry);
 
     BACNET_STACK_EXPORT
-    int bvlc_decode_foreign_device_table_entry(uint8_t *pdu,
+    int bvlc_decode_foreign_device_table_entry(const uint8_t *pdu,
         uint16_t pdu_len,
         BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *fdt_entry);
 
@@ -411,7 +415,7 @@ extern "C" {
         BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *fdt_list);
 
     BACNET_STACK_EXPORT
-    int bvlc_decode_read_foreign_device_table_ack(uint8_t *pdu,
+    int bvlc_decode_read_foreign_device_table_ack(const uint8_t *pdu,
         uint16_t pdu_len,
         BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *fdt_list);
 
@@ -419,14 +423,15 @@ extern "C" {
     int bvlc_encode_result(uint8_t *pdu, uint16_t pdu_size, uint16_t result_code);
 
     BACNET_STACK_EXPORT
-    int bvlc_decode_result(uint8_t *pdu, uint16_t pdu_len, uint16_t *result_code);
+    int bvlc_decode_result(
+        const uint8_t *pdu, uint16_t pdu_len, uint16_t *result_code);
 
     BACNET_STACK_EXPORT
     int bvlc_encode_original_unicast(
-        uint8_t *pdu, uint16_t pdu_size, uint8_t *npdu, uint16_t npdu_len);
+        uint8_t *pdu, uint16_t pdu_size, const uint8_t *npdu, uint16_t npdu_len);
 
     BACNET_STACK_EXPORT
-    int bvlc_decode_original_unicast(uint8_t *pdu,
+    int bvlc_decode_original_unicast(const uint8_t *pdu,
         uint16_t pdu_len,
         uint8_t *npdu,
         uint16_t npdu_size,
@@ -434,10 +439,10 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     int bvlc_encode_original_broadcast(
-        uint8_t *pdu, uint16_t pdu_size, uint8_t *npdu, uint16_t npdu_len);
+        uint8_t *pdu, uint16_t pdu_size, const uint8_t *npdu, uint16_t npdu_len);
 
     BACNET_STACK_EXPORT
-    int bvlc_decode_original_broadcast(uint8_t *pdu,
+    int bvlc_decode_original_broadcast(const uint8_t *pdu,
         uint16_t pdu_len,
         uint8_t *npdu,
         uint16_t npdu_size,
@@ -446,12 +451,12 @@ extern "C" {
     BACNET_STACK_EXPORT
     int bvlc_encode_forwarded_npdu(uint8_t *pdu,
         uint16_t pdu_size,
-        BACNET_IP_ADDRESS *address,
-        uint8_t *npdu,
+        const BACNET_IP_ADDRESS *address,
+        const uint8_t *npdu,
         uint16_t npdu_len);
 
     BACNET_STACK_EXPORT
-    int bvlc_decode_forwarded_npdu(uint8_t *pdu,
+    int bvlc_decode_forwarded_npdu(const uint8_t *pdu,
         uint16_t pdu_len,
         BACNET_IP_ADDRESS *address,
         uint8_t *npdu,
@@ -464,22 +469,22 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     int bvlc_decode_register_foreign_device(
-        uint8_t *pdu, uint16_t pdu_len, uint16_t *ttl_seconds);
+        const uint8_t *pdu, uint16_t pdu_len, uint16_t *ttl_seconds);
 
     BACNET_STACK_EXPORT
     int bvlc_encode_delete_foreign_device(
-        uint8_t *pdu, uint16_t pdu_size, BACNET_IP_ADDRESS *ip_address);
+        uint8_t *pdu, uint16_t pdu_size, const BACNET_IP_ADDRESS *ip_address);
 
     BACNET_STACK_EXPORT
     int bvlc_decode_delete_foreign_device(
-        uint8_t *pdu, uint16_t pdu_len, BACNET_IP_ADDRESS *ip_address);
+        const uint8_t *pdu, uint16_t pdu_len, BACNET_IP_ADDRESS *ip_address);
 
     BACNET_STACK_EXPORT
     int bvlc_encode_secure_bvll(
-        uint8_t *pdu, uint16_t pdu_size, uint8_t *sbuf, uint16_t sbuf_len);
+        uint8_t *pdu, uint16_t pdu_size, const uint8_t *sbuf, uint16_t sbuf_len);
 
     BACNET_STACK_EXPORT
-    int bvlc_decode_secure_bvll(uint8_t *pdu,
+    int bvlc_decode_secure_bvll(const uint8_t *pdu,
         uint16_t pdu_len,
         uint8_t *sbuf,
         uint16_t sbuf_size,
@@ -487,10 +492,10 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     int bvlc_encode_distribute_broadcast_to_network(
-        uint8_t *pdu, uint16_t pdu_size, uint8_t *npdu, uint16_t npdu_len);
+        uint8_t *pdu, uint16_t pdu_size, const uint8_t *npdu, uint16_t npdu_len);
 
     BACNET_STACK_EXPORT
-    int bvlc_decode_distribute_broadcast_to_network(uint8_t *pdu,
+    int bvlc_decode_distribute_broadcast_to_network(const uint8_t *pdu,
         uint16_t pdu_len,
         uint8_t *npdu,
         uint16_t npdu_size,
@@ -502,10 +507,10 @@ extern "C" {
     BACNET_STACK_EXPORT
     int bvlc_foreign_device_bbmd_host_address_encode(uint8_t *apdu,
         uint16_t apdu_size,
-        BACNET_IP_ADDRESS *ip_address);
+        const BACNET_IP_ADDRESS *ip_address);
 
     BACNET_STACK_EXPORT
-    int bvlc_foreign_device_bbmd_host_address_decode(uint8_t *apdu,
+    int bvlc_foreign_device_bbmd_host_address_decode(const uint8_t *apdu,
         uint16_t apdu_len,
         BACNET_ERROR_CODE *error_code,
         BACNET_IP_ADDRESS *ip_address);

--- a/src/bacnet/datalink/bvlc6.c
+++ b/src/bacnet/datalink/bvlc6.c
@@ -53,7 +53,10 @@ int bvlc6_encode_header(
  * @return number of bytes decoded
  */
 int bvlc6_decode_header(
-    uint8_t *pdu, uint16_t pdu_len, uint8_t *message_type, uint16_t *length)
+    const uint8_t *pdu,
+    uint16_t pdu_len,
+    uint8_t *message_type,
+    uint16_t *length)
 {
     int bytes_consumed = 0;
 
@@ -124,7 +127,10 @@ int bvlc6_encode_result(
  * @return number of bytes decoded
  */
 int bvlc6_decode_result(
-    uint8_t *pdu, uint16_t pdu_len, uint32_t *vmac, uint16_t *result_code)
+    const uint8_t *pdu,
+    uint16_t pdu_len,
+    uint32_t *vmac,
+    uint16_t *result_code)
 {
     int bytes_consumed = 0;
 
@@ -166,7 +172,7 @@ int bvlc6_encode_original_unicast(uint8_t *pdu,
     uint16_t pdu_size,
     uint32_t vmac_src,
     uint32_t vmac_dst,
-    uint8_t *npdu,
+    const uint8_t *npdu,
     uint16_t npdu_len)
 {
     int bytes_encoded = 0;
@@ -205,7 +211,7 @@ int bvlc6_encode_original_unicast(uint8_t *pdu,
  *
  * @return number of bytes decoded
  */
-int bvlc6_decode_original_unicast(uint8_t *pdu,
+int bvlc6_decode_original_unicast(const uint8_t *pdu,
     uint16_t pdu_len,
     uint32_t *vmac_src,
     uint32_t *vmac_dst,
@@ -261,7 +267,7 @@ int bvlc6_decode_original_unicast(uint8_t *pdu,
 int bvlc6_encode_original_broadcast(uint8_t *pdu,
     uint16_t pdu_size,
     uint32_t vmac,
-    uint8_t *npdu,
+    const uint8_t *npdu,
     uint16_t npdu_len)
 {
     int bytes_encoded = 0;
@@ -297,7 +303,7 @@ int bvlc6_encode_original_broadcast(uint8_t *pdu,
  *
  * @return number of bytes decoded
  */
-int bvlc6_decode_original_broadcast(uint8_t *pdu,
+int bvlc6_decode_original_broadcast(const uint8_t *pdu,
     uint16_t pdu_len,
     uint32_t *vmac,
     uint8_t *npdu,
@@ -376,7 +382,7 @@ int bvlc6_encode_address_resolution(
  * @return number of bytes decoded
  */
 int bvlc6_decode_address_resolution(
-    uint8_t *pdu, uint16_t pdu_len, uint32_t *vmac_src, uint32_t *vmac_target)
+    const uint8_t *pdu, uint16_t pdu_len, uint32_t *vmac_src, uint32_t *vmac_target)
 {
     int bytes_consumed = 0;
 
@@ -407,7 +413,7 @@ int bvlc6_decode_address_resolution(
  * @return number of bytes encoded
  */
 int bvlc6_encode_address(
-    uint8_t *pdu, uint16_t pdu_size, BACNET_IP6_ADDRESS *bip6_address)
+    uint8_t *pdu, uint16_t pdu_size, const BACNET_IP6_ADDRESS *bip6_address)
 {
     int bytes_encoded = 0;
     uint16_t length = BIP6_ADDRESS_MAX;
@@ -433,7 +439,7 @@ int bvlc6_encode_address(
  * @return number of bytes decoded
  */
 int bvlc6_decode_address(
-    uint8_t *pdu, uint16_t pdu_len, BACNET_IP6_ADDRESS *bip6_address)
+    const uint8_t *pdu, uint16_t pdu_len, BACNET_IP6_ADDRESS *bip6_address)
 {
     int bytes_consumed = 0;
     uint16_t length = BIP6_ADDRESS_MAX;
@@ -462,7 +468,7 @@ int bvlc6_decode_address(
  *
  * @return true if the address was copied
  */
-bool bvlc6_address_copy(BACNET_IP6_ADDRESS *dst, BACNET_IP6_ADDRESS *src)
+bool bvlc6_address_copy(BACNET_IP6_ADDRESS *dst, const BACNET_IP6_ADDRESS *src)
 {
     bool status = false;
     unsigned int i = 0;
@@ -490,7 +496,8 @@ bool bvlc6_address_copy(BACNET_IP6_ADDRESS *dst, BACNET_IP6_ADDRESS *src)
  *
  * @return true if the addresses are different
  */
-bool bvlc6_address_different(BACNET_IP6_ADDRESS *dst, BACNET_IP6_ADDRESS *src)
+bool bvlc6_address_different(
+    const BACNET_IP6_ADDRESS *dst, const BACNET_IP6_ADDRESS *src)
 {
     bool status = false;
     unsigned int i = 0;
@@ -574,7 +581,7 @@ bool bvlc6_address_set(BACNET_IP6_ADDRESS *addr,
  *
  * @return true if the address is set
  */
-bool bvlc6_address_get(BACNET_IP6_ADDRESS *addr,
+bool bvlc6_address_get(const BACNET_IP6_ADDRESS *addr,
     uint16_t *addr0,
     uint16_t *addr1,
     uint16_t *addr2,
@@ -672,7 +679,7 @@ static int snprintf_shift(int len, char **buf, size_t *buf_size)
  *  input, excluding the trailing null.
  * @note buf and buf_size may be null and zero to return only the size
  */
-int bvlc6_address_to_ascii(BACNET_IP6_ADDRESS *addr, char *buf, size_t buf_size)
+int bvlc6_address_to_ascii(const BACNET_IP6_ADDRESS *addr, char *buf, size_t buf_size)
 {
     uint16_t a;
     unsigned int i;
@@ -836,7 +843,7 @@ bool bvlc6_vmac_address_set(BACNET_ADDRESS *addr, uint32_t device_id)
  *
  * @return true if the address is set
  */
-bool bvlc6_vmac_address_get(BACNET_ADDRESS *addr, uint32_t *device_id)
+bool bvlc6_vmac_address_get(const BACNET_ADDRESS *addr, uint32_t *device_id)
 {
     bool status = false;
 
@@ -875,7 +882,7 @@ int bvlc6_encode_forwarded_address_resolution(uint8_t *pdu,
     uint16_t pdu_size,
     uint32_t vmac_src,
     uint32_t vmac_target,
-    BACNET_IP6_ADDRESS *bip6_address)
+    const BACNET_IP6_ADDRESS *bip6_address)
 {
     int bytes_encoded = 0;
     uint16_t length = 0x001C;
@@ -909,7 +916,7 @@ int bvlc6_encode_forwarded_address_resolution(uint8_t *pdu,
  *
  * @return number of bytes decoded
  */
-int bvlc6_decode_forwarded_address_resolution(uint8_t *pdu,
+int bvlc6_decode_forwarded_address_resolution(const uint8_t *pdu,
     uint16_t pdu_len,
     uint32_t *vmac_src,
     uint32_t *vmac_target,
@@ -1007,7 +1014,10 @@ int bvlc6_encode_address_resolution_ack(
  * @return number of bytes decoded
  */
 int bvlc6_decode_address_resolution_ack(
-    uint8_t *pdu, uint16_t pdu_len, uint32_t *vmac_src, uint32_t *vmac_dst)
+    const uint8_t *pdu,
+    uint16_t pdu_len,
+    uint32_t *vmac_src,
+    uint32_t *vmac_dst)
 {
     int bytes_consumed = 0;
     const uint16_t length = 6;
@@ -1070,7 +1080,7 @@ int bvlc6_encode_virtual_address_resolution(
  * @return number of bytes decoded
  */
 int bvlc6_decode_virtual_address_resolution(
-    uint8_t *pdu, uint16_t pdu_len, uint32_t *vmac_src)
+    const uint8_t *pdu, uint16_t pdu_len, uint32_t *vmac_src)
 {
     int bytes_consumed = 0;
 
@@ -1118,7 +1128,7 @@ int bvlc6_encode_virtual_address_resolution_ack(
  * @return number of bytes decoded
  */
 int bvlc6_decode_virtual_address_resolution_ack(
-    uint8_t *pdu, uint16_t pdu_len, uint32_t *vmac_src, uint32_t *vmac_dst)
+    const uint8_t *pdu, uint16_t pdu_len, uint32_t *vmac_src, uint32_t *vmac_dst)
 {
     return bvlc6_decode_address_resolution_ack(
         pdu, pdu_len, vmac_src, vmac_dst);
@@ -1150,8 +1160,8 @@ int bvlc6_decode_virtual_address_resolution_ack(
 int bvlc6_encode_forwarded_npdu(uint8_t *pdu,
     uint16_t pdu_size,
     uint32_t vmac_src,
-    BACNET_IP6_ADDRESS *bip6_address,
-    uint8_t *npdu,
+    const BACNET_IP6_ADDRESS *bip6_address,
+    const uint8_t *npdu,
     uint16_t npdu_len)
 {
     int bytes_encoded = 0;
@@ -1193,7 +1203,7 @@ int bvlc6_encode_forwarded_npdu(uint8_t *pdu,
  *
  * @return number of bytes decoded
  */
-int bvlc6_decode_forwarded_npdu(uint8_t *pdu,
+int bvlc6_decode_forwarded_npdu(const uint8_t *pdu,
     uint16_t pdu_len,
     uint32_t *vmac_src,
     BACNET_IP6_ADDRESS *bip6_address,
@@ -1282,7 +1292,7 @@ int bvlc6_encode_register_foreign_device(
  * @return number of bytes decoded
  */
 int bvlc6_decode_register_foreign_device(
-    uint8_t *pdu, uint16_t pdu_len, uint32_t *vmac_src, uint16_t *ttl_seconds)
+    const uint8_t *pdu, uint16_t pdu_len, uint32_t *vmac_src, uint16_t *ttl_seconds)
 {
     int bytes_consumed = 0;
     const uint16_t length = 5;
@@ -1325,7 +1335,7 @@ int bvlc6_decode_register_foreign_device(
 int bvlc6_encode_delete_foreign_device(uint8_t *pdu,
     uint16_t pdu_size,
     uint32_t vmac_src,
-    BACNET_IP6_ADDRESS *bip6_address)
+    const BACNET_IP6_ADDRESS *bip6_address)
 {
     int bytes_encoded = 0;
     const uint16_t length = 0x0019;
@@ -1359,7 +1369,7 @@ int bvlc6_encode_delete_foreign_device(uint8_t *pdu,
  *
  * @return number of bytes decoded
  */
-int bvlc6_decode_delete_foreign_device(uint8_t *pdu,
+int bvlc6_decode_delete_foreign_device(const uint8_t *pdu,
     uint16_t pdu_len,
     uint32_t *vmac_src,
     BACNET_IP6_ADDRESS *bip6_address)
@@ -1402,7 +1412,7 @@ int bvlc6_decode_delete_foreign_device(uint8_t *pdu,
  * Security Wrapper:            Variable length
  */
 int bvlc6_encode_secure_bvll(
-    uint8_t *pdu, uint16_t pdu_size, uint8_t *sbuf, uint16_t sbuf_len)
+    uint8_t *pdu, uint16_t pdu_size, const uint8_t *sbuf, uint16_t sbuf_len)
 {
     int bytes_encoded = 0;
     uint16_t length = 4;
@@ -1435,7 +1445,7 @@ int bvlc6_encode_secure_bvll(
  *
  * @return number of bytes decoded
  */
-int bvlc6_decode_secure_bvll(uint8_t *pdu,
+int bvlc6_decode_secure_bvll(const uint8_t *pdu,
     uint16_t pdu_len,
     uint8_t *sbuf,
     uint16_t sbuf_size,
@@ -1486,7 +1496,7 @@ int bvlc6_decode_secure_bvll(uint8_t *pdu,
 int bvlc6_encode_distribute_broadcast_to_network(uint8_t *pdu,
     uint16_t pdu_size,
     uint32_t vmac,
-    uint8_t *npdu,
+    const uint8_t *npdu,
     uint16_t npdu_len)
 {
     int bytes_encoded = 0;
@@ -1522,7 +1532,7 @@ int bvlc6_encode_distribute_broadcast_to_network(uint8_t *pdu,
  *
  * @return number of bytes decoded
  */
-int bvlc6_decode_distribute_broadcast_to_network(uint8_t *pdu,
+int bvlc6_decode_distribute_broadcast_to_network(const uint8_t *pdu,
     uint16_t pdu_len,
     uint32_t *vmac,
     uint8_t *npdu,
@@ -1560,7 +1570,7 @@ int bvlc6_decode_distribute_broadcast_to_network(uint8_t *pdu,
  * @return length of the APDU buffer
  */
 int bvlc6_foreign_device_bbmd_host_address_encode(
-    uint8_t *apdu, uint16_t apdu_size, BACNET_IP6_ADDRESS *ip6_address)
+    uint8_t *apdu, uint16_t apdu_size, const BACNET_IP6_ADDRESS *ip6_address)
 {
     BACNET_HOST_N_PORT address = { 0 };
     int apdu_len = 0;
@@ -1598,7 +1608,7 @@ int bvlc6_foreign_device_bbmd_host_address_encode(
  * @return length of the APDU buffer
  */
 int bvlc6_broadcast_distribution_table_entry_encode(uint8_t *apdu,
-    BACNET_IP6_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry)
+    const BACNET_IP6_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry)
 {
     int len = 0;
     int apdu_len = 0;
@@ -1722,7 +1732,7 @@ int bvlc6_broadcast_distribution_table_encode(uint8_t *apdu,
  * @return length of the APDU buffer
  */
 int bvlc6_foreign_device_table_entry_encode(uint8_t *apdu,
-    BACNET_IP6_FOREIGN_DEVICE_TABLE_ENTRY *fdt_entry)
+    const BACNET_IP6_FOREIGN_DEVICE_TABLE_ENTRY *fdt_entry)
 {
     int len = 0;
     int apdu_len = 0;

--- a/src/bacnet/datalink/bvlc6.h
+++ b/src/bacnet/datalink/bvlc6.h
@@ -167,23 +167,23 @@ extern "C" {
     int bvlc6_encode_address(
         uint8_t * pdu,
         uint16_t pdu_size,
-        BACNET_IP6_ADDRESS * ip6_address);
+        const BACNET_IP6_ADDRESS * ip6_address);
     BACNET_STACK_EXPORT
     int bvlc6_decode_address(
-        uint8_t * pdu,
+        const uint8_t * pdu,
         uint16_t pdu_len,
         BACNET_IP6_ADDRESS * ip6_address);
     BACNET_STACK_EXPORT
     bool bvlc6_address_copy(
         BACNET_IP6_ADDRESS * dst,
-        BACNET_IP6_ADDRESS * src);
+        const BACNET_IP6_ADDRESS * src);
     BACNET_STACK_EXPORT
     bool bvlc6_address_different(
-        BACNET_IP6_ADDRESS * dst,
-        BACNET_IP6_ADDRESS * src);
+        const BACNET_IP6_ADDRESS * dst,
+        const BACNET_IP6_ADDRESS * src);
 
     BACNET_STACK_EXPORT
-    int bvlc6_address_to_ascii(BACNET_IP6_ADDRESS *addr, char *buf,
+    int bvlc6_address_to_ascii(const BACNET_IP6_ADDRESS *addr, char *buf,
         size_t buf_size);
     BACNET_STACK_EXPORT
     bool bvlc6_address_from_ascii(
@@ -203,7 +203,7 @@ extern "C" {
         uint16_t addr7);
     BACNET_STACK_EXPORT
     bool bvlc6_address_get(
-        BACNET_IP6_ADDRESS * addr,
+        const BACNET_IP6_ADDRESS * addr,
         uint16_t *addr0,
         uint16_t *addr1,
         uint16_t *addr2,
@@ -219,7 +219,7 @@ extern "C" {
         uint32_t device_id);
     BACNET_STACK_EXPORT
     bool bvlc6_vmac_address_get(
-        BACNET_ADDRESS * addr,
+        const BACNET_ADDRESS * addr,
         uint32_t *device_id);
 
     BACNET_STACK_EXPORT
@@ -230,7 +230,7 @@ extern "C" {
        uint16_t length);
     BACNET_STACK_EXPORT
    int bvlc6_decode_header(
-       uint8_t * pdu,
+       const uint8_t * pdu,
        uint16_t pdu_len,
        uint8_t * message_type,
        uint16_t * length);
@@ -243,7 +243,7 @@ extern "C" {
         uint16_t result_code);
     BACNET_STACK_EXPORT
     int bvlc6_decode_result(
-        uint8_t * pdu,
+        const uint8_t * pdu,
         uint16_t pdu_len,
         uint32_t * vmac,
         uint16_t * result_code);
@@ -254,11 +254,11 @@ extern "C" {
        uint16_t pdu_size,
        uint32_t vmac_src,
        uint32_t vmac_dst,
-       uint8_t * npdu,
+       const uint8_t * npdu,
        uint16_t npdu_len);
     BACNET_STACK_EXPORT
     int bvlc6_decode_original_unicast(
-        uint8_t * pdu,
+        const uint8_t * pdu,
         uint16_t pdu_len,
         uint32_t * vmac_src,
         uint32_t * vmac_dst,
@@ -271,11 +271,11 @@ extern "C" {
         uint8_t * pdu,
         uint16_t pdu_size,
         uint32_t vmac,
-        uint8_t * npdu,
+        const uint8_t * npdu,
         uint16_t npdu_len);
     BACNET_STACK_EXPORT
     int bvlc6_decode_original_broadcast(
-        uint8_t * pdu,
+        const uint8_t * pdu,
         uint16_t pdu_len,
         uint32_t * vmac,
         uint8_t * npdu,
@@ -290,7 +290,7 @@ extern "C" {
         uint32_t vmac_target);
     BACNET_STACK_EXPORT
     int bvlc6_decode_address_resolution(
-        uint8_t * pdu,
+        const uint8_t * pdu,
         uint16_t pdu_len,
         uint32_t * vmac_src,
         uint32_t * vmac_target);
@@ -301,10 +301,10 @@ extern "C" {
         uint16_t pdu_size,
         uint32_t vmac_src,
         uint32_t vmac_target,
-        BACNET_IP6_ADDRESS * bip6_address);
+        const BACNET_IP6_ADDRESS * bip6_address);
     BACNET_STACK_EXPORT
     int bvlc6_decode_forwarded_address_resolution(
-        uint8_t * pdu,
+        const uint8_t * pdu,
         uint16_t pdu_len,
         uint32_t * vmac_src,
         uint32_t * vmac_target,
@@ -318,7 +318,7 @@ extern "C" {
         uint32_t vmac_dst);
     BACNET_STACK_EXPORT
     int bvlc6_decode_address_resolution_ack(
-        uint8_t * pdu,
+        const uint8_t * pdu,
         uint16_t pdu_len,
         uint32_t * vmac_src,
         uint32_t * vmac_dst);
@@ -330,7 +330,7 @@ extern "C" {
         uint32_t vmac_src);
     BACNET_STACK_EXPORT
     int bvlc6_decode_virtual_address_resolution(
-        uint8_t * pdu,
+        const uint8_t * pdu,
         uint16_t pdu_len,
         uint32_t * vmac_src);
 
@@ -342,7 +342,7 @@ extern "C" {
         uint32_t vmac_dst);
     BACNET_STACK_EXPORT
     int bvlc6_decode_virtual_address_resolution_ack(
-        uint8_t * pdu,
+        const uint8_t * pdu,
         uint16_t pdu_len,
         uint32_t * vmac_src,
         uint32_t * vmac_dst);
@@ -352,12 +352,12 @@ extern "C" {
         uint8_t * pdu,
         uint16_t pdu_size,
         uint32_t vmac_src,
-        BACNET_IP6_ADDRESS * address,
-        uint8_t * npdu,
+        const BACNET_IP6_ADDRESS * address,
+        const uint8_t * npdu,
         uint16_t npdu_len);
     BACNET_STACK_EXPORT
     int bvlc6_decode_forwarded_npdu(
-        uint8_t * pdu,
+        const uint8_t * pdu,
         uint16_t pdu_len,
         uint32_t * vmac_src,
         BACNET_IP6_ADDRESS * address,
@@ -373,7 +373,7 @@ extern "C" {
         uint16_t ttl_seconds);
     BACNET_STACK_EXPORT
     int bvlc6_decode_register_foreign_device(
-        uint8_t * pdu,
+        const uint8_t * pdu,
         uint16_t pdu_len,
         uint32_t * vmac_src,
         uint16_t * ttl_seconds);
@@ -383,11 +383,11 @@ extern "C" {
         uint8_t * pdu,
         uint16_t pdu_size,
         uint32_t vmac_src,
-        BACNET_IP6_ADDRESS *bip6_address);
+        const BACNET_IP6_ADDRESS *bip6_address);
 
     BACNET_STACK_EXPORT
     int bvlc6_decode_delete_foreign_device(
-        uint8_t * pdu,
+        const uint8_t * pdu,
         uint16_t pdu_len,
         uint32_t * vmac_src,
         BACNET_IP6_ADDRESS *bip6_address);
@@ -396,11 +396,11 @@ extern "C" {
     int bvlc6_encode_secure_bvll(
         uint8_t * pdu,
         uint16_t pdu_size,
-        uint8_t * sbuf,
+        const uint8_t * sbuf,
         uint16_t sbuf_len);
     BACNET_STACK_EXPORT
     int bvlc6_decode_secure_bvll(
-        uint8_t * pdu,
+        const uint8_t * pdu,
         uint16_t pdu_len,
         uint8_t * sbuf,
         uint16_t sbuf_size,
@@ -411,11 +411,11 @@ extern "C" {
         uint8_t * pdu,
         uint16_t pdu_size,
         uint32_t vmac,
-        uint8_t * npdu,
+        const uint8_t * npdu,
         uint16_t npdu_len);
     BACNET_STACK_EXPORT
     int bvlc6_decode_distribute_broadcast_to_network(
-        uint8_t * pdu,
+        const uint8_t * pdu,
         uint16_t pdu_len,
         uint32_t * vmac,
         uint8_t * npdu,
@@ -424,11 +424,11 @@ extern "C" {
     BACNET_STACK_EXPORT
     int bvlc6_foreign_device_bbmd_host_address_encode(uint8_t *apdu,
         uint16_t apdu_size,
-        BACNET_IP6_ADDRESS *ip6_address);
+        const BACNET_IP6_ADDRESS *ip6_address);
 
     BACNET_STACK_EXPORT
     int bvlc6_broadcast_distribution_table_entry_encode(uint8_t *apdu,
-        BACNET_IP6_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry);
+        const BACNET_IP6_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_entry);
     BACNET_STACK_EXPORT
     int bvlc6_broadcast_distribution_table_list_encode(uint8_t *apdu,
         BACNET_IP6_BROADCAST_DISTRIBUTION_TABLE_ENTRY *bdt_head);
@@ -439,7 +439,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     int bvlc6_foreign_device_table_entry_encode(uint8_t *apdu,
-        BACNET_IP6_FOREIGN_DEVICE_TABLE_ENTRY *fdt_entry);
+        const BACNET_IP6_FOREIGN_DEVICE_TABLE_ENTRY *fdt_entry);
     BACNET_STACK_EXPORT
     int bvlc6_foreign_device_table_list_encode(uint8_t *apdu,
         BACNET_IP6_FOREIGN_DEVICE_TABLE_ENTRY *fdt_head);

--- a/src/bacnet/datalink/cobs.c
+++ b/src/bacnet/datalink/cobs.c
@@ -295,7 +295,7 @@ size_t cobs_frame_decode(
      * Decode the Encoded CRC-32K field
      */
     crc_len = cobs_decode(crc_buffer, sizeof(crc_buffer),
-        (uint8_t *)(from + length - COBS_ENCODED_CRC_SIZE),
+        from + length - COBS_ENCODED_CRC_SIZE,
         COBS_ENCODED_CRC_SIZE, MSTP_PREAMBLE_X55);
     /*
      * Sanity check length of decoded CRC32K.

--- a/src/bacnet/datalink/dlenv.c
+++ b/src/bacnet/datalink/dlenv.c
@@ -77,7 +77,7 @@ void bip_dl_debug_disable(void)
  * @param address - IPv4 address (uint32_t) of BBMD to register with,
  *  in network byte order.
  */
-void dlenv_bbmd_address_set(BACNET_IP_ADDRESS *address)
+void dlenv_bbmd_address_set(const BACNET_IP_ADDRESS *address)
 {
     bvlc_address_copy(&BBMD_Address, address);
     BBMD_Address_Valid = true;

--- a/src/bacnet/datalink/dlenv.h
+++ b/src/bacnet/datalink/dlenv.h
@@ -46,7 +46,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     void dlenv_bbmd_address_set(
-        BACNET_IP_ADDRESS *address);
+        const BACNET_IP_ADDRESS *address);
 
     BACNET_STACK_EXPORT
     void dlenv_bbmd_ttl_set(

--- a/src/bacnet/datalink/dlmstp.c
+++ b/src/bacnet/datalink/dlmstp.c
@@ -124,9 +124,9 @@ uint16_t MSTP_Get_Send(
  */
 static bool MSTP_Compare_Data_Expecting_Reply(
     volatile struct mstp_port_struct_t *mstp_port,
-    uint8_t *reply_pdu,
+    const uint8_t *reply_pdu,
     uint16_t reply_pdu_len,
-    BACNET_ADDRESS *dest_address)
+    const BACNET_ADDRESS *dest_address)
 {
     uint16_t offset;
     /* One way to check the message is to compare NPDU
@@ -284,7 +284,7 @@ uint16_t MSTP_Get_Reply(
  * @param nbytes - number of bytes of data to send
  */
 void MSTP_Send_Frame(struct mstp_port_struct_t *mstp_port,
-    uint8_t *buffer,
+    const uint8_t *buffer,
     uint16_t nbytes)
 {
     struct dlmstp_user_data_t *user;

--- a/src/bacnet/datalink/dlmstp.h
+++ b/src/bacnet/datalink/dlmstp.h
@@ -61,7 +61,7 @@ struct dlmstp_rs485_driver {
     void (*init)(void);
 
     /** Prepare & transmit a packet. */
-    void (*send)(uint8_t *payload, uint16_t payload_len);
+    void (*send)(const uint8_t *payload, uint16_t payload_len);
 
     /** Check if one received byte is available */
     bool (*read)(uint8_t *buf);

--- a/src/bacnet/datalink/ethernet.h
+++ b/src/bacnet/datalink/ethernet.h
@@ -56,7 +56,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     void ethernet_set_my_address(
-        BACNET_ADDRESS * my_address);
+        const BACNET_ADDRESS * my_address);
     BACNET_STACK_EXPORT
     void ethernet_get_my_address(
         BACNET_ADDRESS * my_address);
@@ -68,7 +68,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     void ethernet_debug_address(
         const char *info,
-        BACNET_ADDRESS * dest);
+        const BACNET_ADDRESS * dest);
     BACNET_STACK_EXPORT
     int ethernet_send(
         uint8_t * mtu,

--- a/src/bacnet/datalink/mstp.c
+++ b/src/bacnet/datalink/mstp.c
@@ -98,7 +98,7 @@ static __inline__ void printf_master(const char *format, ...)
             x++;                     \
     }
 
-bool MSTP_Line_Active(struct mstp_port_struct_t *mstp_port)
+bool MSTP_Line_Active(const struct mstp_port_struct_t *mstp_port)
 {
     if (!mstp_port) {
         return false;
@@ -162,7 +162,7 @@ uint16_t MSTP_Create_Frame(uint8_t *buffer,
     uint8_t frame_type,
     uint8_t destination,
     uint8_t source,
-    uint8_t *data,
+    const uint8_t *data,
     uint16_t data_len)
 {
     uint8_t crc8 = 0xFF; /* used to calculate the crc value */
@@ -259,7 +259,7 @@ void MSTP_Create_And_Send_Frame(struct mstp_port_struct_t *mstp_port,
     uint8_t frame_type,
     uint8_t destination,
     uint8_t source,
-    uint8_t *data,
+    const uint8_t *data,
     uint16_t data_len)
 {
     uint16_t len = 0; /* number of bytes to send */
@@ -268,7 +268,7 @@ void MSTP_Create_And_Send_Frame(struct mstp_port_struct_t *mstp_port,
         MSTP_Create_Frame(mstp_port->OutputBuffer, mstp_port->OutputBufferSize,
             frame_type, destination, source, data, data_len);
 
-    MSTP_Send_Frame(mstp_port, (uint8_t *)&mstp_port->OutputBuffer[0], len);
+    MSTP_Send_Frame(mstp_port, &mstp_port->OutputBuffer[0], len);
     /* FIXME: be sure to reset SilenceTimer() after each octet is sent! */
 }
 
@@ -778,7 +778,7 @@ bool MSTP_Master_Node_FSM(struct mstp_port_struct_t *mstp_port)
                 uint8_t frame_type = mstp_port->OutputBuffer[2];
                 uint8_t destination = mstp_port->OutputBuffer[3];
                 MSTP_Send_Frame(mstp_port,
-                    (uint8_t *)&mstp_port->OutputBuffer[0], (uint16_t)length);
+                    &mstp_port->OutputBuffer[0], (uint16_t)length);
                 mstp_port->FrameCount++;
                 switch (frame_type) {
                     case FRAME_TYPE_BACNET_DATA_EXPECTING_REPLY:
@@ -1159,7 +1159,7 @@ bool MSTP_Master_Node_FSM(struct mstp_port_struct_t *mstp_port)
                  * frame  */
                 /* and enter the IDLE state to wait for the next frame. */
                 MSTP_Send_Frame(mstp_port,
-                    (uint8_t *)&mstp_port->OutputBuffer[0], (uint16_t)length);
+                    &mstp_port->OutputBuffer[0], (uint16_t)length);
                 mstp_port->master_state = MSTP_MASTER_STATE_IDLE;
                 /* clear our flag we were holding for comparison */
                 mstp_port->ReceivedValidFrame = false;
@@ -1255,8 +1255,7 @@ void MSTP_Slave_Node_FSM(struct mstp_port_struct_t *mstp_port)
             /* and enter the IDLE state to wait for the next frame.
                 */
             MSTP_Send_Frame(mstp_port,
-                (uint8_t *)&mstp_port->OutputBuffer[0],
-                (uint16_t)length);
+                &mstp_port->OutputBuffer[0], (uint16_t)length);
             /* clear our flag we were holding for comparison */
             mstp_port->ReceivedValidFrame = false;
         } else if (mstp_port->SilenceTimer((void *)mstp_port) >

--- a/src/bacnet/datalink/mstp.h
+++ b/src/bacnet/datalink/mstp.h
@@ -230,7 +230,7 @@ void MSTP_Slave_Node_FSM(struct mstp_port_struct_t *mstp_port);
 
 /* returns true if line is active */
 BACNET_STACK_EXPORT
-bool MSTP_Line_Active(struct mstp_port_struct_t *mstp_port);
+bool MSTP_Line_Active(const struct mstp_port_struct_t *mstp_port);
 
 BACNET_STACK_EXPORT
 uint16_t MSTP_Create_Frame(uint8_t *buffer,
@@ -238,7 +238,7 @@ uint16_t MSTP_Create_Frame(uint8_t *buffer,
     uint8_t frame_type,
     uint8_t destination,
     uint8_t source,
-    uint8_t *data,
+    const uint8_t *data,
     uint16_t data_len);
 
 BACNET_STACK_EXPORT
@@ -247,7 +247,7 @@ void MSTP_Create_And_Send_Frame(
     uint8_t frame_type,
     uint8_t destination,
     uint8_t source,
-    uint8_t *data,
+    const uint8_t *data,
     uint16_t data_len);
 
 BACNET_STACK_EXPORT
@@ -284,7 +284,7 @@ uint16_t MSTP_Get_Reply(struct mstp_port_struct_t *mstp_port,
 BACNET_STACK_EXPORT
 void MSTP_Send_Frame(
    struct mstp_port_struct_t *mstp_port,
-   uint8_t * buffer,
+   const uint8_t * buffer,
    uint16_t nbytes);
 
 #ifdef __cplusplus

--- a/src/bacnet/datetime.c
+++ b/src/bacnet/datetime.c
@@ -61,7 +61,7 @@ bool datetime_ymd_is_valid(uint16_t year, uint8_t month, uint8_t day)
  * @param bdate - BACnet date structure
  * @return true if the date is valid
  */
-bool datetime_date_is_valid(BACNET_DATE *bdate)
+bool datetime_date_is_valid(const BACNET_DATE *bdate)
 {
     bool status = false; /* true if value date */
 
@@ -118,7 +118,7 @@ void datetime_day_of_year_into_date(
  * @param bdate - BACnet date structure
  * @return number of days since Jan 1 (inclusive) of the given year
  */
-uint32_t datetime_day_of_year(BACNET_DATE *bdate)
+uint32_t datetime_day_of_year(const BACNET_DATE *bdate)
 {
     uint32_t days = 0;
 
@@ -164,7 +164,7 @@ uint32_t datetime_ymd_to_days_since_epoch(
  * @param bdate - BACnet date structure
  * @return number of days since epoch, or 0 if out of range
  */
-uint32_t datetime_days_since_epoch(BACNET_DATE *bdate)
+uint32_t datetime_days_since_epoch(const BACNET_DATE *bdate)
 {
     uint32_t days = 0;
 
@@ -261,7 +261,7 @@ uint8_t datetime_day_of_week(uint16_t year, uint8_t month, uint8_t day)
  * @param btime - pointer to a BACNET_TIME structure
  * @return true if the time is valid
  */
-bool datetime_time_is_valid(BACNET_TIME *btime)
+bool datetime_time_is_valid(const BACNET_TIME *btime)
 {
     bool status = false;
 
@@ -283,7 +283,7 @@ bool datetime_time_is_valid(BACNET_TIME *btime)
  *
  * @return true if the date and time are valid
  */
-bool datetime_is_valid(BACNET_DATE *bdate, BACNET_TIME *btime)
+bool datetime_is_valid(const BACNET_DATE *bdate, const BACNET_TIME *btime)
 {
     return datetime_date_is_valid(bdate) && datetime_time_is_valid(btime);
 }
@@ -298,7 +298,7 @@ bool datetime_is_valid(BACNET_DATE *bdate, BACNET_TIME *btime)
  *
  * @return -/0=same/+
  */
-int datetime_compare_date(BACNET_DATE *date1, BACNET_DATE *date2)
+int datetime_compare_date(const BACNET_DATE *date1, const BACNET_DATE *date2)
 {
     int diff = 0;
 
@@ -325,7 +325,7 @@ int datetime_compare_date(BACNET_DATE *date1, BACNET_DATE *date2)
  *
  * @return -/0/+
  */
-int datetime_compare_time(BACNET_TIME *time1, BACNET_TIME *time2)
+int datetime_compare_time(const BACNET_TIME *time1, const BACNET_TIME *time2)
 {
     int diff = 0;
 
@@ -355,7 +355,8 @@ int datetime_compare_time(BACNET_TIME *time1, BACNET_TIME *time2)
  *
  * @return -/0/+
  */
-int datetime_compare(BACNET_DATE_TIME *datetime1, BACNET_DATE_TIME *datetime2)
+int datetime_compare(
+    const BACNET_DATE_TIME *datetime1, const BACNET_DATE_TIME *datetime2)
 {
     int diff = 0;
 
@@ -367,7 +368,8 @@ int datetime_compare(BACNET_DATE_TIME *datetime1, BACNET_DATE_TIME *datetime2)
     return diff;
 }
 
-int datetime_wildcard_compare_date(BACNET_DATE *date1, BACNET_DATE *date2)
+int datetime_wildcard_compare_date(
+    const BACNET_DATE *date1, const BACNET_DATE *date2)
 {
     int diff = 0;
 
@@ -391,7 +393,8 @@ int datetime_wildcard_compare_date(BACNET_DATE *date1, BACNET_DATE *date2)
     return diff;
 }
 
-int datetime_wildcard_compare_time(BACNET_TIME *time1, BACNET_TIME *time2)
+int datetime_wildcard_compare_time(
+    const BACNET_TIME *time1, const BACNET_TIME *time2)
 {
     int diff = 0;
 
@@ -421,7 +424,7 @@ int datetime_wildcard_compare_time(BACNET_TIME *time1, BACNET_TIME *time2)
 }
 
 int datetime_wildcard_compare(
-    BACNET_DATE_TIME *datetime1, BACNET_DATE_TIME *datetime2)
+    const BACNET_DATE_TIME *datetime1, const BACNET_DATE_TIME *datetime2)
 {
     int diff = 0;
 
@@ -434,7 +437,7 @@ int datetime_wildcard_compare(
     return diff;
 }
 
-void datetime_copy_date(BACNET_DATE *dest_date, BACNET_DATE *src_date)
+void datetime_copy_date(BACNET_DATE *dest_date, const BACNET_DATE *src_date)
 {
     if (dest_date && src_date) {
         dest_date->year = src_date->year;
@@ -444,7 +447,7 @@ void datetime_copy_date(BACNET_DATE *dest_date, BACNET_DATE *src_date)
     }
 }
 
-void datetime_copy_time(BACNET_TIME *dest_time, BACNET_TIME *src_time)
+void datetime_copy_time(BACNET_TIME *dest_time, const BACNET_TIME *src_time)
 {
     if (dest_time && src_time) {
         dest_time->hour = src_time->hour;
@@ -455,7 +458,7 @@ void datetime_copy_time(BACNET_TIME *dest_time, BACNET_TIME *src_time)
 }
 
 void datetime_copy(
-    BACNET_DATE_TIME *dest_datetime, BACNET_DATE_TIME *src_datetime)
+    BACNET_DATE_TIME *dest_datetime, const BACNET_DATE_TIME *src_datetime)
 {
     datetime_copy_time(&dest_datetime->time, &src_datetime->time);
     datetime_copy_date(&dest_datetime->date, &src_datetime->date);
@@ -487,7 +490,9 @@ void datetime_set_time(BACNET_TIME *btime,
 }
 
 void datetime_set(
-    BACNET_DATE_TIME *bdatetime, BACNET_DATE *bdate, BACNET_TIME *btime)
+    BACNET_DATE_TIME *bdatetime,
+    const BACNET_DATE *bdate,
+    const BACNET_TIME *btime)
 {
     if (bdate && btime && bdatetime) {
         bdatetime->time.hour = btime->hour;
@@ -576,7 +581,7 @@ void datetime_seconds_since_midnight_into_time(
  *
  * @return seconds since midnight
  */
-uint32_t datetime_seconds_since_midnight(BACNET_TIME *btime)
+uint32_t datetime_seconds_since_midnight(const BACNET_TIME *btime)
 {
     uint32_t seconds = 0;
 
@@ -594,7 +599,7 @@ uint32_t datetime_seconds_since_midnight(BACNET_TIME *btime)
  *
  * @return minutes since midnight
  */
-uint16_t datetime_minutes_since_midnight(BACNET_TIME *btime)
+uint16_t datetime_minutes_since_midnight(const BACNET_TIME *btime)
 {
     uint32_t minutes = 0;
 
@@ -661,7 +666,7 @@ void datetime_add_minutes(BACNET_DATE_TIME *bdatetime, int32_t minutes)
  * @param bdatetime [in] the starting date and time
  * @return seconds since epoch
  */
-bacnet_time_t datetime_seconds_since_epoch(BACNET_DATE_TIME *bdatetime)
+bacnet_time_t datetime_seconds_since_epoch(const BACNET_DATE_TIME *bdatetime)
 {
     bacnet_time_t seconds = 0;
     uint32_t days = 0;
@@ -713,7 +718,7 @@ bacnet_time_t datetime_seconds_since_epoch_max(void)
 }
 
 /* Returns true if year is a wildcard */
-bool datetime_wildcard_year(BACNET_DATE *bdate)
+bool datetime_wildcard_year(const BACNET_DATE *bdate)
 {
     bool wildcard_present = false;
 
@@ -735,7 +740,7 @@ void datetime_wildcard_year_set(BACNET_DATE *bdate)
 }
 
 /* Returns true if month is a wildcard */
-bool datetime_wildcard_month(BACNET_DATE *bdate)
+bool datetime_wildcard_month(const BACNET_DATE *bdate)
 {
     bool wildcard_present = false;
 
@@ -757,7 +762,7 @@ void datetime_wildcard_month_set(BACNET_DATE *bdate)
 }
 
 /* Returns true if day is a wildcard */
-bool datetime_wildcard_day(BACNET_DATE *bdate)
+bool datetime_wildcard_day(const BACNET_DATE *bdate)
 {
     bool wildcard_present = false;
 
@@ -779,7 +784,7 @@ void datetime_wildcard_day_set(BACNET_DATE *bdate)
 }
 
 /* Returns true if weekday is a wildcard */
-bool datetime_wildcard_weekday(BACNET_DATE *bdate)
+bool datetime_wildcard_weekday(const BACNET_DATE *bdate)
 {
     bool wildcard_present = false;
 
@@ -801,7 +806,7 @@ void datetime_wildcard_weekday_set(BACNET_DATE *bdate)
 }
 
 /* Returns true if hour is a wildcard */
-bool datetime_wildcard_hour(BACNET_TIME *btime)
+bool datetime_wildcard_hour(const BACNET_TIME *btime)
 {
     bool wildcard_present = false;
 
@@ -823,7 +828,7 @@ void datetime_wildcard_hour_set(BACNET_TIME *btime)
 }
 
 /* Returns true if minute is a wildcard */
-bool datetime_wildcard_minute(BACNET_TIME *btime)
+bool datetime_wildcard_minute(const BACNET_TIME *btime)
 {
     bool wildcard_present = false;
 
@@ -845,7 +850,7 @@ void datetime_wildcard_minute_set(BACNET_TIME *btime)
 }
 
 /* Returns true if seconds is wildcard */
-bool datetime_wildcard_second(BACNET_TIME *btime)
+bool datetime_wildcard_second(const BACNET_TIME *btime)
 {
     bool wildcard_present = false;
 
@@ -867,7 +872,7 @@ void datetime_wildcard_second_set(BACNET_TIME *btime)
 }
 
 /* Returns true if hundredths is a wildcard */
-bool datetime_wildcard_hundredths(BACNET_TIME *btime)
+bool datetime_wildcard_hundredths(const BACNET_TIME *btime)
 {
     bool wildcard_present = false;
 
@@ -888,7 +893,7 @@ void datetime_wildcard_hundredths_set(BACNET_TIME *btime)
     }
 }
 
-bool datetime_wildcard(BACNET_DATE_TIME *bdatetime)
+bool datetime_wildcard(const BACNET_DATE_TIME *bdatetime)
 {
     bool wildcard_present = false;
 
@@ -912,7 +917,7 @@ bool datetime_wildcard(BACNET_DATE_TIME *bdatetime)
  * on it's own.  Also checks for special day and month values.  Used in
  * trendlog object.
  */
-bool datetime_wildcard_present(BACNET_DATE_TIME *bdatetime)
+bool datetime_wildcard_present(const BACNET_DATE_TIME *bdatetime)
 {
     bool wildcard_present = false;
 
@@ -970,7 +975,7 @@ void datetime_wildcard_set(BACNET_DATE_TIME *bdatetime)
  * @return true if the time is converted
  */
 bool datetime_utc_to_local(BACNET_DATE_TIME *local_time,
-    BACNET_DATE_TIME *utc_time,
+    const BACNET_DATE_TIME *utc_time,
     int16_t utc_offset_minutes,
     int8_t dst_adjust_minutes)
 {
@@ -1002,7 +1007,7 @@ bool datetime_utc_to_local(BACNET_DATE_TIME *local_time,
  * @return true if the time is converted
  */
 bool datetime_local_to_utc(BACNET_DATE_TIME *utc_time,
-    BACNET_DATE_TIME *local_time,
+    const BACNET_DATE_TIME *local_time,
     int16_t utc_offset_minutes,
     int8_t dst_adjust_minutes)
 {
@@ -1033,7 +1038,7 @@ bool datetime_local_to_utc(BACNET_DATE_TIME *utc_time,
  * @param value The value to be encoded.
  * @return the number of apdu bytes encoded
  */
-int bacapp_encode_datetime(uint8_t *apdu, BACNET_DATE_TIME *value)
+int bacapp_encode_datetime(uint8_t *apdu, const BACNET_DATE_TIME *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -1059,7 +1064,7 @@ int bacapp_encode_datetime(uint8_t *apdu, BACNET_DATE_TIME *value)
  * @return the number of apdu bytes encoded
  */
 int bacapp_encode_context_datetime(
-    uint8_t *apdu, uint8_t tag_number, BACNET_DATE_TIME *value)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_DATE_TIME *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -1090,7 +1095,7 @@ int bacapp_encode_context_datetime(
  * @return length of the APDU buffer decoded, or BACNET_STATUS_ERROR
  */
 int bacnet_datetime_decode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_DATE_TIME *value)
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_DATE_TIME *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -1119,7 +1124,7 @@ int bacnet_datetime_decode(
     return apdu_len;
 }
 
-int bacapp_decode_datetime(uint8_t *apdu, BACNET_DATE_TIME *value)
+int bacapp_decode_datetime(const uint8_t *apdu, BACNET_DATE_TIME *value)
 {
     return bacnet_datetime_decode(apdu, MAX_APDU, value);
 }
@@ -1132,7 +1137,7 @@ int bacapp_decode_datetime(uint8_t *apdu, BACNET_DATE_TIME *value)
  * @param value - parameter to store the value after decoding
  * @return length of the APDU buffer decoded, or BACNET_STATUS_ERROR
  */
-int bacnet_datetime_context_decode(uint8_t *apdu,
+int bacnet_datetime_context_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     uint8_t tag_number,
     BACNET_DATE_TIME *value)
@@ -1168,7 +1173,7 @@ int bacnet_datetime_context_decode(uint8_t *apdu,
  * @deprecated - use bacnet_datetime_context_decode() instead
  */
 int bacapp_decode_context_datetime(
-    uint8_t *apdu, uint8_t tag_number, BACNET_DATE_TIME *value)
+    const uint8_t *apdu, uint8_t tag_number, BACNET_DATE_TIME *value)
 {
     return bacnet_datetime_context_decode(apdu, MAX_APDU, tag_number, value);
 }
@@ -1179,8 +1184,9 @@ int bacapp_decode_context_datetime(
  * @param value2 - complex data value 2 structure
  * @return true if the two complex data values are the same
  */
-bool bacnet_daterange_same(BACNET_DATE_RANGE *value1,
-    BACNET_DATE_RANGE *value2)
+bool bacnet_daterange_same(
+    const BACNET_DATE_RANGE *value1,
+    const BACNET_DATE_RANGE *value2)
 {
     bool status = false;
 
@@ -1206,7 +1212,7 @@ bool bacnet_daterange_same(BACNET_DATE_RANGE *value1,
  * @param value - value to encode
  * @return number of bytes emitted, BACNET_STATUS_ERROR on error
  */
-int bacnet_daterange_encode(uint8_t *apdu, BACNET_DATE_RANGE *value)
+int bacnet_daterange_encode(uint8_t *apdu, const BACNET_DATE_RANGE *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -1237,7 +1243,7 @@ int bacnet_daterange_encode(uint8_t *apdu, BACNET_DATE_RANGE *value)
  * @return number of bytes emitted, BACNET_STATUS_ERROR on error
  */
 int bacnet_daterange_decode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_DATE_RANGE *value)
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_DATE_RANGE *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -1269,7 +1275,7 @@ int bacnet_daterange_decode(
  * @return number of bytes decoded, or BACNET_STATUS_ERROR on error
  */
 int bacnet_daterange_context_encode(
-    uint8_t *apdu, uint8_t tag_number, BACNET_DATE_RANGE *value)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_DATE_RANGE *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -1303,7 +1309,7 @@ int bacnet_daterange_context_encode(
  * @param value - value to encode
  * @return number of bytes decoded, BACNET_STATUS_ERROR on error
  */
-int bacnet_daterange_context_decode(uint8_t *apdu,
+int bacnet_daterange_context_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     uint8_t tag_number,
     BACNET_DATE_RANGE *value)
@@ -1370,7 +1376,7 @@ bool datetime_date_init_ascii(BACNET_DATE *bdate, const char *ascii)
  * @param str_size - size of the string, or 0 for length only
  * @return number of characters printed
  */
-int datetime_date_to_ascii(BACNET_DATE *bdate, char *str, size_t str_size)
+int datetime_date_to_ascii(const BACNET_DATE *bdate, char *str, size_t str_size)
 {
     int str_len = 0;
 
@@ -1431,7 +1437,7 @@ bool datetime_time_init_ascii(BACNET_TIME *btime, const char *ascii)
  * @param str_size - size of the string, or 0 for length only
  * @return number of characters printed
  */
-int datetime_time_to_ascii(BACNET_TIME *btime, char *str, size_t str_size)
+int datetime_time_to_ascii(const BACNET_TIME *btime, char *str, size_t str_size)
 {
     int str_len = 0;
 
@@ -1484,7 +1490,7 @@ bool datetime_init_ascii(BACNET_DATE_TIME *bdatetime, const char *ascii)
  * @param str_size - size of the string, or 0 for length only
  * @return number of characters printed
  */
-int datetime_to_ascii(BACNET_DATE_TIME *bdatetime, char *str, size_t str_size)
+int datetime_to_ascii(const BACNET_DATE_TIME *bdatetime, char *str, size_t str_size)
 {
     int str_len = 0;
 

--- a/src/bacnet/datetime.h
+++ b/src/bacnet/datetime.h
@@ -88,7 +88,9 @@ void datetime_set_time(BACNET_TIME *btime,
     uint8_t hundredths);
 BACNET_STACK_EXPORT
 void datetime_set(
-    BACNET_DATE_TIME *bdatetime, BACNET_DATE *bdate, BACNET_TIME *btime);
+    BACNET_DATE_TIME *bdatetime,
+    const BACNET_DATE *bdate,
+    const BACNET_TIME *btime);
 BACNET_STACK_EXPORT
 void datetime_set_values(BACNET_DATE_TIME *bdatetime,
     uint16_t year,
@@ -108,21 +110,21 @@ void datetime_hms_from_seconds_since_midnight(
     uint32_t seconds, uint8_t *pHours, uint8_t *pMinutes, uint8_t *pSeconds);
 /* utility test for validity */
 BACNET_STACK_EXPORT
-bool datetime_is_valid(BACNET_DATE *bdate, BACNET_TIME *btime);
+bool datetime_is_valid(const BACNET_DATE *bdate, const BACNET_TIME *btime);
 BACNET_STACK_EXPORT
-bool datetime_time_is_valid(BACNET_TIME *btime);
+bool datetime_time_is_valid(const BACNET_TIME *btime);
 BACNET_STACK_EXPORT
-bool datetime_date_is_valid(BACNET_DATE *bdate);
+bool datetime_date_is_valid(const BACNET_DATE *bdate);
 /* date and time calculations and summaries */
 BACNET_STACK_EXPORT
 void datetime_ymd_from_days_since_epoch(
     uint32_t days, uint16_t *pYear, uint8_t *pMonth, uint8_t *pDay);
 BACNET_STACK_EXPORT
-uint32_t datetime_days_since_epoch(BACNET_DATE *bdate);
+uint32_t datetime_days_since_epoch(const BACNET_DATE *bdate);
 BACNET_STACK_EXPORT
 void datetime_days_since_epoch_into_date(uint32_t days, BACNET_DATE *bdate);
 BACNET_STACK_EXPORT
-uint32_t datetime_day_of_year(BACNET_DATE *bdate);
+uint32_t datetime_day_of_year(const BACNET_DATE *bdate);
 BACNET_STACK_EXPORT
 uint32_t datetime_ymd_to_days_since_epoch(
     uint16_t year, uint8_t month, uint8_t day);
@@ -144,46 +146,49 @@ BACNET_STACK_EXPORT
 void datetime_seconds_since_midnight_into_time(
     uint32_t seconds, BACNET_TIME *btime);
 BACNET_STACK_EXPORT
-uint32_t datetime_seconds_since_midnight(BACNET_TIME *btime);
+uint32_t datetime_seconds_since_midnight(const BACNET_TIME *btime);
 BACNET_STACK_EXPORT
-uint16_t datetime_minutes_since_midnight(BACNET_TIME *btime);
+uint16_t datetime_minutes_since_midnight(const BACNET_TIME *btime);
 
 /* utility comparison functions:
    if the date/times are the same, return is 0
    if date1 is before date2, returns negative
    if date1 is after date2, returns positive */
 BACNET_STACK_EXPORT
-int datetime_compare_date(BACNET_DATE *date1, BACNET_DATE *date2);
+int datetime_compare_date(const BACNET_DATE *date1, const BACNET_DATE *date2);
 BACNET_STACK_EXPORT
-int datetime_compare_time(BACNET_TIME *time1, BACNET_TIME *time2);
+int datetime_compare_time(const BACNET_TIME *time1, const BACNET_TIME *time2);
 BACNET_STACK_EXPORT
-int datetime_compare(BACNET_DATE_TIME *datetime1, BACNET_DATE_TIME *datetime2);
+int datetime_compare(
+    const BACNET_DATE_TIME *datetime1, const BACNET_DATE_TIME *datetime2);
 
 /* full comparison functions:
  * taking into account FF fields in date and time structures,
  * do a full comparison of two values */
 BACNET_STACK_EXPORT
-int datetime_wildcard_compare_date(BACNET_DATE *date1, BACNET_DATE *date2);
+int datetime_wildcard_compare_date(
+    const BACNET_DATE *date1, const BACNET_DATE *date2);
 BACNET_STACK_EXPORT
-int datetime_wildcard_compare_time(BACNET_TIME *time1, BACNET_TIME *time2);
+int datetime_wildcard_compare_time(
+    const BACNET_TIME *time1, const BACNET_TIME *time2);
 BACNET_STACK_EXPORT
 int datetime_wildcard_compare(
-    BACNET_DATE_TIME *datetime1, BACNET_DATE_TIME *datetime2);
+    const BACNET_DATE_TIME *datetime1, const BACNET_DATE_TIME *datetime2);
 
 /* utility copy functions */
 BACNET_STACK_EXPORT
-void datetime_copy_date(BACNET_DATE *dest, BACNET_DATE *src);
+void datetime_copy_date(BACNET_DATE *dest, const BACNET_DATE *src);
 BACNET_STACK_EXPORT
-void datetime_copy_time(BACNET_TIME *dest, BACNET_TIME *src);
+void datetime_copy_time(BACNET_TIME *dest, const BACNET_TIME *src);
 BACNET_STACK_EXPORT
-void datetime_copy(BACNET_DATE_TIME *dest, BACNET_DATE_TIME *src);
+void datetime_copy(BACNET_DATE_TIME *dest, const BACNET_DATE_TIME *src);
 
 /* utility add or subtract minutes function */
 BACNET_STACK_EXPORT
 void datetime_add_minutes(BACNET_DATE_TIME *bdatetime, int32_t minutes);
 
 BACNET_STACK_EXPORT
-bacnet_time_t datetime_seconds_since_epoch(BACNET_DATE_TIME *bdatetime);
+bacnet_time_t datetime_seconds_since_epoch(const BACNET_DATE_TIME *bdatetime);
 BACNET_STACK_EXPORT
 void datetime_since_epoch_seconds(
     BACNET_DATE_TIME *bdatetime, bacnet_time_t seconds);
@@ -192,41 +197,41 @@ bacnet_time_t datetime_seconds_since_epoch_max(void);
 
 /* date and time wildcards */
 BACNET_STACK_EXPORT
-bool datetime_wildcard_year(BACNET_DATE *bdate);
+bool datetime_wildcard_year(const BACNET_DATE *bdate);
 BACNET_STACK_EXPORT
 void datetime_wildcard_year_set(BACNET_DATE *bdate);
 BACNET_STACK_EXPORT
-bool datetime_wildcard_month(BACNET_DATE *bdate);
+bool datetime_wildcard_month(const BACNET_DATE *bdate);
 BACNET_STACK_EXPORT
 void datetime_wildcard_month_set(BACNET_DATE *bdate);
 BACNET_STACK_EXPORT
-bool datetime_wildcard_day(BACNET_DATE *bdate);
+bool datetime_wildcard_day(const BACNET_DATE *bdate);
 BACNET_STACK_EXPORT
 void datetime_wildcard_day_set(BACNET_DATE *bdate);
 BACNET_STACK_EXPORT
-bool datetime_wildcard_weekday(BACNET_DATE *bdate);
+bool datetime_wildcard_weekday(const BACNET_DATE *bdate);
 BACNET_STACK_EXPORT
 void datetime_wildcard_weekday_set(BACNET_DATE *bdate);
 BACNET_STACK_EXPORT
-bool datetime_wildcard_hour(BACNET_TIME *btime);
+bool datetime_wildcard_hour(const BACNET_TIME *btime);
 BACNET_STACK_EXPORT
 void datetime_wildcard_hour_set(BACNET_TIME *btime);
 BACNET_STACK_EXPORT
-bool datetime_wildcard_minute(BACNET_TIME *btime);
+bool datetime_wildcard_minute(const BACNET_TIME *btime);
 BACNET_STACK_EXPORT
 void datetime_wildcard_minute_set(BACNET_TIME *btime);
 BACNET_STACK_EXPORT
-bool datetime_wildcard_second(BACNET_TIME *btime);
+bool datetime_wildcard_second(const BACNET_TIME *btime);
 BACNET_STACK_EXPORT
 void datetime_wildcard_second_set(BACNET_TIME *btime);
 BACNET_STACK_EXPORT
-bool datetime_wildcard_hundredths(BACNET_TIME *btime);
+bool datetime_wildcard_hundredths(const BACNET_TIME *btime);
 BACNET_STACK_EXPORT
 void datetime_wildcard_hundredths_set(BACNET_TIME *btime);
 BACNET_STACK_EXPORT
-bool datetime_wildcard(BACNET_DATE_TIME *bdatetime);
+bool datetime_wildcard(const BACNET_DATE_TIME *bdatetime);
 BACNET_STACK_EXPORT
-bool datetime_wildcard_present(BACNET_DATE_TIME *bdatetime);
+bool datetime_wildcard_present(const BACNET_DATE_TIME *bdatetime);
 BACNET_STACK_EXPORT
 void datetime_wildcard_set(BACNET_DATE_TIME *bdatetime);
 BACNET_STACK_EXPORT
@@ -236,65 +241,65 @@ void datetime_time_wildcard_set(BACNET_TIME *btime);
 
 BACNET_STACK_EXPORT
 bool datetime_local_to_utc(BACNET_DATE_TIME *utc_time,
-    BACNET_DATE_TIME *local_time,
+    const BACNET_DATE_TIME *local_time,
     int16_t utc_offset_minutes,
     int8_t dst_adjust_minutes);
 BACNET_STACK_EXPORT
 bool datetime_utc_to_local(BACNET_DATE_TIME *local_time,
-    BACNET_DATE_TIME *utc_time,
+    const BACNET_DATE_TIME *utc_time,
     int16_t utc_offset_minutes,
     int8_t dst_adjust_minutes);
 
 BACNET_STACK_EXPORT
 bool datetime_date_init_ascii(BACNET_DATE *bdate, const char *ascii);
 BACNET_STACK_EXPORT
-int datetime_date_to_ascii(BACNET_DATE *bdate, char *str, size_t str_size);
+int datetime_date_to_ascii(const BACNET_DATE *bdate, char *str, size_t str_size);
 BACNET_STACK_EXPORT
 bool datetime_time_init_ascii(BACNET_TIME *btime, const char *ascii);
 BACNET_STACK_EXPORT
-int datetime_time_to_ascii(BACNET_TIME *btime, char *str, size_t str_size);
+int datetime_time_to_ascii(const BACNET_TIME *btime, char *str, size_t str_size);
 BACNET_STACK_EXPORT
 bool datetime_init_ascii(BACNET_DATE_TIME *bdatetime, const char *ascii);
 BACNET_STACK_EXPORT
-int datetime_to_ascii(BACNET_DATE_TIME *bdatetime, char *str, size_t str_size);
+int datetime_to_ascii(const BACNET_DATE_TIME *bdatetime, char *str, size_t str_size);
 
 BACNET_STACK_EXPORT
-int bacapp_encode_datetime(uint8_t *apdu, BACNET_DATE_TIME *value);
+int bacapp_encode_datetime(uint8_t *apdu, const BACNET_DATE_TIME *value);
 BACNET_STACK_EXPORT
 int bacapp_encode_context_datetime(
-    uint8_t *apdu, uint8_t tag_number, BACNET_DATE_TIME *value);
+    uint8_t *apdu, uint8_t tag_number, const BACNET_DATE_TIME *value);
 BACNET_STACK_EXPORT
 int bacnet_datetime_decode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_DATE_TIME *value);
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_DATE_TIME *value);
 BACNET_STACK_EXPORT
 int bacnet_datetime_context_decode(
-    uint8_t *apdu, uint32_t apdu_size,  uint8_t tag_number,
+    const uint8_t *apdu, uint32_t apdu_size,  uint8_t tag_number,
     BACNET_DATE_TIME *value);
 
 BACNET_STACK_DEPRECATED("Use bacnet_datetime_decode() instead")
 BACNET_STACK_EXPORT
 int bacapp_decode_datetime(
-    uint8_t *apdu, BACNET_DATE_TIME *value);
+    const uint8_t *apdu, BACNET_DATE_TIME *value);
 BACNET_STACK_DEPRECATED("Use bacnet_datetime_context_decode() instead")
 BACNET_STACK_EXPORT
-int bacapp_decode_context_datetime(uint8_t *apdu,
+int bacapp_decode_context_datetime(const uint8_t *apdu,
     uint8_t tag_number,
     BACNET_DATE_TIME *value);
 
 BACNET_STACK_EXPORT
-bool bacnet_daterange_same(BACNET_DATE_RANGE *value1,
-    BACNET_DATE_RANGE *value2);
+bool bacnet_daterange_same(const BACNET_DATE_RANGE *value1,
+    const BACNET_DATE_RANGE *value2);
 BACNET_STACK_EXPORT
-int bacnet_daterange_encode(uint8_t *apdu, BACNET_DATE_RANGE *value);
+int bacnet_daterange_encode(uint8_t *apdu, const BACNET_DATE_RANGE *value);
 BACNET_STACK_EXPORT
-int bacnet_daterange_decode(uint8_t *apdu,
+int bacnet_daterange_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     BACNET_DATE_RANGE *value);
 BACNET_STACK_EXPORT
 int bacnet_daterange_context_encode(
-    uint8_t *apdu, uint8_t tag_number, BACNET_DATE_RANGE *value);
+    uint8_t *apdu, uint8_t tag_number, const BACNET_DATE_RANGE *value);
 BACNET_STACK_EXPORT
-int bacnet_daterange_context_decode(uint8_t *apdu,
+int bacnet_daterange_context_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     uint8_t tag_number,
     BACNET_DATE_RANGE *value);
@@ -307,8 +312,7 @@ bool datetime_local(BACNET_DATE *bdate,
     bool *dst_active);
 
 BACNET_STACK_EXPORT
-void datetime_timesync(
-    BACNET_DATE *bdate, BACNET_TIME *btime, bool utc);
+void datetime_timesync(BACNET_DATE *bdate, BACNET_TIME *btime, bool utc);
 
 BACNET_STACK_EXPORT
 void datetime_init(void);

--- a/src/bacnet/dcc.c
+++ b/src/bacnet/dcc.c
@@ -144,7 +144,7 @@ bool dcc_set_status_duration(
 int dcc_apdu_encode(uint8_t *apdu,
     uint16_t timeDuration,
     BACNET_COMMUNICATION_ENABLE_DISABLE enable_disable,
-    BACNET_CHARACTER_STRING *password)
+    const BACNET_CHARACTER_STRING *password)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -187,7 +187,7 @@ size_t dcc_service_request_encode(uint8_t *apdu,
     size_t apdu_size,
     uint16_t timeDuration,
     BACNET_COMMUNICATION_ENABLE_DISABLE enable_disable,
-    BACNET_CHARACTER_STRING *password)
+    const BACNET_CHARACTER_STRING *password)
 {
     size_t apdu_len = 0; /* total length of the apdu, return value */
 
@@ -216,7 +216,7 @@ int dcc_encode_apdu(uint8_t *apdu,
     uint8_t invoke_id,
     uint16_t timeDuration,
     BACNET_COMMUNICATION_ENABLE_DISABLE enable_disable,
-    BACNET_CHARACTER_STRING *password)
+    const BACNET_CHARACTER_STRING *password)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -252,7 +252,7 @@ int dcc_encode_apdu(uint8_t *apdu,
  *
  * @return Bytes decoded, or BACNET_STATUS_ABORT or BACNET_STATUS_REJECT
  */
-int dcc_decode_service_request(uint8_t *apdu,
+int dcc_decode_service_request(const uint8_t *apdu,
     unsigned apdu_len_max,
     uint16_t *timeDuration,
     BACNET_COMMUNICATION_ENABLE_DISABLE *enable_disable,

--- a/src/bacnet/dcc.h
+++ b/src/bacnet/dcc.h
@@ -51,24 +51,24 @@ extern "C" {
     int dcc_apdu_encode(uint8_t *apdu,
         uint16_t timeDuration,
         BACNET_COMMUNICATION_ENABLE_DISABLE enable_disable,
-        BACNET_CHARACTER_STRING *password);
+        const BACNET_CHARACTER_STRING *password);
     BACNET_STACK_EXPORT
     size_t dcc_service_request_encode(uint8_t *apdu,
         size_t apdu_size,
         uint16_t timeDuration,
         BACNET_COMMUNICATION_ENABLE_DISABLE enable_disable,
-        BACNET_CHARACTER_STRING *password);
+        const BACNET_CHARACTER_STRING *password);
     BACNET_STACK_EXPORT
     int dcc_encode_apdu(
         uint8_t * apdu,
         uint8_t invoke_id,
         uint16_t timeDuration,
         BACNET_COMMUNICATION_ENABLE_DISABLE enable_disable,
-        BACNET_CHARACTER_STRING * password);
+        const BACNET_CHARACTER_STRING * password);
 
     BACNET_STACK_EXPORT
     int dcc_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         uint16_t * timeDuration,
         BACNET_COMMUNICATION_ENABLE_DISABLE * enable_disable,

--- a/src/bacnet/delete_object.c
+++ b/src/bacnet/delete_object.c
@@ -28,7 +28,7 @@
  * @return Bytes encoded or zero on error.
  */
 int delete_object_encode_service_request(
-    uint8_t *apdu, BACNET_DELETE_OBJECT_DATA *data)
+    uint8_t *apdu, const BACNET_DELETE_OBJECT_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -56,7 +56,7 @@ int delete_object_encode_service_request(
  * @return number of bytes encoded, or zero if unable to encode or too large
  */
 int delete_object_service_request_encode(
-    uint8_t *apdu, size_t apdu_size, BACNET_DELETE_OBJECT_DATA *data)
+    uint8_t *apdu, size_t apdu_size, const BACNET_DELETE_OBJECT_DATA *data)
 {
     size_t apdu_len = 0; /* total length of the apdu, return value */
 
@@ -84,7 +84,7 @@ int delete_object_service_request_encode(
  * @return Bytes decoded or BACNET_STATUS_REJECT on error.
  */
 int delete_object_decode_service_request(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_DELETE_OBJECT_DATA *data)
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_DELETE_OBJECT_DATA *data)
 {
     int len = 0;
     int apdu_len = 0;

--- a/src/bacnet/delete_object.h
+++ b/src/bacnet/delete_object.h
@@ -42,15 +42,15 @@ extern "C" {
 
 BACNET_STACK_EXPORT
 int delete_object_encode_service_request(
-    uint8_t *apdu, BACNET_DELETE_OBJECT_DATA *data);
+    uint8_t *apdu, const BACNET_DELETE_OBJECT_DATA *data);
 
 BACNET_STACK_EXPORT
 int delete_object_service_request_encode(
-    uint8_t *apdu, size_t apdu_size, BACNET_DELETE_OBJECT_DATA *data);
+    uint8_t *apdu, size_t apdu_size, const BACNET_DELETE_OBJECT_DATA *data);
 
 BACNET_STACK_EXPORT
 int delete_object_decode_service_request(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_DELETE_OBJECT_DATA *data);
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_DELETE_OBJECT_DATA *data);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/event.c
+++ b/src/bacnet/event.c
@@ -23,7 +23,9 @@
  * @return number of apdu bytes decoded, or BACNET_STATUS_ERROR on error.
  */
 static int complex_event_type_values_decode(
-    uint8_t *apdu, unsigned apdu_size, BACNET_EVENT_NOTIFICATION_DATA *data)
+    const uint8_t *apdu,
+    unsigned apdu_size,
+    BACNET_EVENT_NOTIFICATION_DATA *data)
 {
     int len = 0; /* return value */
     BACNET_PROPERTY_VALUE *value;
@@ -73,7 +75,7 @@ static int complex_event_type_values_decode(
  * @return number of bytes encoded, or zero if unable to encode
  */
 int uevent_notify_encode_apdu(
-    uint8_t *apdu, BACNET_EVENT_NOTIFICATION_DATA *data)
+    uint8_t *apdu, const BACNET_EVENT_NOTIFICATION_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -105,7 +107,9 @@ int uevent_notify_encode_apdu(
  * @return number of bytes encoded, or zero if unable to encode
  */
 int cevent_notify_encode_apdu(
-    uint8_t *apdu, uint8_t invoke_id, BACNET_EVENT_NOTIFICATION_DATA *data)
+    uint8_t *apdu,
+    uint8_t invoke_id,
+    const BACNET_EVENT_NOTIFICATION_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -138,7 +142,7 @@ int cevent_notify_encode_apdu(
  * @return number of bytes encoded, or zero if unable to encode
  */
 int event_notify_encode_service_request(
-    uint8_t *apdu, BACNET_EVENT_NOTIFICATION_DATA *data)
+    uint8_t *apdu, const BACNET_EVENT_NOTIFICATION_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -686,7 +690,9 @@ int event_notify_encode_service_request(
  * @return number of bytes encoded, or zero if unable to encode or too large
  */
 size_t event_notification_service_request_encode(
-    uint8_t *apdu, size_t apdu_size, BACNET_EVENT_NOTIFICATION_DATA *data)
+    uint8_t *apdu,
+    size_t apdu_size,
+    const BACNET_EVENT_NOTIFICATION_DATA *data)
 {
     size_t apdu_len = 0; /* total length of the apdu, return value */
 
@@ -709,7 +715,9 @@ size_t event_notification_service_request_encode(
  * @return Bytes decoded or BACNET_STATUS_ERROR on error.
  */
 int event_notify_decode_service_request(
-    uint8_t *apdu, unsigned apdu_len, BACNET_EVENT_NOTIFICATION_DATA *data)
+    const uint8_t *apdu,
+    unsigned apdu_len,
+    BACNET_EVENT_NOTIFICATION_DATA *data)
 {
     int len = 0; /* return value */
     int section_length = 0;

--- a/src/bacnet/event.h
+++ b/src/bacnet/event.h
@@ -191,7 +191,7 @@ extern "C" {
     int cevent_notify_encode_apdu(
         uint8_t * apdu,
         uint8_t invoke_id,
-        BACNET_EVENT_NOTIFICATION_DATA * data);
+        const BACNET_EVENT_NOTIFICATION_DATA * data);
 
 /***************************************************
 **
@@ -201,7 +201,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     int uevent_notify_encode_apdu(
         uint8_t * apdu,
-        BACNET_EVENT_NOTIFICATION_DATA * data);
+        const BACNET_EVENT_NOTIFICATION_DATA * data);
 
 /***************************************************
 **
@@ -211,13 +211,13 @@ extern "C" {
     BACNET_STACK_EXPORT
     int event_notify_encode_service_request(
         uint8_t * apdu,
-        BACNET_EVENT_NOTIFICATION_DATA * data);
+        const BACNET_EVENT_NOTIFICATION_DATA * data);
 
     BACNET_STACK_EXPORT
     size_t event_notification_service_request_encode(
         uint8_t *apdu,
         size_t apdu_size,
-        BACNET_EVENT_NOTIFICATION_DATA *data);
+        const BACNET_EVENT_NOTIFICATION_DATA *data);
 
 /***************************************************
 **
@@ -226,7 +226,7 @@ extern "C" {
 ****************************************************/
     BACNET_STACK_EXPORT
     int event_notify_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_EVENT_NOTIFICATION_DATA * data);
 

--- a/src/bacnet/get_alarm_sum.c
+++ b/src/bacnet/get_alarm_sum.c
@@ -66,7 +66,7 @@ int get_alarm_summary_ack_encode_apdu_init(uint8_t *apdu, uint8_t invoke_id)
  */
 int get_alarm_summary_ack_encode_apdu_data(uint8_t *apdu,
     size_t max_apdu,
-    BACNET_GET_ALARM_SUMMARY_DATA *get_alarm_data)
+    const BACNET_GET_ALARM_SUMMARY_DATA *get_alarm_data)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
 
@@ -98,7 +98,7 @@ int get_alarm_summary_ack_encode_apdu_data(uint8_t *apdu,
  *
  * @return number of bytes decoded, or BACNET_STATUS_ERROR if an error.
  */
-int get_alarm_summary_ack_decode_apdu_data(uint8_t *apdu,
+int get_alarm_summary_ack_decode_apdu_data(const uint8_t *apdu,
     size_t max_apdu,
     BACNET_GET_ALARM_SUMMARY_DATA *get_alarm_data)
 {

--- a/src/bacnet/get_alarm_sum.h
+++ b/src/bacnet/get_alarm_sum.h
@@ -54,11 +54,11 @@ extern "C" {
     int get_alarm_summary_ack_encode_apdu_data(
         uint8_t * apdu,
         size_t max_apdu,
-        BACNET_GET_ALARM_SUMMARY_DATA * get_alarm_data);
+        const BACNET_GET_ALARM_SUMMARY_DATA * get_alarm_data);
 
     BACNET_STACK_EXPORT
     int get_alarm_summary_ack_decode_apdu_data(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         size_t max_apdu,
         BACNET_GET_ALARM_SUMMARY_DATA * get_alarm_data);
 

--- a/src/bacnet/getevent.c
+++ b/src/bacnet/getevent.c
@@ -19,7 +19,7 @@
  * @return Bytes encoded.
  */
 int getevent_apdu_encode(uint8_t *apdu,
-    BACNET_OBJECT_ID *lastReceivedObjectIdentifier)
+    const BACNET_OBJECT_ID *lastReceivedObjectIdentifier)
 {
     int len = 0;
     int apdu_len = 0;
@@ -44,7 +44,7 @@ int getevent_apdu_encode(uint8_t *apdu,
  */
 size_t getevent_service_request_encode(
     uint8_t *apdu, size_t apdu_size,
-    BACNET_OBJECT_ID *data)
+    const BACNET_OBJECT_ID *data)
 {
     size_t apdu_len = 0; /* total length of the apdu, return value */
 
@@ -69,7 +69,7 @@ size_t getevent_service_request_encode(
  */
 int getevent_encode_apdu(uint8_t *apdu,
     uint8_t invoke_id,
-    BACNET_OBJECT_ID *data)
+    const BACNET_OBJECT_ID *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -99,7 +99,7 @@ int getevent_encode_apdu(uint8_t *apdu,
  *
  * @return Bytes encoded.
  */
-int getevent_decode_service_request(uint8_t *apdu,
+int getevent_decode_service_request(const uint8_t *apdu,
     unsigned apdu_len,
     BACNET_OBJECT_ID *lastReceivedObjectIdentifier)
 {
@@ -202,7 +202,7 @@ int getevent_ack_encode_apdu_end(
     return apdu_len;
 }
 
-int getevent_ack_decode_service_request(uint8_t *apdu,
+int getevent_ack_decode_service_request(const uint8_t *apdu,
     int apdu_len, /* total length of the apdu */
     BACNET_GET_EVENT_INFORMATION_DATA *get_event_data,
     bool *moreEvents)

--- a/src/bacnet/getevent.h
+++ b/src/bacnet/getevent.h
@@ -43,23 +43,23 @@ extern "C" {
     BACNET_STACK_EXPORT
     int getevent_apdu_encode(
         uint8_t *apdu,
-        BACNET_OBJECT_ID *lastReceivedObjectIdentifier);
+        const BACNET_OBJECT_ID *lastReceivedObjectIdentifier);
 
     BACNET_STACK_DEPRECATED("Use getevent_apdu_encode() instead")
     BACNET_STACK_EXPORT
     int getevent_encode_apdu(
         uint8_t * apdu,
         uint8_t invoke_id,
-        BACNET_OBJECT_ID * lastReceivedObjectIdentifier);
+        const BACNET_OBJECT_ID * lastReceivedObjectIdentifier);
 
     BACNET_STACK_EXPORT
     size_t getevent_service_request_encode(
         uint8_t *apdu, size_t apdu_size,
-        BACNET_OBJECT_ID *data);
+        const BACNET_OBJECT_ID *data);
 
     BACNET_STACK_EXPORT
     int getevent_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_OBJECT_ID * object_id);
 
@@ -83,7 +83,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     int getevent_ack_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         int apdu_len,   /* total length of the apdu */
         BACNET_GET_EVENT_INFORMATION_DATA * get_event_data,
         bool * moreEvents);

--- a/src/bacnet/hostnport.c
+++ b/src/bacnet/hostnport.c
@@ -21,7 +21,7 @@
  * @param address - IP address and port number
  * @return length of the encoded APDU buffer
  */
-int host_n_port_address_encode(uint8_t *apdu, BACNET_HOST_N_PORT *address)
+int host_n_port_address_encode(uint8_t *apdu, const BACNET_HOST_N_PORT *address)
 {
     int len = 0;
 
@@ -61,7 +61,7 @@ int host_n_port_address_encode(uint8_t *apdu, BACNET_HOST_N_PORT *address)
  * @param address - IP address and port number
  * @return length of the encoded APDU buffer
  */
-int host_n_port_encode(uint8_t *apdu, BACNET_HOST_N_PORT *address)
+int host_n_port_encode(uint8_t *apdu, const BACNET_HOST_N_PORT *address)
 {
     int len = 0;
     int apdu_len = 0;
@@ -101,7 +101,7 @@ int host_n_port_encode(uint8_t *apdu, BACNET_HOST_N_PORT *address)
  * @return length of the APDU buffer, or 0 if not able to encode
  */
 int host_n_port_context_encode(
-    uint8_t *apdu, uint8_t tag_number, BACNET_HOST_N_PORT *address)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_HOST_N_PORT *address)
 {
     int len = 0;
     int apdu_len = 0;
@@ -133,7 +133,7 @@ int host_n_port_context_encode(
  * @return length of the APDU buffer decoded, or BACNET_STATUS_REJECT
  */
 int host_n_port_address_decode(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     uint32_t apdu_size,
     BACNET_ERROR_CODE *error_code,
     BACNET_HOST_N_PORT *address)
@@ -226,7 +226,7 @@ int host_n_port_address_decode(
  * @return length of the APDU buffer decoded, or ERROR, REJECT, or ABORT
  */
 int host_n_port_decode(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     uint32_t apdu_size,
     BACNET_ERROR_CODE *error_code,
     BACNET_HOST_N_PORT *address)
@@ -303,7 +303,7 @@ int host_n_port_decode(
  * @return length of the APDU buffer decoded, or ERROR, REJECT, or ABORT
  */
 int host_n_port_context_decode(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     uint32_t apdu_size,
     uint8_t tag_number,
     BACNET_ERROR_CODE *error_code,
@@ -353,7 +353,7 @@ int host_n_port_context_decode(
  * @param src - source structure
  * @return true if successfully copied
  */
-bool host_n_port_copy(BACNET_HOST_N_PORT *dst, BACNET_HOST_N_PORT *src)
+bool host_n_port_copy(BACNET_HOST_N_PORT *dst, const BACNET_HOST_N_PORT *src)
 {
     bool status = false;
 
@@ -380,7 +380,8 @@ bool host_n_port_copy(BACNET_HOST_N_PORT *dst, BACNET_HOST_N_PORT *src)
  * @param host2 - host 2 structure
  * @return true if successfully copied
  */
-bool host_n_port_same(BACNET_HOST_N_PORT *host1, BACNET_HOST_N_PORT *host2)
+bool host_n_port_same(
+    const BACNET_HOST_N_PORT *host1, const BACNET_HOST_N_PORT *host2)
 {
     bool status = false;
 
@@ -454,7 +455,7 @@ bool host_n_port_from_ascii(BACNET_HOST_N_PORT *value, const char *argv)
  * @param entry - BACnet BDT entry
  * @return length of the encoded APDU buffer
  */
-int bacnet_bdt_entry_encode(uint8_t *apdu, BACNET_BDT_ENTRY *entry)
+int bacnet_bdt_entry_encode(uint8_t *apdu, const BACNET_BDT_ENTRY *entry)
 {
     int len = 0;
     int apdu_len = 0;
@@ -496,7 +497,7 @@ int bacnet_bdt_entry_encode(uint8_t *apdu, BACNET_BDT_ENTRY *entry)
  * @return length of the encoded APDU buffer
  */
 int bacnet_bdt_entry_context_encode(
-    uint8_t *apdu, uint8_t tag_number, BACNET_BDT_ENTRY *entry)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_BDT_ENTRY *entry)
 {
     int len = 0;
     int apdu_len = 0;
@@ -520,7 +521,7 @@ int bacnet_bdt_entry_context_encode(
 }
 
 int bacnet_bdt_entry_decode(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     uint32_t apdu_size,
     BACNET_ERROR_CODE *error_code,
     BACNET_BDT_ENTRY *address)
@@ -571,7 +572,7 @@ int bacnet_bdt_entry_decode(
  * @param src - source structure
  * @return true if successfully copied
  */
-bool bacnet_bdt_entry_copy(BACNET_BDT_ENTRY *dst, BACNET_BDT_ENTRY *src)
+bool bacnet_bdt_entry_copy(BACNET_BDT_ENTRY *dst, const BACNET_BDT_ENTRY *src)
 {
     bool status = false;
 
@@ -592,7 +593,8 @@ bool bacnet_bdt_entry_copy(BACNET_BDT_ENTRY *dst, BACNET_BDT_ENTRY *src)
  * @param src - source structure
  * @return true if both are the same
  */
-bool bacnet_bdt_entry_same(BACNET_BDT_ENTRY *dst, BACNET_BDT_ENTRY *src)
+bool bacnet_bdt_entry_same(
+    const BACNET_BDT_ENTRY *dst, const BACNET_BDT_ENTRY *src)
 {
     bool status = false;
 
@@ -729,7 +731,7 @@ bool bacnet_bdt_entry_from_ascii(BACNET_BDT_ENTRY *value, const char *argv)
  * @return length of the ASCII string
  */
 int bacnet_bdt_entry_to_ascii(
-    char *str, size_t str_size, BACNET_BDT_ENTRY *value)
+    char *str, size_t str_size, const BACNET_BDT_ENTRY *value)
 {
     int len = 0;
     int ip_len = 0;
@@ -796,7 +798,7 @@ int bacnet_bdt_entry_to_ascii(
  * @param entry - BACnet FDT entry
  * @return length of the encoded APDU buffer
  */
-int bacnet_fdt_entry_encode(uint8_t *apdu, BACNET_FDT_ENTRY *entry)
+int bacnet_fdt_entry_encode(uint8_t *apdu, const BACNET_FDT_ENTRY *entry)
 {
     int len = 0;
     int apdu_len = 0;
@@ -830,7 +832,7 @@ int bacnet_fdt_entry_encode(uint8_t *apdu, BACNET_FDT_ENTRY *entry)
  * @return length of the encoded APDU buffer
  */
 int bacnet_fdt_entry_context_encode(
-    uint8_t *apdu, uint8_t tag_number, BACNET_FDT_ENTRY *entry)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_FDT_ENTRY *entry)
 {
     int len = 0;
     int apdu_len = 0;
@@ -862,7 +864,7 @@ int bacnet_fdt_entry_context_encode(
  * @return length of the APDU buffer decoded, or BACNET_STATUS_REJECT
  */
 int bacnet_fdt_entry_decode(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     uint32_t apdu_size,
     BACNET_ERROR_CODE *error_code,
     BACNET_FDT_ENTRY *entry)
@@ -922,7 +924,7 @@ int bacnet_fdt_entry_decode(
  * @return length of the APDU buffer decoded, or BACNET_STATUS_REJECT
  */
 int bacnet_fdt_entry_context_decode(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     uint32_t apdu_size,
     uint8_t tag_number,
     BACNET_ERROR_CODE *error_code,
@@ -971,7 +973,7 @@ int bacnet_fdt_entry_context_decode(
  * @param src - source structure
  * @return true if successfully copied
  */
-bool bacnet_fdt_entry_copy(BACNET_FDT_ENTRY *dst, BACNET_FDT_ENTRY *src)
+bool bacnet_fdt_entry_copy(BACNET_FDT_ENTRY *dst, const BACNET_FDT_ENTRY *src)
 {
     bool status = false;
 
@@ -991,7 +993,8 @@ bool bacnet_fdt_entry_copy(BACNET_FDT_ENTRY *dst, BACNET_FDT_ENTRY *src)
  * @param src - source structure
  * @return true if both are the same
  */
-bool bacnet_fdt_entry_same(BACNET_FDT_ENTRY *dst, BACNET_FDT_ENTRY *src)
+bool bacnet_fdt_entry_same(
+    const BACNET_FDT_ENTRY *dst, const BACNET_FDT_ENTRY *src)
 {
     bool status = false;
 
@@ -1119,7 +1122,7 @@ bool bacnet_fdt_entry_from_ascii(BACNET_FDT_ENTRY *value, const char *argv)
  * @return length of the ASCII string
  */
 int bacnet_fdt_entry_to_ascii(
-    char *str, size_t str_size, BACNET_FDT_ENTRY *value)
+    char *str, size_t str_size, const BACNET_FDT_ENTRY *value)
 {
     int len = 0;
     int ip_len = 0;

--- a/src/bacnet/hostnport.h
+++ b/src/bacnet/hostnport.h
@@ -73,28 +73,28 @@ extern "C" {
     BACNET_STACK_EXPORT
     int host_n_port_address_encode(
         uint8_t *apdu,
-        BACNET_HOST_N_PORT *address);
+        const BACNET_HOST_N_PORT *address);
     BACNET_STACK_EXPORT
     int host_n_port_encode(
         uint8_t * apdu,
-        BACNET_HOST_N_PORT *address);
+        const BACNET_HOST_N_PORT *address);
     BACNET_STACK_EXPORT
     int host_n_port_context_encode(
         uint8_t * apdu,
         uint8_t tag_number,
-        BACNET_HOST_N_PORT *address);
+        const BACNET_HOST_N_PORT *address);
     BACNET_STACK_EXPORT
-    int host_n_port_address_decode(uint8_t *apdu,
+    int host_n_port_address_decode(const uint8_t *apdu,
         uint32_t apdu_size,
         BACNET_ERROR_CODE *error_code,
         BACNET_HOST_N_PORT *address);
     BACNET_STACK_EXPORT
-    int host_n_port_decode(uint8_t *apdu,
+    int host_n_port_decode(const uint8_t *apdu,
         uint32_t apdu_len,
         BACNET_ERROR_CODE *error_code,
         BACNET_HOST_N_PORT *address);
     BACNET_STACK_EXPORT
-    int host_n_port_context_decode(uint8_t *apdu,
+    int host_n_port_context_decode(const uint8_t *apdu,
         uint32_t apdu_size,
         uint8_t tag_number,
         BACNET_ERROR_CODE *error_code,
@@ -102,11 +102,11 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool host_n_port_copy(
         BACNET_HOST_N_PORT * dst,
-        BACNET_HOST_N_PORT * src);
+        const BACNET_HOST_N_PORT * src);
     BACNET_STACK_EXPORT
     bool host_n_port_same(
-        BACNET_HOST_N_PORT * dst,
-        BACNET_HOST_N_PORT * src);
+        const BACNET_HOST_N_PORT * dst,
+        const BACNET_HOST_N_PORT * src);
     BACNET_STACK_EXPORT
     bool host_n_port_from_ascii(
         BACNET_HOST_N_PORT *value,
@@ -115,19 +115,19 @@ extern "C" {
     BACNET_STACK_EXPORT
     int bacnet_bdt_entry_encode(
         uint8_t * apdu,
-        BACNET_BDT_ENTRY *entry);
+        const BACNET_BDT_ENTRY *entry);
     BACNET_STACK_EXPORT
     int bacnet_bdt_entry_context_encode(
         uint8_t * apdu,
         uint8_t tag_number,
-        BACNET_BDT_ENTRY *entry);
+        const BACNET_BDT_ENTRY *entry);
     BACNET_STACK_EXPORT
-    int bacnet_bdt_entry_decode(uint8_t *apdu,
+    int bacnet_bdt_entry_decode(const uint8_t *apdu,
         uint32_t apdu_len,
         BACNET_ERROR_CODE *error_code,
         BACNET_BDT_ENTRY *address);
     BACNET_STACK_EXPORT
-    int bacnet_bdt_entry_context_decode(uint8_t *apdu,
+    int bacnet_bdt_entry_context_decode(const uint8_t *apdu,
         uint32_t apdu_size,
         uint8_t tag_number,
         BACNET_ERROR_CODE *error_code,
@@ -135,11 +135,11 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool bacnet_bdt_entry_copy(
         BACNET_BDT_ENTRY * dst,
-        BACNET_BDT_ENTRY * src);
+        const BACNET_BDT_ENTRY * src);
     BACNET_STACK_EXPORT
     bool bacnet_bdt_entry_same(
-        BACNET_BDT_ENTRY * dst,
-        BACNET_BDT_ENTRY * src);
+        const BACNET_BDT_ENTRY * dst,
+        const BACNET_BDT_ENTRY * src);
     BACNET_STACK_EXPORT
     bool bacnet_bdt_entry_from_ascii(
         BACNET_BDT_ENTRY *value,
@@ -147,24 +147,24 @@ extern "C" {
     BACNET_STACK_EXPORT
     int bacnet_bdt_entry_to_ascii(
         char *str, size_t str_size,
-        BACNET_BDT_ENTRY *value);
+        const BACNET_BDT_ENTRY *value);
 
     BACNET_STACK_EXPORT
     int bacnet_fdt_entry_encode(
         uint8_t * apdu,
-        BACNET_FDT_ENTRY *entry);
+        const BACNET_FDT_ENTRY *entry);
     BACNET_STACK_EXPORT
     int bacnet_fdt_entry_context_encode(
         uint8_t * apdu,
         uint8_t tag_number,
-        BACNET_FDT_ENTRY *entry);
+        const BACNET_FDT_ENTRY *entry);
     BACNET_STACK_EXPORT
-    int bacnet_fdt_entry_decode(uint8_t *apdu,
+    int bacnet_fdt_entry_decode(const uint8_t *apdu,
         uint32_t apdu_len,
         BACNET_ERROR_CODE *error_code,
         BACNET_FDT_ENTRY *address);
     BACNET_STACK_EXPORT
-    int bacnet_fdt_entry_context_decode(uint8_t *apdu,
+    int bacnet_fdt_entry_context_decode(const uint8_t *apdu,
         uint32_t apdu_size,
         uint8_t tag_number,
         BACNET_ERROR_CODE *error_code,
@@ -172,11 +172,11 @@ extern "C" {
     BACNET_STACK_EXPORT
     bool bacnet_fdt_entry_copy(
         BACNET_FDT_ENTRY * dst,
-        BACNET_FDT_ENTRY * src);
+        const BACNET_FDT_ENTRY * src);
     BACNET_STACK_EXPORT
     bool bacnet_fdt_entry_same(
-        BACNET_FDT_ENTRY * dst,
-        BACNET_FDT_ENTRY * src);
+        const BACNET_FDT_ENTRY * dst,
+        const BACNET_FDT_ENTRY * src);
     BACNET_STACK_EXPORT
     bool bacnet_fdt_entry_from_ascii(
         BACNET_FDT_ENTRY *value,
@@ -184,7 +184,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     int bacnet_fdt_entry_to_ascii(
         char *str, size_t str_size,
-        BACNET_FDT_ENTRY *value);
+        const BACNET_FDT_ENTRY *value);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/iam.c
+++ b/src/bacnet/iam.c
@@ -64,7 +64,7 @@ int iam_encode_apdu(uint8_t *apdu,
  *
  * @return Total length of the apdu, zero otherwise.
  */
-int iam_decode_service_request(uint8_t *apdu,
+int iam_decode_service_request(const uint8_t *apdu,
     uint32_t *pDevice_id,
     unsigned *pMax_apdu,
     int *pSegmentation,

--- a/src/bacnet/iam.h
+++ b/src/bacnet/iam.h
@@ -30,7 +30,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     int iam_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint32_t * pDevice_id,
         unsigned *pMax_apdu,
         int *pSegmentation,

--- a/src/bacnet/ihave.c
+++ b/src/bacnet/ihave.c
@@ -20,7 +20,7 @@
  *
  * @return Bytes encoded.
  */
-int ihave_encode_apdu(uint8_t *apdu, BACNET_I_HAVE_DATA *data)
+int ihave_encode_apdu(uint8_t *apdu, const BACNET_I_HAVE_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -58,7 +58,7 @@ int ihave_encode_apdu(uint8_t *apdu, BACNET_I_HAVE_DATA *data)
  * @return Bytes decoded.
  */
 int ihave_decode_service_request(
-    uint8_t *apdu, unsigned apdu_len, BACNET_I_HAVE_DATA *data)
+    const uint8_t *apdu, unsigned apdu_len, BACNET_I_HAVE_DATA *data)
 {
     int len = 0;
     uint8_t tag_number = 0;
@@ -115,7 +115,7 @@ int ihave_decode_service_request(
  * @return Bytes decoded.
  */
 int ihave_decode_apdu(
-    uint8_t *apdu, unsigned apdu_len, BACNET_I_HAVE_DATA *data)
+    const uint8_t *apdu, unsigned apdu_len, BACNET_I_HAVE_DATA *data)
 {
     int len = 0;
 

--- a/src/bacnet/ihave.h
+++ b/src/bacnet/ihave.h
@@ -28,17 +28,17 @@ extern "C" {
     BACNET_STACK_EXPORT
     int ihave_encode_apdu(
         uint8_t * apdu,
-        BACNET_I_HAVE_DATA * data);
+        const BACNET_I_HAVE_DATA * data);
 
     BACNET_STACK_EXPORT
     int ihave_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_I_HAVE_DATA * data);
 
     BACNET_STACK_EXPORT
     int ihave_decode_apdu(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_I_HAVE_DATA * data);
 

--- a/src/bacnet/indtext.c
+++ b/src/bacnet/indtext.c
@@ -23,8 +23,8 @@ int indtext_stricmp(const char *a, const char *b)
     int twin_a, twin_b;
 
     do {
-        twin_a = *(unsigned char *)a;
-        twin_b = *(unsigned char *)b;
+        twin_a = *(const unsigned char *)a;
+        twin_b = *(const unsigned char *)b;
         twin_a = tolower(toupper(twin_a));
         twin_b = tolower(toupper(twin_b));
         a++;

--- a/src/bacnet/lighting.c
+++ b/src/bacnet/lighting.c
@@ -38,7 +38,7 @@
  *
  * @return  number of bytes encoded
  */
-int lighting_command_encode(uint8_t *apdu, BACNET_LIGHTING_COMMAND *data)
+int lighting_command_encode(uint8_t *apdu, const BACNET_LIGHTING_COMMAND *data)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
     int len = 0; /* total length of the apdu, return value */
@@ -113,7 +113,7 @@ int lighting_command_encode(uint8_t *apdu, BACNET_LIGHTING_COMMAND *data)
  * @return  number of bytes encoded, or 0 if unable to encode.
  */
 int lighting_command_encode_context(
-    uint8_t *apdu, uint8_t tag_number, BACNET_LIGHTING_COMMAND *value)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_LIGHTING_COMMAND *value)
 {
     int apdu_len = 0;
     uint8_t *apdu_offset = NULL;
@@ -153,7 +153,7 @@ int lighting_command_encode_context(
  * @return  number of bytes decoded, or BACNET_STATUS_ERROR
  */
 int lighting_command_decode(
-    uint8_t *apdu, unsigned apdu_size, BACNET_LIGHTING_COMMAND *data)
+    const uint8_t *apdu, unsigned apdu_size, BACNET_LIGHTING_COMMAND *data)
 {
     int len = 0;
     int apdu_len = 0;
@@ -387,7 +387,7 @@ int lighting_command_decode(
  * @return  true if copy succeeded
  */
 bool lighting_command_copy(
-    BACNET_LIGHTING_COMMAND *dst, BACNET_LIGHTING_COMMAND *src)
+    BACNET_LIGHTING_COMMAND *dst, const BACNET_LIGHTING_COMMAND *src)
 {
     bool status = false;
 
@@ -418,7 +418,7 @@ bool lighting_command_copy(
  * @return  true if lighting-commands are the same for values in-use
  */
 bool lighting_command_same(
-    BACNET_LIGHTING_COMMAND *dst, BACNET_LIGHTING_COMMAND *src)
+    const BACNET_LIGHTING_COMMAND *dst, const BACNET_LIGHTING_COMMAND *src)
 {
     bool status = false;
 
@@ -741,7 +741,7 @@ bool lighting_command_from_ascii(
  * @param value - BACnetxyColor structure
  * @return length of the encoded APDU buffer
  */
-int xy_color_encode(uint8_t *apdu, BACNET_XY_COLOR *value)
+int xy_color_encode(uint8_t *apdu, const BACNET_XY_COLOR *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -769,7 +769,7 @@ int xy_color_encode(uint8_t *apdu, BACNET_XY_COLOR *value)
  * @return length of the APDU buffer, or 0 if not able to encode
  */
 int xy_color_context_encode(
-    uint8_t *apdu, uint8_t tag_number, BACNET_XY_COLOR *value)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_XY_COLOR *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -803,7 +803,7 @@ int xy_color_context_encode(
  *
  * @return the number of apdu bytes consumed, or BACNET_STATUS_ERROR
  */
-int xy_color_decode(uint8_t *apdu, uint32_t apdu_size, BACNET_XY_COLOR *value)
+int xy_color_decode(const uint8_t *apdu, uint32_t apdu_size, BACNET_XY_COLOR *value)
 {
     float real_value;
     int len = 0;
@@ -844,7 +844,7 @@ int xy_color_decode(uint8_t *apdu, uint32_t apdu_size, BACNET_XY_COLOR *value)
  *
  * @return the number of apdu bytes consumed, or BACNET_STATUS_ERROR
  */
-int xy_color_context_decode(uint8_t *apdu,
+int xy_color_context_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     uint8_t tag_number,
     BACNET_XY_COLOR *value)
@@ -897,7 +897,7 @@ void xy_color_set(BACNET_XY_COLOR *dst, float x, float y)
  * @param src - source BACNET_XY_COLOR structure
  * @return true if successfully copied
  */
-int xy_color_copy(BACNET_XY_COLOR *dst, BACNET_XY_COLOR *src)
+int xy_color_copy(BACNET_XY_COLOR *dst, const BACNET_XY_COLOR *src)
 {
     bool status = false;
 
@@ -916,7 +916,8 @@ int xy_color_copy(BACNET_XY_COLOR *dst, BACNET_XY_COLOR *src)
  * @param value2 - BACNET_XY_COLOR structure
  * @return true if the same
  */
-bool xy_color_same(BACNET_XY_COLOR *value1, BACNET_XY_COLOR *value2)
+bool xy_color_same(
+    const BACNET_XY_COLOR *value1, const BACNET_XY_COLOR *value2)
 {
     bool status = false;
 
@@ -1002,7 +1003,7 @@ bool xy_color_from_ascii(BACNET_XY_COLOR *value, const char *argv)
  * @param value - BACnetColorCommand structure
  * @return length of the encoded APDU buffer
  */
-int color_command_encode(uint8_t *apdu, BACNET_COLOR_COMMAND *value)
+int color_command_encode(uint8_t *apdu, const BACNET_COLOR_COMMAND *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -1095,7 +1096,7 @@ int color_command_encode(uint8_t *apdu, BACNET_COLOR_COMMAND *value)
  * @return length of the APDU buffer, or 0 if not able to encode
  */
 int color_command_context_encode(
-    uint8_t *apdu, uint8_t tag_number, BACNET_COLOR_COMMAND *value)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_COLOR_COMMAND *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -1135,7 +1136,7 @@ int color_command_context_encode(
  * @param value - BACnetColorCommand structure values
  * @return length of the APDU buffer decoded, or ERROR, REJECT, or ABORT
  */
-int color_command_decode(uint8_t *apdu,
+int color_command_decode(const uint8_t *apdu,
     uint16_t apdu_size,
     BACNET_ERROR_CODE *error_code,
     BACNET_COLOR_COMMAND *value)
@@ -1405,7 +1406,7 @@ int color_command_decode(uint8_t *apdu,
  * @param src - source structure
  * @return true if successfully copied
  */
-bool color_command_copy(BACNET_COLOR_COMMAND *dst, BACNET_COLOR_COMMAND *src)
+bool color_command_copy(BACNET_COLOR_COMMAND *dst, const BACNET_COLOR_COMMAND *src)
 {
     bool status = false;
 
@@ -1424,7 +1425,7 @@ bool color_command_copy(BACNET_COLOR_COMMAND *dst, BACNET_COLOR_COMMAND *src)
  * @return true if the same
  */
 bool color_command_same(
-    BACNET_COLOR_COMMAND *value1, BACNET_COLOR_COMMAND *value2)
+    const BACNET_COLOR_COMMAND *value1, const BACNET_COLOR_COMMAND *value2)
 {
     bool status = false;
 

--- a/src/bacnet/lighting.h
+++ b/src/bacnet/lighting.h
@@ -91,25 +91,25 @@ extern "C" {
     BACNET_STACK_EXPORT
     int lighting_command_encode(
         uint8_t * apdu,
-        BACNET_LIGHTING_COMMAND * data);
+        const BACNET_LIGHTING_COMMAND * data);
     BACNET_STACK_EXPORT
     int lighting_command_encode_context(
         uint8_t * apdu,
         uint8_t tag_number,
-        BACNET_LIGHTING_COMMAND * value);
+        const BACNET_LIGHTING_COMMAND * value);
     BACNET_STACK_EXPORT
     int lighting_command_decode(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_max_len,
         BACNET_LIGHTING_COMMAND * data);
     BACNET_STACK_EXPORT
     bool lighting_command_copy(
         BACNET_LIGHTING_COMMAND * dst,
-        BACNET_LIGHTING_COMMAND * src);
+        const BACNET_LIGHTING_COMMAND * src);
     BACNET_STACK_EXPORT
     bool lighting_command_same(
-        BACNET_LIGHTING_COMMAND * dst,
-        BACNET_LIGHTING_COMMAND * src);
+        const BACNET_LIGHTING_COMMAND * dst,
+        const BACNET_LIGHTING_COMMAND * src);
 
     BACNET_STACK_EXPORT
     bool lighting_command_from_ascii(
@@ -123,31 +123,31 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     int xy_color_encode(uint8_t *apdu,
-        BACNET_XY_COLOR *value);
+        const BACNET_XY_COLOR *value);
     BACNET_STACK_EXPORT
     int xy_color_context_encode(
         uint8_t * apdu,
         uint8_t tag_number,
-        BACNET_XY_COLOR *value);
+        const BACNET_XY_COLOR *value);
     BACNET_STACK_EXPORT
     int xy_color_decode(
-        uint8_t *apdu,
+        const uint8_t *apdu,
         uint32_t apdu_size,
         BACNET_XY_COLOR *value);
     BACNET_STACK_EXPORT
     int xy_color_context_decode(
-        uint8_t *apdu,
+        const uint8_t *apdu,
         uint32_t apdu_size,
         uint8_t tag_number,
         BACNET_XY_COLOR *value);
     BACNET_STACK_EXPORT
     int xy_color_copy(
         BACNET_XY_COLOR *dst,
-        BACNET_XY_COLOR *src);
+        const BACNET_XY_COLOR *src);
     BACNET_STACK_EXPORT
     bool xy_color_same(
-        BACNET_XY_COLOR *value1,
-        BACNET_XY_COLOR *value2);
+        const BACNET_XY_COLOR *value1,
+        const BACNET_XY_COLOR *value2);
     BACNET_STACK_EXPORT
     void xy_color_set(
         BACNET_XY_COLOR *dst,
@@ -166,25 +166,25 @@ extern "C" {
     BACNET_STACK_EXPORT
     int color_command_encode(
         uint8_t * apdu,
-        BACNET_COLOR_COMMAND *address);
+        const BACNET_COLOR_COMMAND *address);
     BACNET_STACK_EXPORT
     int color_command_context_encode(
         uint8_t * apdu,
         uint8_t tag_number,
-        BACNET_COLOR_COMMAND *address);
+        const BACNET_COLOR_COMMAND *address);
     BACNET_STACK_EXPORT
-    int color_command_decode(uint8_t *apdu,
+    int color_command_decode(const uint8_t *apdu,
         uint16_t apdu_len,
         BACNET_ERROR_CODE *error_code,
         BACNET_COLOR_COMMAND *address);
     BACNET_STACK_EXPORT
     bool color_command_copy(
         BACNET_COLOR_COMMAND * dst,
-        BACNET_COLOR_COMMAND * src);
+        const BACNET_COLOR_COMMAND * src);
     BACNET_STACK_EXPORT
     bool color_command_same(
-        BACNET_COLOR_COMMAND * dst,
-        BACNET_COLOR_COMMAND * src);
+        const BACNET_COLOR_COMMAND * dst,
+        const BACNET_COLOR_COMMAND * src);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/list_element.c
+++ b/src/bacnet/list_element.c
@@ -38,7 +38,7 @@
  * @return Bytes encoded or zero on error.
  */
 int list_element_encode_service_request(
-    uint8_t *apdu, BACNET_LIST_ELEMENT_DATA *list_element)
+    uint8_t *apdu, const BACNET_LIST_ELEMENT_DATA *list_element)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -90,7 +90,7 @@ int list_element_encode_service_request(
  * @return number of bytes encoded, or zero if unable to encode or too large
  */
 size_t list_element_service_request_encode(
-    uint8_t *apdu, size_t apdu_size, BACNET_LIST_ELEMENT_DATA *data)
+    uint8_t *apdu, size_t apdu_size, const BACNET_LIST_ELEMENT_DATA *data)
 {
     size_t apdu_len = 0; /* total length of the apdu, return value */
 
@@ -260,7 +260,7 @@ int list_element_decode_service_request(
  * @return Bytes encoded or zero on error.
  */
 int list_element_error_ack_encode(
-    uint8_t *apdu, BACNET_LIST_ELEMENT_DATA *list_element)
+    uint8_t *apdu, const BACNET_LIST_ELEMENT_DATA *list_element)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -309,7 +309,9 @@ int list_element_error_ack_encode(
  * @return Bytes encoded or zero on error.
  */
 int list_element_error_ack_decode(
-    uint8_t *apdu, uint16_t apdu_size, BACNET_LIST_ELEMENT_DATA *list_element)
+    const uint8_t *apdu,
+    uint16_t apdu_size,
+    BACNET_LIST_ELEMENT_DATA *list_element)
 {
     int len = 0, apdu_len = 0;
     BACNET_ERROR_CLASS error_class = ERROR_CLASS_SERVICES;

--- a/src/bacnet/list_element.h
+++ b/src/bacnet/list_element.h
@@ -61,19 +61,25 @@ extern "C" {
 
 BACNET_STACK_EXPORT
 int list_element_encode_service_request(
-    uint8_t *apdu, BACNET_LIST_ELEMENT_DATA *list_element);
+    uint8_t *apdu, const BACNET_LIST_ELEMENT_DATA *list_element);
 BACNET_STACK_EXPORT
 size_t list_element_service_request_encode(
-    uint8_t *apdu, size_t apdu_size, BACNET_LIST_ELEMENT_DATA *list_element);
+    uint8_t *apdu,
+    size_t apdu_size,
+    const BACNET_LIST_ELEMENT_DATA *list_element);
 BACNET_STACK_EXPORT
 int list_element_decode_service_request(
-    uint8_t *apdu, unsigned apdu_len, BACNET_LIST_ELEMENT_DATA *list_element);
+    uint8_t *apdu,
+    unsigned apdu_len,
+    BACNET_LIST_ELEMENT_DATA *list_element);
 BACNET_STACK_EXPORT
 int list_element_error_ack_encode(
-    uint8_t *apdu, BACNET_LIST_ELEMENT_DATA *list_element);
+    uint8_t *apdu, const BACNET_LIST_ELEMENT_DATA *list_element);
 BACNET_STACK_EXPORT
 int list_element_error_ack_decode(
-    uint8_t *apdu, uint16_t apdu_size, BACNET_LIST_ELEMENT_DATA *list_element);
+    const uint8_t *apdu,
+    uint16_t apdu_size,
+    BACNET_LIST_ELEMENT_DATA *list_element);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/lso.c
+++ b/src/bacnet/lso.c
@@ -17,7 +17,7 @@
  * @param data  Pointer to the data to encode.
  * @return number of bytes encoded, or zero on error.
  */
-int life_safety_operation_encode(uint8_t *apdu, BACNET_LSO_DATA *data)
+int life_safety_operation_encode(uint8_t *apdu, const BACNET_LSO_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -60,7 +60,8 @@ int life_safety_operation_encode(uint8_t *apdu, BACNET_LSO_DATA *data)
  * @param data  Pointer to the data to encode.
  * @return number of bytes encoded, or zero on error.
  */
-int lso_encode_apdu(uint8_t *apdu, uint8_t invoke_id, BACNET_LSO_DATA *data)
+int lso_encode_apdu(
+    uint8_t *apdu, uint8_t invoke_id, const BACNET_LSO_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -94,7 +95,7 @@ int lso_encode_apdu(uint8_t *apdu, uint8_t invoke_id, BACNET_LSO_DATA *data)
  * @return number of bytes encoded, or zero if unable to encode or too large
  */
 size_t life_safety_operation_request_encode(
-    uint8_t *apdu, size_t apdu_size, BACNET_LSO_DATA *data)
+    uint8_t *apdu, size_t apdu_size, const BACNET_LSO_DATA *data)
 {
     size_t apdu_len = 0;
 
@@ -109,7 +110,7 @@ size_t life_safety_operation_request_encode(
 }
 
 int lso_decode_service_request(
-    uint8_t *apdu, unsigned apdu_len, BACNET_LSO_DATA *data)
+    const uint8_t *apdu, unsigned apdu_len, BACNET_LSO_DATA *data)
 {
     int len = 0; /* return value */
     int section_length = 0; /* length returned from decoding */

--- a/src/bacnet/lso.h
+++ b/src/bacnet/lso.h
@@ -32,22 +32,22 @@ extern "C" {
     int lso_encode_apdu(
         uint8_t * apdu,
         uint8_t invoke_id,
-        BACNET_LSO_DATA * data);
+        const BACNET_LSO_DATA * data);
 
     BACNET_STACK_EXPORT
     int life_safety_operation_encode(
         uint8_t *apdu,
-        BACNET_LSO_DATA *data);
+        const BACNET_LSO_DATA *data);
 
     BACNET_STACK_EXPORT
     size_t life_safety_operation_request_encode(
         uint8_t *apdu,
         size_t apdu_size,
-        BACNET_LSO_DATA *data);
+        const BACNET_LSO_DATA *data);
 
     BACNET_STACK_EXPORT
     int lso_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_LSO_DATA * data);
 

--- a/src/bacnet/memcopy.c
+++ b/src/bacnet/memcopy.c
@@ -77,7 +77,7 @@ size_t memcopy(void *dest, void *src, size_t offset, size_t len, size_t max)
  * the number of bytes copied.
  */
 size_t memcopy(void *dest,
-    void *src,
+    const void *src,
     size_t offset, /* where in dest to put the data */
     size_t len, /* amount of data to copy */
     size_t max)

--- a/src/bacnet/memcopy.h
+++ b/src/bacnet/memcopy.h
@@ -22,7 +22,7 @@ extern "C" {
         size_t len);
     size_t memcopy(
         void *dest,
-        void *src,
+        const void *src,
         size_t offset,
         size_t len,
         size_t max);

--- a/src/bacnet/npdu.c
+++ b/src/bacnet/npdu.c
@@ -19,7 +19,7 @@
  * @param dest [out] The 'to' structure
  * @param src   [in] The 'from' structure
  */
-void npdu_copy_data(BACNET_NPDU_DATA *dest, BACNET_NPDU_DATA *src)
+void npdu_copy_data(BACNET_NPDU_DATA *dest, const BACNET_NPDU_DATA *src)
 {
     if (dest && src) {
         dest->protocol_version = src->protocol_version;
@@ -98,7 +98,7 @@ ABORT.indication               Yes         Yes         Yes        No
 int npdu_encode_pdu(uint8_t *npdu,
     BACNET_ADDRESS *dest,
     BACNET_ADDRESS *src,
-    BACNET_NPDU_DATA *npdu_data)
+    const BACNET_NPDU_DATA *npdu_data)
 {
     int len = 0; /* return value - number of octets loaded in this function */
     uint8_t i = 0; /* counter  */
@@ -263,7 +263,7 @@ int bacnet_npdu_encode_pdu(uint8_t *pdu,
     uint16_t pdu_size,
     BACNET_ADDRESS *dest,
     BACNET_ADDRESS *src,
-    BACNET_NPDU_DATA *npdu_data)
+    const BACNET_NPDU_DATA *npdu_data)
 {
     int pdu_len = 0;
 
@@ -389,7 +389,7 @@ void npdu_encode_npdu_network(BACNET_NPDU_DATA *npdu_data,
  * be more bytes left in the NPDU; if not a network msg, the APDU follows. If 0
  * or negative, there were problems with the data or arguments.
  */
-int npdu_decode(uint8_t *npdu,
+int npdu_decode(const uint8_t *npdu,
     BACNET_ADDRESS *dest,
     BACNET_ADDRESS *src,
     BACNET_NPDU_DATA *npdu_data)
@@ -421,7 +421,7 @@ int npdu_decode(uint8_t *npdu,
  * be more bytes left in the NPDU; if not a network msg, the APDU follows. If 0
  * or negative, there were problems with the data or arguments.
  */
-int bacnet_npdu_decode(uint8_t *npdu,
+int bacnet_npdu_decode(const uint8_t *npdu,
     uint16_t pdu_len,
     BACNET_ADDRESS *dest,
     BACNET_ADDRESS *src,
@@ -587,7 +587,7 @@ int bacnet_npdu_decode(uint8_t *npdu,
  * @param pdu_len [in] The size of the received message in the pdu[] buffer.
  * @return true if the PDU is a confirmed APDU
  */
-bool npdu_confirmed_service(uint8_t *pdu, uint16_t pdu_len)
+bool npdu_confirmed_service(const uint8_t *pdu, uint16_t pdu_len)
 {
     bool status = false;
     int apdu_offset = 0;

--- a/src/bacnet/npdu.h
+++ b/src/bacnet/npdu.h
@@ -71,7 +71,7 @@ extern "C" {
         uint8_t * npdu,
         BACNET_ADDRESS * dest,
         BACNET_ADDRESS * src,
-        BACNET_NPDU_DATA * npdu_data);
+        const BACNET_NPDU_DATA * npdu_data);
 
     BACNET_STACK_EXPORT
     int bacnet_npdu_encode_pdu(
@@ -79,7 +79,7 @@ extern "C" {
         uint16_t pdu_size,
         BACNET_ADDRESS * dest,
         BACNET_ADDRESS * src,
-        BACNET_NPDU_DATA * npdu_data);
+        const BACNET_NPDU_DATA * npdu_data);
 
     BACNET_STACK_EXPORT
     void npdu_encode_npdu_data(
@@ -97,19 +97,19 @@ extern "C" {
     BACNET_STACK_EXPORT
     void npdu_copy_data(
         BACNET_NPDU_DATA * dest,
-        BACNET_NPDU_DATA * src);
+        const BACNET_NPDU_DATA * src);
 
     BACNET_STACK_DEPRECATED("Use bacnet_npdu_decode() instead")
     BACNET_STACK_EXPORT
     int npdu_decode(
-        uint8_t * npdu,
+        const uint8_t * npdu,
         BACNET_ADDRESS * dest,
         BACNET_ADDRESS * src,
         BACNET_NPDU_DATA * npdu_data);
 
     BACNET_STACK_EXPORT
     int bacnet_npdu_decode(
-        uint8_t * npdu,
+        const uint8_t * npdu,
         uint16_t pdu_len,
         BACNET_ADDRESS * dest,
         BACNET_ADDRESS * src,
@@ -117,7 +117,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     bool npdu_confirmed_service(
-        uint8_t *pdu,
+        const uint8_t *pdu,
         uint16_t pdu_len);
 
 #ifdef __cplusplus

--- a/src/bacnet/ptransfer.c
+++ b/src/bacnet/ptransfer.c
@@ -15,7 +15,7 @@
 /* encode service */
 static int pt_encode_apdu(uint8_t *apdu,
     uint16_t max_apdu,
-    BACNET_PRIVATE_TRANSFER_DATA *private_data)
+    const BACNET_PRIVATE_TRANSFER_DATA *private_data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -50,7 +50,7 @@ static int pt_encode_apdu(uint8_t *apdu,
 
 int ptransfer_encode_apdu(uint8_t *apdu,
     uint8_t invoke_id,
-    BACNET_PRIVATE_TRANSFER_DATA *private_data)
+    const BACNET_PRIVATE_TRANSFER_DATA *private_data)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
     int len = 0;
@@ -70,7 +70,7 @@ int ptransfer_encode_apdu(uint8_t *apdu,
 }
 
 int uptransfer_encode_apdu(
-    uint8_t *apdu, BACNET_PRIVATE_TRANSFER_DATA *private_data)
+    uint8_t *apdu, const BACNET_PRIVATE_TRANSFER_DATA *private_data)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
     int len = 0;
@@ -134,7 +134,7 @@ int ptransfer_error_encode_apdu(uint8_t *apdu,
     uint8_t invoke_id,
     BACNET_ERROR_CLASS error_class,
     BACNET_ERROR_CODE error_code,
-    BACNET_PRIVATE_TRANSFER_DATA *private_data)
+    const BACNET_PRIVATE_TRANSFER_DATA *private_data)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
     int len = 0; /* length of the part of the encoding */
@@ -266,7 +266,7 @@ int ptransfer_error_decode_service_request(uint8_t *apdu,
 
 int ptransfer_ack_encode_apdu(uint8_t *apdu,
     uint8_t invoke_id,
-    BACNET_PRIVATE_TRANSFER_DATA *private_data)
+    const BACNET_PRIVATE_TRANSFER_DATA *private_data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */

--- a/src/bacnet/ptransfer.h
+++ b/src/bacnet/ptransfer.h
@@ -28,11 +28,11 @@ extern "C" {
     int ptransfer_encode_apdu(
         uint8_t * apdu,
         uint8_t invoke_id,
-        BACNET_PRIVATE_TRANSFER_DATA * private_data);
+        const BACNET_PRIVATE_TRANSFER_DATA * private_data);
     BACNET_STACK_EXPORT
     int uptransfer_encode_apdu(
         uint8_t * apdu,
-        BACNET_PRIVATE_TRANSFER_DATA * private_data);
+        const BACNET_PRIVATE_TRANSFER_DATA * private_data);
     BACNET_STACK_EXPORT
     int ptransfer_decode_service_request(
         uint8_t * apdu,
@@ -45,7 +45,7 @@ extern "C" {
         uint8_t invoke_id,
         BACNET_ERROR_CLASS error_class,
         BACNET_ERROR_CODE error_code,
-        BACNET_PRIVATE_TRANSFER_DATA * private_data);
+        const BACNET_PRIVATE_TRANSFER_DATA * private_data);
     BACNET_STACK_EXPORT
     int ptransfer_error_decode_service_request(
         uint8_t * apdu,
@@ -58,7 +58,7 @@ extern "C" {
     int ptransfer_ack_encode_apdu(
         uint8_t * apdu,
         uint8_t invoke_id,
-        BACNET_PRIVATE_TRANSFER_DATA * private_data);
+        const BACNET_PRIVATE_TRANSFER_DATA * private_data);
 /* ptransfer_ack_decode_service_request() is the same as
        ptransfer_decode_service_request */
 

--- a/src/bacnet/rd.c
+++ b/src/bacnet/rd.c
@@ -37,7 +37,7 @@
  */
 int reinitialize_device_encode(uint8_t *apdu,
     BACNET_REINITIALIZED_STATE state,
-    BACNET_CHARACTER_STRING *password)
+    const BACNET_CHARACTER_STRING *password)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -70,7 +70,7 @@ int reinitialize_device_encode(uint8_t *apdu,
 size_t reinitialize_device_request_encode(uint8_t *apdu,
     size_t apdu_size,
     BACNET_REINITIALIZED_STATE state,
-    BACNET_CHARACTER_STRING *password)
+    const BACNET_CHARACTER_STRING *password)
 {
     size_t apdu_len = 0; /* total length of the apdu, return value */
 
@@ -96,7 +96,7 @@ size_t reinitialize_device_request_encode(uint8_t *apdu,
 int rd_encode_apdu(uint8_t *apdu,
     uint8_t invoke_id,
     BACNET_REINITIALIZED_STATE state,
-    BACNET_CHARACTER_STRING *password)
+    const BACNET_CHARACTER_STRING *password)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -143,7 +143,7 @@ int rd_encode_apdu(uint8_t *apdu,
  *
  * @return number of bytes decoded, or #BACNET_STATUS_ERROR if malformed
  */
-int rd_decode_service_request(uint8_t *apdu,
+int rd_decode_service_request(const uint8_t *apdu,
     unsigned apdu_size,
     BACNET_REINITIALIZED_STATE *state,
     BACNET_CHARACTER_STRING *password)

--- a/src/bacnet/rd.h
+++ b/src/bacnet/rd.h
@@ -34,23 +34,23 @@ extern "C" {
         uint8_t * apdu,
         uint8_t invoke_id,
         BACNET_REINITIALIZED_STATE state,
-        BACNET_CHARACTER_STRING * password);
+        const BACNET_CHARACTER_STRING * password);
 
     BACNET_STACK_EXPORT
     int reinitialize_device_encode(uint8_t *apdu,
         BACNET_REINITIALIZED_STATE state,
-        BACNET_CHARACTER_STRING *password);
+        const BACNET_CHARACTER_STRING *password);
 
     BACNET_STACK_EXPORT
     size_t reinitialize_device_request_encode(
         uint8_t *apdu, size_t apdu_size,
         BACNET_REINITIALIZED_STATE state,
-        BACNET_CHARACTER_STRING *password);
+        const BACNET_CHARACTER_STRING *password);
 
 /* decode the service request only */
     BACNET_STACK_EXPORT
     int rd_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_REINITIALIZED_STATE * state,
         BACNET_CHARACTER_STRING * password);

--- a/src/bacnet/readrange.c
+++ b/src/bacnet/readrange.c
@@ -43,7 +43,7 @@
  * @param data  Pointer to the data to encode.
  * @return number of bytes encoded, or zero on error.
  */
-int read_range_encode(uint8_t *apdu, BACNET_READ_RANGE_DATA *data)
+int read_range_encode(uint8_t *apdu, const BACNET_READ_RANGE_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -156,7 +156,7 @@ int read_range_encode(uint8_t *apdu, BACNET_READ_RANGE_DATA *data)
  * @return number of bytes encoded, or zero if unable to encode or too large
  */
 size_t read_range_request_encode(
-    uint8_t *apdu, size_t apdu_size, BACNET_READ_RANGE_DATA *data)
+    uint8_t *apdu, size_t apdu_size, const BACNET_READ_RANGE_DATA *data)
 {
     size_t apdu_len = 0; /* total length of the apdu, return value */
 
@@ -180,7 +180,7 @@ size_t read_range_request_encode(
  *  @return Bytes encoded.
  */
 int rr_encode_apdu(
-    uint8_t *apdu, uint8_t invoke_id, BACNET_READ_RANGE_DATA *data)
+    uint8_t *apdu, uint8_t invoke_id, const BACNET_READ_RANGE_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -212,7 +212,7 @@ int rr_encode_apdu(
  *  @return Bytes encoded.
  */
 int rr_decode_service_request(
-    uint8_t *apdu, unsigned apdu_len, BACNET_READ_RANGE_DATA *rrdata)
+    const uint8_t *apdu, unsigned apdu_len, BACNET_READ_RANGE_DATA *rrdata)
 {
     unsigned len = 0;
     unsigned TagLen = 0;
@@ -414,7 +414,7 @@ int rr_decode_service_request(
  * @return The count of encoded bytes.
  */
 int rr_ack_encode_apdu(
-    uint8_t *apdu, uint8_t invoke_id, BACNET_READ_RANGE_DATA *rrdata)
+    uint8_t *apdu, uint8_t invoke_id, const BACNET_READ_RANGE_DATA *rrdata)
 {
     int imax = 0;
     int len = 0; /* length of each encoding */

--- a/src/bacnet/readrange.h
+++ b/src/bacnet/readrange.h
@@ -122,21 +122,21 @@ extern "C" {
     int rr_encode_apdu(
         uint8_t * apdu,
         uint8_t invoke_id,
-        BACNET_READ_RANGE_DATA * rrdata);
+        const BACNET_READ_RANGE_DATA * rrdata);
 
     BACNET_STACK_EXPORT
     int read_range_encode(
         uint8_t *apdu,
-        BACNET_READ_RANGE_DATA *data);
+        const BACNET_READ_RANGE_DATA *data);
     BACNET_STACK_EXPORT
     size_t read_range_request_encode(
         uint8_t *apdu,
         size_t apdu_size,
-        BACNET_READ_RANGE_DATA *data);
+        const BACNET_READ_RANGE_DATA *data);
 
     BACNET_STACK_EXPORT
     int rr_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_READ_RANGE_DATA * rrdata);
 
@@ -144,7 +144,7 @@ extern "C" {
     int rr_ack_encode_apdu(
         uint8_t * apdu,
         uint8_t invoke_id,
-        BACNET_READ_RANGE_DATA * rrdata);
+        const BACNET_READ_RANGE_DATA * rrdata);
 
     BACNET_STACK_EXPORT
     int rr_ack_decode_service_request(

--- a/src/bacnet/reject.c
+++ b/src/bacnet/reject.c
@@ -186,7 +186,7 @@ int reject_encode_apdu(uint8_t *apdu, uint8_t invoke_id, uint8_t reject_reason)
  *
  * @return Bytes encoded, typically 3.
  */
-int reject_decode_service_request(uint8_t *apdu,
+int reject_decode_service_request(const uint8_t *apdu,
     unsigned apdu_len,
     uint8_t *invoke_id,
     uint8_t *reject_reason)

--- a/src/bacnet/reject.h
+++ b/src/bacnet/reject.h
@@ -35,7 +35,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     int reject_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         uint8_t * invoke_id,
         uint8_t * reject_reason);

--- a/src/bacnet/rp.c
+++ b/src/bacnet/rp.c
@@ -29,7 +29,8 @@
  * @param data  Pointer to the data to encode.
  * @return number of bytes encoded, or zero on error.
  */
-int read_property_request_encode(uint8_t *apdu, BACNET_READ_PROPERTY_DATA *data)
+int read_property_request_encode(
+    uint8_t *apdu, const BACNET_READ_PROPERTY_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -71,7 +72,7 @@ int read_property_request_encode(uint8_t *apdu, BACNET_READ_PROPERTY_DATA *data)
  * @return number of bytes encoded, or zero if unable to encode or too large
  */
 size_t read_property_request_service_encode(
-    uint8_t *apdu, size_t apdu_size, BACNET_READ_PROPERTY_DATA *data)
+    uint8_t *apdu, size_t apdu_size, const BACNET_READ_PROPERTY_DATA *data)
 {
     size_t apdu_len = 0; /* total length of the apdu, return value */
 
@@ -94,7 +95,7 @@ size_t read_property_request_service_encode(
  * @return Bytes encoded or zero on error.
  */
 int rp_encode_apdu(
-    uint8_t *apdu, uint8_t invoke_id, BACNET_READ_PROPERTY_DATA *data)
+    uint8_t *apdu, uint8_t invoke_id, const BACNET_READ_PROPERTY_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -126,7 +127,7 @@ int rp_encode_apdu(
  * @return number of bytes decoded, or #BACNET_STATUS_REJECT
  */
 int rp_decode_service_request(
-    uint8_t *apdu, unsigned apdu_size, BACNET_READ_PROPERTY_DATA *data)
+    const uint8_t *apdu, unsigned apdu_size, BACNET_READ_PROPERTY_DATA *data)
 {
     int len = 0;
     int apdu_len = 0;
@@ -218,7 +219,8 @@ int rp_decode_service_request(
  * @param data  Pointer to the data to encode.
  * @return number of bytes encoded, or zero on error.
  */
-int read_property_ack_encode(uint8_t *apdu, BACNET_READ_PROPERTY_DATA *data)
+int read_property_ack_encode(
+    uint8_t *apdu, const BACNET_READ_PROPERTY_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -274,7 +276,7 @@ int read_property_ack_encode(uint8_t *apdu, BACNET_READ_PROPERTY_DATA *data)
  * @return number of bytes encoded, or zero if unable to encode or too large
  */
 size_t read_property_ack_service_encode(
-    uint8_t *apdu, size_t apdu_size, BACNET_READ_PROPERTY_DATA *data)
+    uint8_t *apdu, size_t apdu_size, const BACNET_READ_PROPERTY_DATA *data)
 {
     size_t apdu_len = 0; /* total length of the apdu, return value */
 
@@ -297,7 +299,7 @@ size_t read_property_ack_service_encode(
  * @return Bytes decoded or zero on error.
  */
 int rp_ack_encode_apdu_init(
-    uint8_t *apdu, uint8_t invoke_id, BACNET_READ_PROPERTY_DATA *rpdata)
+    uint8_t *apdu, uint8_t invoke_id, const BACNET_READ_PROPERTY_DATA *rpdata)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -367,7 +369,7 @@ int rp_ack_encode_apdu_object_property_end(uint8_t *apdu)
  * @return Bytes encoded or zero on error.
  */
 int rp_ack_encode_apdu(
-    uint8_t *apdu, uint8_t invoke_id, BACNET_READ_PROPERTY_DATA *rpdata)
+    uint8_t *apdu, uint8_t invoke_id, const BACNET_READ_PROPERTY_DATA *rpdata)
 {
     int imax = 0;
     int len = 0; /* length of each encoding */

--- a/src/bacnet/rp.h
+++ b/src/bacnet/rp.h
@@ -56,35 +56,35 @@ extern "C" {
     BACNET_STACK_EXPORT
     int read_property_request_encode(
         uint8_t *apdu,
-        BACNET_READ_PROPERTY_DATA *data);
+        const BACNET_READ_PROPERTY_DATA *data);
 
     BACNET_STACK_EXPORT
     size_t read_property_request_service_encode(
         uint8_t *apdu,
         size_t apdu_size,
-        BACNET_READ_PROPERTY_DATA *data);
+        const BACNET_READ_PROPERTY_DATA *data);
 
     BACNET_STACK_EXPORT
     int read_property_ack_encode(
         uint8_t *apdu,
-        BACNET_READ_PROPERTY_DATA *data);
+        const BACNET_READ_PROPERTY_DATA *data);
 
     BACNET_STACK_EXPORT
     size_t read_property_ack_service_encode(
         uint8_t *apdu,
         size_t apdu_size,
-        BACNET_READ_PROPERTY_DATA *data);
+        const BACNET_READ_PROPERTY_DATA *data);
 
     BACNET_STACK_EXPORT
     int rp_encode_apdu(
         uint8_t * apdu,
         uint8_t invoke_id,
-        BACNET_READ_PROPERTY_DATA * rpdata);
+        const BACNET_READ_PROPERTY_DATA * rpdata);
 
 /* decode the service request only */
     BACNET_STACK_EXPORT
     int rp_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_READ_PROPERTY_DATA * rpdata);
 
@@ -93,7 +93,7 @@ extern "C" {
     int rp_ack_encode_apdu_init(
         uint8_t * apdu,
         uint8_t invoke_id,
-        BACNET_READ_PROPERTY_DATA * rpdata);
+        const BACNET_READ_PROPERTY_DATA * rpdata);
 
     BACNET_STACK_EXPORT
     int rp_ack_encode_apdu_object_property_end(
@@ -104,7 +104,7 @@ extern "C" {
     int rp_ack_encode_apdu(
         uint8_t * apdu,
         uint8_t invoke_id,
-        BACNET_READ_PROPERTY_DATA * rpdata);
+        const BACNET_READ_PROPERTY_DATA * rpdata);
 
     BACNET_STACK_EXPORT
     int rp_ack_decode_service_request(

--- a/src/bacnet/rpm.c
+++ b/src/bacnet/rpm.c
@@ -236,7 +236,7 @@ int rpm_encode_apdu(
  * @return number of decoded bytes, or negative on failure.
  */
 int rpm_decode_object_id(
-    uint8_t *apdu, unsigned apdu_len, BACNET_RPM_DATA *rpmdata)
+    const uint8_t *apdu, unsigned apdu_len, BACNET_RPM_DATA *rpmdata)
 {
     int len = 0;
     BACNET_OBJECT_TYPE type = OBJECT_NONE; /* for decoding */
@@ -271,7 +271,7 @@ int rpm_decode_object_id(
  * @param apdu_len [in] Count of valid bytes in the buffer.
  * @return number of decoded bytes, or negative on failure.
  */
-int rpm_decode_object_end(uint8_t *apdu, unsigned apdu_len)
+int rpm_decode_object_end(const uint8_t *apdu, unsigned apdu_len)
 {
     int len = 0; /* total length of the apdu, return value */
 
@@ -300,7 +300,7 @@ int rpm_decode_object_end(uint8_t *apdu, unsigned apdu_len)
  * @return number of decoded bytes, or negative on failure.
  */
 int rpm_decode_object_property(
-    uint8_t *apdu, unsigned apdu_len, BACNET_RPM_DATA *rpmdata)
+    const uint8_t *apdu, unsigned apdu_len, BACNET_RPM_DATA *rpmdata)
 {
     int len = 0;
     int option_len = 0;
@@ -377,7 +377,8 @@ int rpm_ack_encode_apdu_init(uint8_t *apdu, uint8_t invoke_id)
  * @param rpmdata [in] Pointer to the data used to fill in the APDU.
  * @return number of bytes encoded
  */
-int rpm_ack_encode_apdu_object_begin(uint8_t *apdu, BACNET_RPM_DATA *rpmdata)
+int rpm_ack_encode_apdu_object_begin(
+    uint8_t *apdu, const BACNET_RPM_DATA *rpmdata)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
     int len = 0;
@@ -435,7 +436,9 @@ int rpm_ack_encode_apdu_object_property(
  * @return number of bytes encoded
  */
 int rpm_ack_encode_apdu_object_property_value(
-    uint8_t *apdu, uint8_t *application_data, unsigned application_data_len)
+    uint8_t *apdu,
+    const uint8_t *application_data,
+    unsigned application_data_len)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
     int len = 0;
@@ -519,7 +522,7 @@ int rpm_ack_encode_apdu_object_end(uint8_t *apdu)
  * @return Number of bytes decoded, or negative on error.
  */
 int rpm_ack_decode_object_id(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     unsigned apdu_size,
     BACNET_OBJECT_TYPE *object_type,
     uint32_t *object_instance)
@@ -554,7 +557,7 @@ int rpm_ack_decode_object_id(
  * @param apdu_size size of the application data unit buffer
  * @return Number of bytes decoded, or negative on error.
  */
-int rpm_ack_decode_object_end(uint8_t *apdu, unsigned apdu_size)
+int rpm_ack_decode_object_end(const uint8_t *apdu, unsigned apdu_size)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
     int len = 0;
@@ -577,7 +580,7 @@ int rpm_ack_decode_object_end(uint8_t *apdu, unsigned apdu_size)
  * @return Number of bytes decoded, or negative on error.
  */
 int rpm_ack_decode_object_property(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     unsigned apdu_size,
     BACNET_PROPERTY_ID *object_property,
     BACNET_ARRAY_INDEX *array_index)

--- a/src/bacnet/rpm.h
+++ b/src/bacnet/rpm.h
@@ -113,20 +113,20 @@ extern "C" {
 /* decode the object portion of the service request only */
     BACNET_STACK_EXPORT
     int rpm_decode_object_id(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_RPM_DATA * rpmdata);
 
 /* is this the end of this object property list? */
     BACNET_STACK_EXPORT
     int rpm_decode_object_end(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len);
 
 /* decode the object property portion of the service request only */
     BACNET_STACK_EXPORT
     int rpm_decode_object_property(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_RPM_DATA * rpmdata);
 
@@ -139,7 +139,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     int rpm_ack_encode_apdu_object_begin(
         uint8_t * apdu,
-        BACNET_RPM_DATA * rpmdata);
+        const BACNET_RPM_DATA * rpmdata);
 
     BACNET_STACK_EXPORT
     int rpm_ack_encode_apdu_object_property(
@@ -150,7 +150,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     int rpm_ack_encode_apdu_object_property_value(
         uint8_t * apdu,
-        uint8_t * application_data,
+        const uint8_t * application_data,
         unsigned application_data_len);
 
     BACNET_STACK_EXPORT
@@ -165,18 +165,18 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     int rpm_ack_decode_object_id(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_OBJECT_TYPE * object_type,
         uint32_t * object_instance);
 /* is this the end of the list of this objects properties values? */
     BACNET_STACK_EXPORT
     int rpm_ack_decode_object_end(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len);
     BACNET_STACK_EXPORT
     int rpm_ack_decode_object_property(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_PROPERTY_ID * object_property,
         BACNET_ARRAY_INDEX * array_index);

--- a/src/bacnet/special_event.c
+++ b/src/bacnet/special_event.c
@@ -29,7 +29,7 @@
  * @return length of the APDU buffer, or BACNET_STATUS_ERROR if unable to decode
  */
 int bacnet_special_event_decode(
-    uint8_t *apdu, int apdu_size, BACNET_SPECIAL_EVENT *value)
+    const uint8_t *apdu, int apdu_size, BACNET_SPECIAL_EVENT *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -97,7 +97,8 @@ int bacnet_special_event_decode(
  * @param value - BACnetSpecialEvent structure
  * @return length of the APDU buffer, or 0 if not able to encode
  */
-int bacnet_special_event_encode(uint8_t *apdu, BACNET_SPECIAL_EVENT *value)
+int bacnet_special_event_encode(
+    uint8_t *apdu, const BACNET_SPECIAL_EVENT *value)
 {
     int apdu_len = 0;
     int len;
@@ -153,7 +154,7 @@ int bacnet_special_event_encode(uint8_t *apdu, BACNET_SPECIAL_EVENT *value)
  * @return length of the APDU buffer, or 0 if not able to encode
  */
 int bacnet_special_event_context_encode(
-    uint8_t *apdu, uint8_t tag_number, BACNET_SPECIAL_EVENT *value)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_SPECIAL_EVENT *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -184,7 +185,7 @@ int bacnet_special_event_context_encode(
  * @param value - BACnetSpecialEvent structure
  * @return length of the APDU buffer, or BACNET_STATUS_ERROR if unable to decode
  */
-int bacnet_special_event_context_decode(uint8_t *apdu,
+int bacnet_special_event_context_decode(const uint8_t *apdu,
     int apdu_size,
     uint8_t tag_number,
     BACNET_SPECIAL_EVENT *value)
@@ -222,10 +223,10 @@ int bacnet_special_event_context_decode(uint8_t *apdu,
  * @return true if the same
  */
 bool bacnet_special_event_same(
-    BACNET_SPECIAL_EVENT *value1, BACNET_SPECIAL_EVENT *value2)
+    const BACNET_SPECIAL_EVENT *value1, const BACNET_SPECIAL_EVENT *value2)
 {
     BACNET_APPLICATION_DATA_VALUE adv1, adv2;
-    BACNET_TIME_VALUE *tv1, *tv2;
+    const BACNET_TIME_VALUE *tv1, *tv2;
     int ti;
 
     if (value1->periodTag != value2->periodTag ||

--- a/src/bacnet/special_event.h
+++ b/src/bacnet/special_event.h
@@ -42,7 +42,7 @@ extern "C" {
     /** Decode Special Event */
     BACNET_STACK_EXPORT
     int bacnet_special_event_decode(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         int max_apdu_len,
         BACNET_SPECIAL_EVENT * value);
 
@@ -50,20 +50,21 @@ extern "C" {
     BACNET_STACK_EXPORT
     int bacnet_special_event_encode(
         uint8_t * apdu,
-        BACNET_SPECIAL_EVENT * value);
+        const BACNET_SPECIAL_EVENT * value);
 
     BACNET_STACK_EXPORT
     int bacnet_special_event_context_encode(
-        uint8_t *apdu, uint8_t tag_number, BACNET_SPECIAL_EVENT *value);
+        uint8_t *apdu, uint8_t tag_number, const BACNET_SPECIAL_EVENT *value);
 
     BACNET_STACK_EXPORT
     int bacnet_special_event_context_decode(
-        uint8_t *apdu, int max_apdu_len, uint8_t tag_number,
+        const uint8_t *apdu, int max_apdu_len, uint8_t tag_number,
         BACNET_SPECIAL_EVENT *value);
 
     BACNET_STACK_EXPORT
     bool bacnet_special_event_same(
-        BACNET_SPECIAL_EVENT *value1, BACNET_SPECIAL_EVENT *value2);
+        const BACNET_SPECIAL_EVENT *value1,
+        const BACNET_SPECIAL_EVENT *value2);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/timestamp.c
+++ b/src/bacnet/timestamp.c
@@ -34,7 +34,7 @@ void bacapp_timestamp_sequence_set(BACNET_TIMESTAMP *dest, uint16_t sequenceNum)
  * @param dest  Pointer to the destination time stamp structure.
  * @param btime  Pointer to the BACNet time structure.
  */
-void bacapp_timestamp_time_set(BACNET_TIMESTAMP *dest, BACNET_TIME *btime)
+void bacapp_timestamp_time_set(BACNET_TIMESTAMP *dest, const BACNET_TIME *btime)
 {
     if (dest && btime) {
         dest->tag = TIME_STAMP_TIME;
@@ -49,7 +49,7 @@ void bacapp_timestamp_time_set(BACNET_TIMESTAMP *dest, BACNET_TIME *btime)
  * @param bdateTime  Pointer to the BACNet date/time structure.
  */
 void bacapp_timestamp_datetime_set(
-    BACNET_TIMESTAMP *dest, BACNET_DATE_TIME *bdateTime)
+    BACNET_TIMESTAMP *dest, const BACNET_DATE_TIME *bdateTime)
 {
     if (dest && bdateTime) {
         dest->tag = TIME_STAMP_DATETIME;
@@ -62,7 +62,7 @@ void bacapp_timestamp_datetime_set(
  * @param dest  Pointer to the destination time stamp structure.
  * @param src   Pointer to the source time stamp structure.
  */
-void bacapp_timestamp_copy(BACNET_TIMESTAMP *dest, BACNET_TIMESTAMP *src)
+void bacapp_timestamp_copy(BACNET_TIMESTAMP *dest, const BACNET_TIMESTAMP *src)
 {
     if (dest && src) {
         dest->tag = src->tag;
@@ -88,7 +88,8 @@ void bacapp_timestamp_copy(BACNET_TIMESTAMP *dest, BACNET_TIMESTAMP *src)
  * @param value2 - complex data value 2 structure
  * @return true if the two complex data values are the same
  */
-bool bacapp_timestamp_same(BACNET_TIMESTAMP *value1, BACNET_TIMESTAMP *value2)
+bool bacapp_timestamp_same(
+    const BACNET_TIMESTAMP *value1, const BACNET_TIMESTAMP *value2)
 {
     bool status = false;
 
@@ -137,7 +138,7 @@ bool bacapp_timestamp_same(BACNET_TIMESTAMP *value1, BACNET_TIMESTAMP *value2)
  *
  * @return Bytes encoded or 0 on error.
  */
-int bacapp_encode_timestamp(uint8_t *apdu, BACNET_TIMESTAMP *value)
+int bacapp_encode_timestamp(uint8_t *apdu, const BACNET_TIMESTAMP *value)
 {
     int len = 0; /* length of each encoding */
 
@@ -178,7 +179,7 @@ int bacapp_encode_timestamp(uint8_t *apdu, BACNET_TIMESTAMP *value)
  * @return Bytes encoded or 0 on error.
  */
 int bacapp_encode_context_timestamp(
-    uint8_t *apdu, uint8_t tag_number, BACNET_TIMESTAMP *value)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_TIMESTAMP *value)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0;
@@ -216,7 +217,7 @@ int bacapp_encode_context_timestamp(
  * @return number of bytes decoded, or BACNET_STATUS_ERROR if an error occurs
  */
 int bacnet_timestamp_decode(
-    uint8_t *apdu, uint32_t apdu_size, BACNET_TIMESTAMP *value)
+    const uint8_t *apdu, uint32_t apdu_size, BACNET_TIMESTAMP *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -289,7 +290,7 @@ int bacnet_timestamp_decode(
  * @return number of bytes decoded, or BACNET_STATUS_ERROR if an error occurs
  * @deprecated use bacnet_timestamp_decode() instead
  */
-int bacapp_decode_timestamp(uint8_t *apdu, BACNET_TIMESTAMP *value)
+int bacapp_decode_timestamp(const uint8_t *apdu, BACNET_TIMESTAMP *value)
 {
     return bacnet_timestamp_decode(apdu, MAX_APDU, value);
 }
@@ -304,7 +305,7 @@ int bacapp_decode_timestamp(uint8_t *apdu, BACNET_TIMESTAMP *value)
  *               take the time stamp values.
  * @return number of bytes decoded, or BACNET_STATUS_ERROR if an error occurs
  */
-int bacnet_timestamp_context_decode(uint8_t *apdu,
+int bacnet_timestamp_context_decode(const uint8_t *apdu,
     uint32_t apdu_size,
     uint8_t tag_number,
     BACNET_TIMESTAMP *value)
@@ -342,7 +343,7 @@ int bacnet_timestamp_context_decode(uint8_t *apdu,
  * @deprecated use bacnet_timestamp_context_decode() instead
  */
 int bacapp_decode_context_timestamp(
-    uint8_t *apdu, uint8_t tag_number, BACNET_TIMESTAMP *value)
+    const uint8_t *apdu, uint8_t tag_number, BACNET_TIMESTAMP *value)
 {
     const uint32_t apdu_size = MAX_APDU;
     int len;
@@ -442,7 +443,7 @@ bool bacapp_timestamp_init_ascii(BACNET_TIMESTAMP *timestamp, const char *ascii)
  * @return number of characters printed
 */
 int bacapp_timestamp_to_ascii(char *str, size_t str_size,
-    BACNET_TIMESTAMP *timestamp)
+    const BACNET_TIMESTAMP *timestamp)
 {
     int str_len = 0;
 

--- a/src/bacnet/timestamp.h
+++ b/src/bacnet/timestamp.h
@@ -43,41 +43,41 @@ extern "C" {
     BACNET_STACK_EXPORT
     void bacapp_timestamp_time_set(
         BACNET_TIMESTAMP * dest,
-        BACNET_TIME *btime);
+        const BACNET_TIME *btime);
 
     BACNET_STACK_EXPORT
     void bacapp_timestamp_datetime_set(
         BACNET_TIMESTAMP * dest,
-        BACNET_DATE_TIME * bdateTime);
+        const BACNET_DATE_TIME * bdateTime);
 
     BACNET_STACK_EXPORT
     void bacapp_timestamp_copy(
         BACNET_TIMESTAMP * dest,
-        BACNET_TIMESTAMP * src);
+        const BACNET_TIMESTAMP * src);
 
     BACNET_STACK_EXPORT
     bool bacapp_timestamp_same(
-        BACNET_TIMESTAMP *value1,
-        BACNET_TIMESTAMP *value2);
+        const BACNET_TIMESTAMP *value1,
+        const BACNET_TIMESTAMP *value2);
 
     BACNET_STACK_EXPORT
     int bacapp_encode_timestamp(
         uint8_t * apdu,
-        BACNET_TIMESTAMP * value);
+        const BACNET_TIMESTAMP * value);
     BACNET_STACK_EXPORT
     int bacapp_encode_context_timestamp(
         uint8_t * apdu,
         uint8_t tag_number,
-        BACNET_TIMESTAMP * value);
+        const BACNET_TIMESTAMP * value);
 
     BACNET_STACK_EXPORT
     int bacnet_timestamp_decode(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint32_t apdu_size,
         BACNET_TIMESTAMP * value);
     BACNET_STACK_EXPORT
     int bacnet_timestamp_context_decode(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint32_t apdu_size,
         uint8_t tag_number,
         BACNET_TIMESTAMP * value);
@@ -85,12 +85,12 @@ extern "C" {
     BACNET_STACK_DEPRECATED("Use bacnet_timestamp_decode() instead")
     BACNET_STACK_EXPORT
     int bacapp_decode_timestamp(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         BACNET_TIMESTAMP * value);
     BACNET_STACK_DEPRECATED("Use bacnet_timestamp_context_decode() instead")
     BACNET_STACK_EXPORT
     int bacapp_decode_context_timestamp(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint8_t tag_number,
         BACNET_TIMESTAMP * value);
 
@@ -102,7 +102,7 @@ extern "C" {
     int bacapp_timestamp_to_ascii(
         char *str,
         size_t str_size,
-        BACNET_TIMESTAMP *timestamp);
+        const BACNET_TIMESTAMP *timestamp);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/timesync.c
+++ b/src/bacnet/timesync.c
@@ -27,8 +27,8 @@
  */
 int timesync_encode_apdu_service(uint8_t *apdu,
     BACNET_UNCONFIRMED_SERVICE service,
-    BACNET_DATE *my_date,
-    BACNET_TIME *my_time)
+    const BACNET_DATE *my_date,
+    const BACNET_TIME *my_time)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -55,7 +55,7 @@ int timesync_encode_apdu_service(uint8_t *apdu,
  * @return Count of encoded bytes.
  */
 int timesync_utc_encode_apdu(
-    uint8_t *apdu, BACNET_DATE *my_date, BACNET_TIME *my_time)
+    uint8_t *apdu, const BACNET_DATE *my_date, const BACNET_TIME *my_time)
 {
     return timesync_encode_apdu_service(
         apdu, SERVICE_UNCONFIRMED_UTC_TIME_SYNCHRONIZATION, my_date, my_time);
@@ -70,7 +70,7 @@ int timesync_utc_encode_apdu(
  * @return Count of encoded bytes.
  */
 int timesync_encode_apdu(
-    uint8_t *apdu, BACNET_DATE *my_date, BACNET_TIME *my_time)
+    uint8_t *apdu, const BACNET_DATE *my_date, const BACNET_TIME *my_time)
 {
     return timesync_encode_apdu_service(
         apdu, SERVICE_UNCONFIRMED_TIME_SYNCHRONIZATION, my_date, my_time);
@@ -86,7 +86,7 @@ int timesync_encode_apdu(
  *
  * @return Count of decoded bytes.
  */
-int timesync_decode_service_request(uint8_t *apdu,
+int timesync_decode_service_request(const uint8_t *apdu,
     unsigned apdu_len,
     BACNET_DATE *my_date,
     BACNET_TIME *my_time)
@@ -240,7 +240,7 @@ int timesync_encode_timesync_recipients(
  *   BACNET_STATUS_ABORT if there was a problem decoding the buffer
  */
 int timesync_decode_timesync_recipients(
-    uint8_t *apdu, unsigned max_apdu, BACNET_RECIPIENT_LIST *recipient)
+    const uint8_t *apdu, unsigned max_apdu, BACNET_RECIPIENT_LIST *recipient)
 {
     int len = 0;
     int apdu_len = 0;

--- a/src/bacnet/timesync.h
+++ b/src/bacnet/timesync.h
@@ -39,35 +39,35 @@ extern "C" {
     BACNET_STACK_EXPORT
     int timesync_utc_encode_apdu(
         uint8_t * apdu,
-        BACNET_DATE * my_date,
-        BACNET_TIME * my_time);
+        const BACNET_DATE * my_date,
+        const BACNET_TIME * my_time);
     BACNET_STACK_EXPORT
     int timesync_encode_apdu(
         uint8_t * apdu,
-        BACNET_DATE * my_date,
-        BACNET_TIME * my_time);
+        const BACNET_DATE * my_date,
+        const BACNET_TIME * my_time);
     BACNET_STACK_EXPORT
     int timesync_encode_apdu_service(
         uint8_t * apdu,
         BACNET_UNCONFIRMED_SERVICE service,
-        BACNET_DATE * my_date,
-        BACNET_TIME * my_time);
+        const BACNET_DATE * my_date,
+        const BACNET_TIME * my_time);
     /* decode the service request only */
     BACNET_STACK_EXPORT
     int timesync_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_DATE * my_date,
         BACNET_TIME * my_time);
     BACNET_STACK_EXPORT
     int timesync_utc_decode_apdu(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_DATE * my_date,
         BACNET_TIME * my_time);
     BACNET_STACK_EXPORT
     int timesync_decode_apdu(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_DATE * my_date,
         BACNET_TIME * my_time);
@@ -79,7 +79,7 @@ extern "C" {
         BACNET_RECIPIENT_LIST * recipient);
     BACNET_STACK_EXPORT
     int timesync_decode_timesync_recipients(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_RECIPIENT_LIST * recipient);
 

--- a/src/bacnet/weeklyschedule.c
+++ b/src/bacnet/weeklyschedule.c
@@ -19,7 +19,7 @@
  * @return  number of bytes decoded, or BACNET_STATUS_ERROR if errors occur
  */
 int bacnet_weeklyschedule_decode(
-    uint8_t *apdu, int apdu_size, BACNET_WEEKLY_SCHEDULE *value)
+    const uint8_t *apdu, int apdu_size, BACNET_WEEKLY_SCHEDULE *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -60,7 +60,8 @@ int bacnet_weeklyschedule_decode(
  * @return the number of apdu bytes encoded, or BACNET_STATUS_ERROR if value
  * was inconsistent.
  */
-int bacnet_weeklyschedule_encode(uint8_t *apdu, BACNET_WEEKLY_SCHEDULE *value)
+int bacnet_weeklyschedule_encode(
+    uint8_t *apdu, const BACNET_WEEKLY_SCHEDULE *value)
 {
     int apdu_len = 0;
     int len = 0;
@@ -89,7 +90,7 @@ int bacnet_weeklyschedule_encode(uint8_t *apdu, BACNET_WEEKLY_SCHEDULE *value)
  * @return length of the APDU buffer, or 0 if not able to encode
  */
 int bacnet_weeklyschedule_context_encode(
-    uint8_t *apdu, uint8_t tag_number, BACNET_WEEKLY_SCHEDULE *value)
+    uint8_t *apdu, uint8_t tag_number, const BACNET_WEEKLY_SCHEDULE *value)
 {
     int len = 0;
     int apdu_len = 0;
@@ -124,7 +125,7 @@ int bacnet_weeklyschedule_context_encode(
  * @return number of bytes decoded, or BACNET_STATUS_ERROR if an error occurs
  */
 int bacnet_weeklyschedule_context_decode(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     int apdu_size,
     uint8_t tag_number,
     BACNET_WEEKLY_SCHEDULE *value)
@@ -168,11 +169,11 @@ int bacnet_weeklyschedule_context_decode(
  * @return true if the same
  */
 bool bacnet_weeklyschedule_same(
-    BACNET_WEEKLY_SCHEDULE *value1, BACNET_WEEKLY_SCHEDULE *value2)
+    const BACNET_WEEKLY_SCHEDULE *value1, const BACNET_WEEKLY_SCHEDULE *value2)
 {
     BACNET_APPLICATION_DATA_VALUE adv1, adv2;
-    BACNET_DAILY_SCHEDULE *ds1, *ds2;
-    BACNET_TIME_VALUE *tv1, *tv2;
+    const BACNET_DAILY_SCHEDULE *ds1, *ds2;
+    const BACNET_TIME_VALUE *tv1, *tv2;
     int wi, ti;
 
     for (wi = 0; wi < 7; wi++) {

--- a/src/bacnet/weeklyschedule.h
+++ b/src/bacnet/weeklyschedule.h
@@ -28,7 +28,7 @@ extern "C" {
     /** Decode WeeklySchedule */
     BACNET_STACK_EXPORT
     int bacnet_weeklyschedule_decode(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         int apdu_size,
         BACNET_WEEKLY_SCHEDULE * value);
 
@@ -36,20 +36,22 @@ extern "C" {
     BACNET_STACK_EXPORT
     int bacnet_weeklyschedule_encode(
         uint8_t * apdu,
-        BACNET_WEEKLY_SCHEDULE * value);
+        const BACNET_WEEKLY_SCHEDULE * value);
 
     BACNET_STACK_EXPORT
     int bacnet_weeklyschedule_context_encode(
-        uint8_t *apdu, uint8_t tag_number, BACNET_WEEKLY_SCHEDULE *value);
+        uint8_t *apdu, uint8_t tag_number,
+        const BACNET_WEEKLY_SCHEDULE *value);
 
     BACNET_STACK_EXPORT
     int bacnet_weeklyschedule_context_decode(
-        uint8_t *apdu, int apdu_size, uint8_t tag_number,
+        const uint8_t *apdu, int apdu_size, uint8_t tag_number,
         BACNET_WEEKLY_SCHEDULE *value);
 
     BACNET_STACK_EXPORT
     bool bacnet_weeklyschedule_same(
-        BACNET_WEEKLY_SCHEDULE *value1, BACNET_WEEKLY_SCHEDULE *value2);
+        const BACNET_WEEKLY_SCHEDULE *value1,
+        const BACNET_WEEKLY_SCHEDULE *value2);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/whohas.c
+++ b/src/bacnet/whohas.c
@@ -29,7 +29,8 @@
  * @param data application data to be encoded
  * @return number of bytes encoded
  */
-int bacnet_who_has_request_encode(uint8_t *apdu, BACNET_WHO_HAS_DATA *data)
+int bacnet_who_has_request_encode(
+    uint8_t *apdu, const BACNET_WHO_HAS_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -73,7 +74,7 @@ int bacnet_who_has_request_encode(uint8_t *apdu, BACNET_WHO_HAS_DATA *data)
  * @return number of bytes encoded, or zero if unable to encode or too large
  */
 size_t bacnet_who_has_service_request_encode(
-    uint8_t *apdu, size_t apdu_size, BACNET_WHO_HAS_DATA *data)
+    uint8_t *apdu, size_t apdu_size, const BACNET_WHO_HAS_DATA *data)
 {
     size_t apdu_len = 0; /* total length of the apdu, return value */
 
@@ -93,7 +94,7 @@ size_t bacnet_who_has_service_request_encode(
  * @param data  Pointer to the Who-Has application data.
  * @return Bytes encoded.
  */
-int whohas_encode_apdu(uint8_t *apdu, BACNET_WHO_HAS_DATA *data)
+int whohas_encode_apdu(uint8_t *apdu, const BACNET_WHO_HAS_DATA *data)
 {
     int len = 0; /* length of each encoding */
     int apdu_len = 0; /* total length of the apdu, return value */
@@ -125,7 +126,7 @@ int whohas_encode_apdu(uint8_t *apdu, BACNET_WHO_HAS_DATA *data)
  * @return number of bytes decoded, or BACNET_STATUS_ERROR on error
  */
 int whohas_decode_service_request(
-    uint8_t *apdu, unsigned apdu_size, BACNET_WHO_HAS_DATA *data)
+    const uint8_t *apdu, unsigned apdu_size, BACNET_WHO_HAS_DATA *data)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
     int len = 0;

--- a/src/bacnet/whohas.h
+++ b/src/bacnet/whohas.h
@@ -49,22 +49,23 @@ extern "C" {
 #endif /* __cplusplus */
 
 BACNET_STACK_EXPORT
-int whohas_encode_apdu(uint8_t *apdu, BACNET_WHO_HAS_DATA *data);
+int whohas_encode_apdu(uint8_t *apdu, const BACNET_WHO_HAS_DATA *data);
 
 BACNET_STACK_EXPORT
-int bacnet_who_has_request_encode(uint8_t *apdu, BACNET_WHO_HAS_DATA *data);
+int bacnet_who_has_request_encode(
+    uint8_t *apdu, const BACNET_WHO_HAS_DATA *data);
 BACNET_STACK_EXPORT
 size_t bacnet_who_has_service_request_encode(
-    uint8_t *apdu, size_t apdu_size, BACNET_WHO_HAS_DATA *data);
+    uint8_t *apdu, size_t apdu_size, const BACNET_WHO_HAS_DATA *data);
 
 BACNET_STACK_EXPORT
 int whohas_decode_service_request(
-    uint8_t *apdu, unsigned apdu_size, BACNET_WHO_HAS_DATA *data);
+    const uint8_t *apdu, unsigned apdu_size, BACNET_WHO_HAS_DATA *data);
 
 /* defined in unit test */
 BACNET_STACK_EXPORT
 int whohas_decode_apdu(
-    uint8_t *apdu, unsigned apdu_size, BACNET_WHO_HAS_DATA *data);
+    const uint8_t *apdu, unsigned apdu_size, BACNET_WHO_HAS_DATA *data);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/whois.c
+++ b/src/bacnet/whois.c
@@ -37,7 +37,10 @@ int whois_encode_apdu(uint8_t *apdu, int32_t low_limit, int32_t high_limit)
 
 /* decode the service request only */
 int whois_decode_service_request(
-    uint8_t *apdu, unsigned apdu_len, int32_t *pLow_limit, int32_t *pHigh_limit)
+    const uint8_t *apdu,
+    unsigned apdu_len,
+    int32_t *pLow_limit,
+    int32_t *pHigh_limit)
 {
     unsigned int len = 0;
     uint8_t tag_number = 0;

--- a/src/bacnet/whois.h
+++ b/src/bacnet/whois.h
@@ -26,7 +26,7 @@ extern "C" {
 
     BACNET_STACK_EXPORT
     int whois_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         int32_t * pLow_limit,
         int32_t * pHigh_limit);

--- a/src/bacnet/wp.c
+++ b/src/bacnet/wp.c
@@ -37,7 +37,7 @@
  * @return number of bytes encoded, or zero if unable to encode
  */
 size_t writeproperty_apdu_encode(
-    uint8_t *apdu, BACNET_WRITE_PROPERTY_DATA *data)
+    uint8_t *apdu, const BACNET_WRITE_PROPERTY_DATA *data)
 {
     size_t apdu_len = 0; /* total length of the apdu, return value */
     size_t len = 0; /* total length of the apdu, return value */
@@ -100,7 +100,7 @@ size_t writeproperty_apdu_encode(
  * @return number of bytes encoded, or zero if unable to encode or too large
  */
 size_t writeproperty_service_request_encode(
-    uint8_t *apdu, size_t apdu_size, BACNET_WRITE_PROPERTY_DATA *data)
+    uint8_t *apdu, size_t apdu_size, const BACNET_WRITE_PROPERTY_DATA *data)
 {
     size_t apdu_len = 0; /* total length of the apdu, return value */
 
@@ -136,7 +136,7 @@ size_t writeproperty_service_request_encode(
  * @return Bytes encoded
  */
 int wp_encode_apdu(
-    uint8_t *apdu, uint8_t invoke_id, BACNET_WRITE_PROPERTY_DATA *wpdata)
+    uint8_t *apdu, uint8_t invoke_id, const BACNET_WRITE_PROPERTY_DATA *wpdata)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
     int len = 0; /* total length of the apdu, return value */
@@ -184,7 +184,9 @@ int wp_encode_apdu(
  * @return number of bytes decoded, or #BACNET_STATUS_ERROR
  */
 int wp_decode_service_request(
-    uint8_t *apdu, unsigned apdu_size, BACNET_WRITE_PROPERTY_DATA *wpdata)
+    const uint8_t *apdu,
+    unsigned apdu_size,
+    BACNET_WRITE_PROPERTY_DATA *wpdata)
 {
     int len = 0;
     int apdu_len = 0;
@@ -304,7 +306,7 @@ int wp_decode_service_request(
  * @return true if the expected tag matches the value tag
  */
 bool write_property_type_valid(BACNET_WRITE_PROPERTY_DATA *wp_data,
-    BACNET_APPLICATION_DATA_VALUE *value,
+    const BACNET_APPLICATION_DATA_VALUE *value,
     uint8_t expected_tag)
 {
     /* assume success */
@@ -330,7 +332,7 @@ bool write_property_type_valid(BACNET_WRITE_PROPERTY_DATA *wp_data,
  * @return true if the character string value is valid
  */
 bool write_property_string_valid(BACNET_WRITE_PROPERTY_DATA *wp_data,
-    BACNET_APPLICATION_DATA_VALUE *value,
+    const BACNET_APPLICATION_DATA_VALUE *value,
     size_t len_max)
 {
     bool valid = false;
@@ -387,7 +389,7 @@ bool write_property_string_valid(BACNET_WRITE_PROPERTY_DATA *wp_data,
  * @return true if the character string value is valid
  */
 bool write_property_empty_string_valid(BACNET_WRITE_PROPERTY_DATA *wp_data,
-    BACNET_APPLICATION_DATA_VALUE *value,
+    const BACNET_APPLICATION_DATA_VALUE *value,
     size_t len_max)
 {
     bool valid = false;

--- a/src/bacnet/wp.h
+++ b/src/bacnet/wp.h
@@ -56,39 +56,39 @@ extern "C" {
     BACNET_STACK_EXPORT
     size_t writeproperty_apdu_encode(
         uint8_t *apdu,
-        BACNET_WRITE_PROPERTY_DATA *data);
+        const BACNET_WRITE_PROPERTY_DATA *data);
     BACNET_STACK_EXPORT
     size_t writeproperty_service_request_encode(
         uint8_t *apdu,
         size_t apdu_size,
-        BACNET_WRITE_PROPERTY_DATA *data);
+        const BACNET_WRITE_PROPERTY_DATA *data);
     BACNET_STACK_EXPORT
     int wp_encode_apdu(
         uint8_t * apdu,
         uint8_t invoke_id,
-        BACNET_WRITE_PROPERTY_DATA * wp_data);
+        const BACNET_WRITE_PROPERTY_DATA * wp_data);
 
     /* decode the service request only */
     BACNET_STACK_EXPORT
     int wp_decode_service_request(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         unsigned apdu_len,
         BACNET_WRITE_PROPERTY_DATA * wp_data);
 
     BACNET_STACK_EXPORT
     bool write_property_type_valid(
         BACNET_WRITE_PROPERTY_DATA * wp_data,
-        BACNET_APPLICATION_DATA_VALUE * value,
+        const BACNET_APPLICATION_DATA_VALUE * value,
         uint8_t expected_tag);
     BACNET_STACK_EXPORT
     bool write_property_string_valid(
         BACNET_WRITE_PROPERTY_DATA * wp_data,
-        BACNET_APPLICATION_DATA_VALUE * value,
+        const BACNET_APPLICATION_DATA_VALUE * value,
         size_t len_max);
     BACNET_STACK_EXPORT
     bool write_property_empty_string_valid(
         BACNET_WRITE_PROPERTY_DATA * wp_data,
-        BACNET_APPLICATION_DATA_VALUE * value,
+        const BACNET_APPLICATION_DATA_VALUE * value,
         size_t len_max);
 
 #ifdef __cplusplus

--- a/src/bacnet/wpm.c
+++ b/src/bacnet/wpm.c
@@ -38,7 +38,7 @@
  * @return Count of decoded bytes.
  */
 int wpm_decode_object_id(
-    uint8_t *apdu, uint16_t apdu_len, BACNET_WRITE_PROPERTY_DATA *wp_data)
+    const uint8_t *apdu, uint16_t apdu_len, BACNET_WRITE_PROPERTY_DATA *wp_data)
 {
     uint8_t tag_number = 0;
     uint32_t len_value = 0;
@@ -99,7 +99,7 @@ int wpm_decode_object_id(
  * @return Bytes decoded
  */
 int wpm_decode_object_property(
-    uint8_t *apdu, uint16_t apdu_len, BACNET_WRITE_PROPERTY_DATA *wp_data)
+    const uint8_t *apdu, uint16_t apdu_len, BACNET_WRITE_PROPERTY_DATA *wp_data)
 {
     uint8_t tag_number = 0;
     uint32_t len_value = 0;
@@ -248,7 +248,7 @@ int wpm_encode_apdu_object_end(uint8_t *apdu)
  * @return number of bytes encoded
  */
 int wpm_encode_apdu_object_property(
-    uint8_t *apdu, BACNET_WRITE_PROPERTY_DATA *wpdata)
+    uint8_t *apdu, const BACNET_WRITE_PROPERTY_DATA *wpdata)
 {
     int apdu_len = 0; /* total length of the apdu, return value */
     int len = 0;
@@ -449,7 +449,7 @@ int wpm_ack_encode_apdu_init(uint8_t *apdu, uint8_t invoke_id)
  * @return Bytes encoded.
  */
 int wpm_error_ack_encode_apdu(
-    uint8_t *apdu, uint8_t invoke_id, BACNET_WRITE_PROPERTY_DATA *wp_data)
+    uint8_t *apdu, uint8_t invoke_id, const BACNET_WRITE_PROPERTY_DATA *wp_data)
 {
     int len = 0;
 
@@ -493,10 +493,10 @@ int wpm_error_ack_encode_apdu(
  * @return Count of decoded bytes.
  */
 int wpm_error_ack_decode_apdu(
-    uint8_t *apdu, uint16_t apdu_size, BACNET_WRITE_PROPERTY_DATA *wp_data)
+    const uint8_t *apdu, uint16_t apdu_size, BACNET_WRITE_PROPERTY_DATA *wp_data)
 {
     int len = 0, apdu_len = 0;
-    uint8_t *apdu_offset = NULL;
+    const uint8_t *apdu_offset = NULL;
     BACNET_ERROR_CLASS error_class = ERROR_CLASS_SERVICES;
     BACNET_ERROR_CODE error_code = ERROR_CODE_SUCCESS;
     BACNET_OBJECT_PROPERTY_REFERENCE value;

--- a/src/bacnet/wpm.h
+++ b/src/bacnet/wpm.h
@@ -34,13 +34,13 @@ extern "C" {
     /* decode the service request only */
     BACNET_STACK_EXPORT
     int wpm_decode_object_id(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint16_t apdu_len,
         BACNET_WRITE_PROPERTY_DATA * wpdata);
 
     BACNET_STACK_EXPORT
     int wpm_decode_object_property(
-        uint8_t * apdu,
+        const uint8_t * apdu,
         uint16_t apdu_len,
         BACNET_WRITE_PROPERTY_DATA * wpdata);
 
@@ -57,7 +57,7 @@ extern "C" {
     BACNET_STACK_EXPORT
     int wpm_encode_apdu_object_property(
         uint8_t * apdu,
-        BACNET_WRITE_PROPERTY_DATA * wpdata);
+        const BACNET_WRITE_PROPERTY_DATA * wpdata);
     BACNET_STACK_EXPORT
     int wpm_encode_apdu_object_end(
         uint8_t * apdu);
@@ -88,11 +88,11 @@ extern "C" {
     int wpm_error_ack_encode_apdu(
         uint8_t * apdu,
         uint8_t invoke_id,
-        BACNET_WRITE_PROPERTY_DATA * wp_data);
+        const BACNET_WRITE_PROPERTY_DATA * wp_data);
 
     BACNET_STACK_EXPORT
     int wpm_error_ack_decode_apdu(
-        uint8_t *apdu,
+        const uint8_t *apdu,
         uint16_t apdu_size,
         BACNET_WRITE_PROPERTY_DATA * wp_data);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ if (CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
     add_compile_options(-Wswitch-default)
     add_compile_options(-Wunused-variable)
     add_compile_options(-Wcast-qual)
+    add_compile_options(-Wwrite-strings)
 
     # don't warn about conversion, sign, compares, long long and attributes
     # since they are common in embedded
@@ -41,6 +42,7 @@ if (CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
     add_compile_options(-Wno-float-conversion)
     add_compile_options(-Wno-missing-declarations)
     add_compile_options(-Wno-unused-but-set-variable)
+    add_compile_options(-Wno-write-strings)
 
     add_link_options(-fprofile-arcs -ftest-coverage)
 endif()

--- a/test/bacnet/arf/src/main.c
+++ b/test/bacnet/arf/src/main.c
@@ -112,7 +112,7 @@ static void testAtomicReadFileAck(void)
     return;
 }
 
-static void testAtomicReadFileAccess(BACNET_ATOMIC_READ_FILE_DATA *data)
+static void testAtomicReadFileAccess(const BACNET_ATOMIC_READ_FILE_DATA *data)
 {
     BACNET_ATOMIC_READ_FILE_DATA test_data = { 0 };
     uint8_t apdu[480] = { 0 };

--- a/test/bacnet/awf/src/main.c
+++ b/test/bacnet/awf/src/main.c
@@ -100,7 +100,8 @@ static void testAtomicWriteFile(void)
     return;
 }
 
-static void testAtomicWriteFileAckAccess(BACNET_ATOMIC_WRITE_FILE_DATA *data)
+static void testAtomicWriteFileAckAccess(
+    const BACNET_ATOMIC_WRITE_FILE_DATA *data)
 {
     BACNET_ATOMIC_WRITE_FILE_DATA test_data = { 0 };
     uint8_t apdu[480] = { 0 };

--- a/test/bacnet/bacapp/src/main.c
+++ b/test/bacnet/bacapp/src/main.c
@@ -860,7 +860,7 @@ static void testBACnetApplicationDataLength(void)
  * @brief Test
  */
 static bool
-verifyBACnetApplicationDataValue(BACNET_APPLICATION_DATA_VALUE *value)
+verifyBACnetApplicationDataValue(const BACNET_APPLICATION_DATA_VALUE *value)
 {
     uint8_t apdu[480] = { 0 };
     int apdu_len = 0;
@@ -917,7 +917,7 @@ verifyBACnetApplicationDataValue(BACNET_APPLICATION_DATA_VALUE *value)
  * @brief Test
  */
 static void verifyBACnetComplexDataValue(
-    BACNET_APPLICATION_DATA_VALUE *value,
+    const BACNET_APPLICATION_DATA_VALUE *value,
     BACNET_OBJECT_TYPE object_type,
     BACNET_PROPERTY_ID prop)
 {

--- a/test/bacnet/bacerror/src/main.c
+++ b/test/bacnet/bacerror/src/main.c
@@ -18,7 +18,7 @@
  */
 
 static int bacerror_decode_apdu(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     unsigned apdu_size,
     uint8_t *invoke_id,
     BACNET_CONFIRMED_SERVICE *service,

--- a/test/bacnet/bacstr/src/main.c
+++ b/test/bacnet/bacstr/src/main.c
@@ -95,7 +95,7 @@ static void testCharacterString(void)
 #endif
 {
     BACNET_CHARACTER_STRING bacnet_string;
-    char *value = "Joshua,Mary,Anna,Christopher";
+    const char *value = "Joshua,Mary,Anna,Christopher";
     char test_value[MAX_APDU] = "Patricia";
     char test_append_value[MAX_APDU] = " and the Kids";
     char test_append_string[MAX_APDU] = "";

--- a/test/bacnet/basic/bbmd/src/main.c
+++ b/test/bacnet/basic/bbmd/src/main.c
@@ -70,7 +70,8 @@ uint16_t bip_receive(
  * @return Upon successful completion, returns the number of bytes sent.
  *  Otherwise, -1 shall be returned and errno set to indicate the error.
  */
-int bip_send_mpdu(BACNET_IP_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
+int bip_send_mpdu(
+    const BACNET_IP_ADDRESS *dest, const uint8_t *mtu, uint16_t mtu_len)
 {
     uint8_t message_type = 0;
     uint16_t message_length = 0;

--- a/test/bacnet/basic/bbmd6/src/main.c
+++ b/test/bacnet/basic/bbmd6/src/main.c
@@ -75,7 +75,8 @@ uint16_t bip6_receive(
  * @return Upon successful completion, returns the number of bytes sent.
  *  Otherwise, -1 shall be returned and errno set to indicate the error.
  */
-int bip6_send_mpdu(BACNET_IP6_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
+int bip6_send_mpdu(
+    const BACNET_IP6_ADDRESS *dest, const uint8_t *mtu, uint16_t mtu_len)
 {
     uint8_t message_type = 0;
     uint16_t message_length = 0;

--- a/test/bacnet/basic/object/nc/stubs.c
+++ b/test/bacnet/basic/object/nc/stubs.c
@@ -19,7 +19,9 @@ uint32_t Device_Object_Instance_Number(void)
 }
 
 int Send_UEvent_Notify(
-    uint8_t *buffer, BACNET_EVENT_NOTIFICATION_DATA *data, BACNET_ADDRESS *dest)
+    uint8_t *buffer,
+    const BACNET_EVENT_NOTIFICATION_DATA *data,
+    BACNET_ADDRESS *dest)
 {
     (void)buffer;
     (void)data;

--- a/test/bacnet/basic/object/test/device_mock.c
+++ b/test/bacnet/basic/object/test/device_mock.c
@@ -11,7 +11,7 @@
 #include <bacnet/basic/object/device.h>
 
 bool Device_Valid_Object_Name(
-    BACNET_CHARACTER_STRING *object_name,
+    const BACNET_CHARACTER_STRING *object_name,
     BACNET_OBJECT_TYPE *object_type,
     uint32_t *object_instance)
 {

--- a/test/bacnet/basic/object/test/property_test.h
+++ b/test/bacnet/basic/object/test/property_test.h
@@ -15,7 +15,7 @@
 
 /* function API pattern for testing ASCII name get/set */
 typedef bool (*object_name_ascii_set_function) (uint32_t object_instance,
-    char *new_name);
+    const char *new_name);
 typedef const char * (*object_name_ascii_function) (
     uint32_t object_instance);
 

--- a/test/bacnet/basic/sys/filename/src/main.c
+++ b/test/bacnet/basic/sys/filename/src/main.c
@@ -25,12 +25,12 @@ ZTEST(filename_tests, testFilename)
 static void testFilename(void)
 #endif
 {
-    char *data1 = "c:\\Joshua\\run";
-    char *data2 = "/home/Anna/run";
-    char *data3 = "c:\\Program Files\\Christopher\\run.exe";
-    char *data4 = "//Mary/data/run";
-    char *data5 = "bin\\run";
-    char *filename = NULL;
+    const char *data1 = "c:\\Joshua\\run";
+    const char *data2 = "/home/Anna/run";
+    const char *data3 = "c:\\Program Files\\Christopher\\run.exe";
+    const char *data4 = "//Mary/data/run";
+    const char *data5 = "bin\\run";
+    const char *filename = NULL;
 
     filename = filename_remove_path(data1);
     zassert_equal(strcmp("run", filename), 0, NULL);

--- a/test/bacnet/cov/src/main.c
+++ b/test/bacnet/cov/src/main.c
@@ -21,7 +21,10 @@
  * @brief Test encode/decode API for unsigned 16b integers
  */
 int ccov_notify_decode_apdu(
-    uint8_t *apdu, unsigned apdu_len, uint8_t *invoke_id, BACNET_COV_DATA *data)
+    const uint8_t *apdu,
+    unsigned apdu_len,
+    uint8_t *invoke_id,
+    BACNET_COV_DATA *data)
 {
     int len = 0;
     unsigned offset = 0;
@@ -48,7 +51,7 @@ int ccov_notify_decode_apdu(
 }
 
 int ucov_notify_decode_apdu(
-    uint8_t *apdu, unsigned apdu_len, BACNET_COV_DATA *data)
+    const uint8_t *apdu, unsigned apdu_len, BACNET_COV_DATA *data)
 {
     int len = 0;
     unsigned offset = 0;
@@ -71,7 +74,7 @@ int ucov_notify_decode_apdu(
 }
 
 static int cov_subscribe_decode_apdu(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     unsigned apdu_len,
     uint8_t *invoke_id,
     BACNET_SUBSCRIBE_COV_DATA *data)
@@ -100,7 +103,7 @@ static int cov_subscribe_decode_apdu(
 }
 
 static int cov_subscribe_property_decode_apdu(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     unsigned apdu_len,
     uint8_t *invoke_id,
     BACNET_SUBSCRIBE_COV_DATA *data)
@@ -129,9 +132,10 @@ static int cov_subscribe_property_decode_apdu(
 }
 
 /* dummy function stubs */
-static void testCOVNotifyData(BACNET_COV_DATA *data, BACNET_COV_DATA *test_data)
+static void testCOVNotifyData(
+    const BACNET_COV_DATA *data, BACNET_COV_DATA *test_data)
 {
-    BACNET_PROPERTY_VALUE *value = NULL;
+    const BACNET_PROPERTY_VALUE *value = NULL;
     BACNET_PROPERTY_VALUE *test_value = NULL;
 
     zassert_equal(
@@ -170,7 +174,7 @@ static void testCOVNotifyData(BACNET_COV_DATA *data, BACNET_COV_DATA *test_data)
     }
 }
 
-static void testUCOVNotifyData(BACNET_COV_DATA *data)
+static void testUCOVNotifyData(const BACNET_COV_DATA *data)
 {
     uint8_t apdu[480] = { 0 };
     int len = 0, null_len = 0, apdu_len = 0;
@@ -190,7 +194,7 @@ static void testUCOVNotifyData(BACNET_COV_DATA *data)
     testCOVNotifyData(data, &test_data);
 }
 
-static void testCCOVNotifyData(uint8_t invoke_id, BACNET_COV_DATA *data)
+static void testCCOVNotifyData(uint8_t invoke_id, const BACNET_COV_DATA *data)
 {
     uint8_t apdu[480] = { 0 };
     int len = 0, null_len = 0, apdu_len = 0;
@@ -247,7 +251,8 @@ static void testCOVNotify(void)
 }
 
 static void testCOVSubscribeData(
-    BACNET_SUBSCRIBE_COV_DATA *data, BACNET_SUBSCRIBE_COV_DATA *test_data)
+    const BACNET_SUBSCRIBE_COV_DATA *data,
+    const BACNET_SUBSCRIBE_COV_DATA *test_data)
 {
     zassert_equal(
         test_data->subscriberProcessIdentifier,
@@ -272,7 +277,8 @@ static void testCOVSubscribeData(
 }
 
 static void testCOVSubscribePropertyData(
-    BACNET_SUBSCRIBE_COV_DATA *data, BACNET_SUBSCRIBE_COV_DATA *test_data)
+    const BACNET_SUBSCRIBE_COV_DATA *data,
+    const BACNET_SUBSCRIBE_COV_DATA *test_data)
 {
     testCOVSubscribeData(data, test_data);
     zassert_equal(
@@ -290,7 +296,8 @@ static void testCOVSubscribePropertyData(
 }
 
 static void
-testCOVSubscribeEncoding(uint8_t invoke_id, BACNET_SUBSCRIBE_COV_DATA *data)
+testCOVSubscribeEncoding(
+    uint8_t invoke_id, const BACNET_SUBSCRIBE_COV_DATA *data)
 {
     uint8_t apdu[480] = { 0 };
     int len = 0;
@@ -310,7 +317,7 @@ testCOVSubscribeEncoding(uint8_t invoke_id, BACNET_SUBSCRIBE_COV_DATA *data)
 }
 
 static void testCOVSubscribePropertyEncoding(
-    uint8_t invoke_id, BACNET_SUBSCRIBE_COV_DATA *data)
+    uint8_t invoke_id, const BACNET_SUBSCRIBE_COV_DATA *data)
 {
     uint8_t apdu[480] = { 0 };
     int len = 0;

--- a/test/bacnet/datalink/bvlc/src/main.c
+++ b/test/bacnet/datalink/bvlc/src/main.c
@@ -22,14 +22,15 @@
  * @brief Test
  */
 static void test_BVLC_Address(
-    BACNET_IP_ADDRESS *bip_address_1, BACNET_IP_ADDRESS *bip_address_2)
+    const BACNET_IP_ADDRESS *bip_address_1,
+    const BACNET_IP_ADDRESS *bip_address_2)
 {
     zassert_false(bvlc_address_different(bip_address_1, bip_address_2), NULL);
 }
 
 static void test_BVLC_Broadcast_Distribution_Mask(
-    BACNET_IP_BROADCAST_DISTRIBUTION_MASK *bd_mask_1,
-    BACNET_IP_BROADCAST_DISTRIBUTION_MASK *bd_mask_2)
+    const BACNET_IP_BROADCAST_DISTRIBUTION_MASK *bd_mask_1,
+    const BACNET_IP_BROADCAST_DISTRIBUTION_MASK *bd_mask_2)
 {
     zassert_false(
         bvlc_broadcast_distribution_mask_different(bd_mask_1, bd_mask_2), NULL);
@@ -68,7 +69,7 @@ static void test_BVLC_Foreign_Device_Table_Entry(
 }
 
 static int test_BVLC_Header(
-    uint8_t *pdu,
+    const uint8_t *pdu,
     uint16_t pdu_len,
     uint8_t *message_type,
     uint16_t *message_length)
@@ -175,8 +176,8 @@ static void test_BVLC_Original_Unicast_NPDU(void)
     test_BVLC_Original_Unicast_NPDU_Message(npdu, npdu_len);
 }
 
-static void
-test_BVLC_Original_Broadcast_NPDU_Message(uint8_t *npdu, uint16_t npdu_len)
+static void test_BVLC_Original_Broadcast_NPDU_Message(
+    const uint8_t *npdu, uint16_t npdu_len)
 {
     uint8_t test_npdu[50] = { 0 };
     uint8_t pdu[60] = { 0 };
@@ -223,7 +224,9 @@ static void test_BVLC_Original_Broadcast_NPDU(void)
 }
 
 static void test_BVLC_Forwarded_NPDU_Message(
-    uint8_t *npdu, uint16_t npdu_len, BACNET_IP_ADDRESS *bip_address)
+    const uint8_t *npdu,
+    uint16_t npdu_len,
+    const BACNET_IP_ADDRESS *bip_address)
 {
     uint8_t test_npdu[50] = { 0 };
     uint8_t pdu[75] = { 0 };
@@ -314,7 +317,7 @@ static void test_BVLC_Register_Foreign_Device(void)
 }
 
 static void test_BVLC_Delete_Foreign_Device_Message(
-    BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *fdt_entry)
+    const BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY *fdt_entry)
 {
     uint8_t pdu[64] = { 0 };
     BACNET_IP_FOREIGN_DEVICE_TABLE_ENTRY test_fdt_entry = { 0 };
@@ -362,7 +365,8 @@ static void test_BVLC_Delete_Foreign_Device(void)
     test_BVLC_Delete_Foreign_Device_Message(&fdt_entry);
 }
 
-static void test_BVLC_Secure_BVLL_Message(uint8_t *sbuf, uint16_t sbuf_len)
+static void test_BVLC_Secure_BVLL_Message(
+    const uint8_t *sbuf, uint16_t sbuf_len)
 {
     uint8_t test_sbuf[50] = { 0 };
     uint8_t pdu[60] = { 0 };
@@ -429,7 +433,7 @@ static void test_BVLC_Read_Broadcast_Distribution_Table_Message(void)
 }
 
 static void test_BVLC_Distribute_Broadcast_To_Network_Message(
-    uint8_t *npdu, uint16_t npdu_len)
+    const uint8_t *npdu, uint16_t npdu_len)
 {
     uint8_t test_npdu[50] = { 0 };
     uint8_t pdu[60] = { 0 };

--- a/test/bacnet/datalink/mock/src/bip-mock.c
+++ b/test/bacnet/datalink/mock/src/bip-mock.c
@@ -19,7 +19,7 @@ bool bip_init(char *ifname)
     return ztest_get_return_value();
 }
 
-void bip_set_interface(char *ifname)
+void bip_set_interface(const char *ifname)
 {
     ztest_check_expected_value(ifname);
 }
@@ -56,7 +56,8 @@ int bip_send_pdu(
     return ztest_get_return_value();
 }
 
-int bip_send_mpdu(BACNET_IP_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
+int bip_send_mpdu(
+    const BACNET_IP_ADDRESS *dest, const uint8_t *mtu, uint16_t mtu_len)
 {
     ztest_check_expected_value(dest);
     ztest_check_expected_data(mtu, mtu_len);
@@ -87,7 +88,7 @@ uint16_t bip_get_port(void)
     return ztest_get_return_value();
 }
 
-bool bip_set_addr(BACNET_IP_ADDRESS *addr)
+bool bip_set_addr(const BACNET_IP_ADDRESS *addr)
 {
     ztest_check_expected_data(addr, sizeof(BACNET_IP_ADDRESS));
     return ztest_get_return_value();
@@ -111,7 +112,7 @@ void bip_get_broadcast_address(BACNET_ADDRESS *dest)
     ztest_copy_return_data(dest, sizeof(BACNET_ADDRESS));
 }
 
-bool bip_set_broadcast_addr(BACNET_IP_ADDRESS *addr)
+bool bip_set_broadcast_addr(const BACNET_IP_ADDRESS *addr)
 {
     return ztest_get_return_value();
 }

--- a/test/bacnet/datalink/mock/src/bip6-mock.c
+++ b/test/bacnet/datalink/mock/src/bip6-mock.c
@@ -58,13 +58,13 @@ void bip6_set_interface(char *ifname)
     ztest_check_expected_value(ifname);
 }
 
-bool bip6_address_match_self(BACNET_IP6_ADDRESS *addr)
+bool bip6_address_match_self(const BACNET_IP6_ADDRESS *addr)
 {
     ztest_check_expected_value(addr);
     return ztest_get_return_value();
 }
 
-bool bip6_set_addr(BACNET_IP6_ADDRESS *addr)
+bool bip6_set_addr(const BACNET_IP6_ADDRESS *addr)
 {
     ztest_check_expected_data(addr, sizeof(BACNET_IP6_ADDRESS));
     return ztest_get_return_value();
@@ -91,12 +91,12 @@ void bip6_get_broadcast_address(BACNET_ADDRESS *my_address)
     ztest_copy_return_data(my_address, sizeof(BACNET_ADDRESS));
 }
 
-bool bip6_set_broadcast_addr(BACNET_IP6_ADDRESS *addr)
+bool bip6_set_broadcast_addr(const BACNET_IP6_ADDRESS *addr)
 {
     return ztest_get_return_value();
 }
 
-int bip6_send_mpdu(BACNET_IP6_ADDRESS *dest, uint8_t *mtu, uint16_t mtu_len)
+int bip6_send_mpdu(const BACNET_IP6_ADDRESS *dest, const uint8_t *mtu, uint16_t mtu_len)
 {
     ztest_check_expected_value(dest);
     ztest_check_expected_data(mtu, mtu_len);

--- a/test/bacnet/datalink/mock/src/ethernet-mock.c
+++ b/test/bacnet/datalink/mock/src/ethernet-mock.c
@@ -45,7 +45,7 @@ uint16_t ethernet_receive(
     return ztest_get_return_value();
 }
 
-void ethernet_set_my_address(BACNET_ADDRESS *my_address)
+void ethernet_set_my_address(const BACNET_ADDRESS *my_address)
 {
     ztest_check_expected_data(my_address, sizeof(BACNET_ADDRESS));
 }
@@ -60,7 +60,7 @@ void ethernet_get_broadcast_address(BACNET_ADDRESS *dest)
     ztest_copy_return_data(dest, sizeof(BACNET_ADDRESS));
 }
 
-void ethernet_debug_address(const char *info, BACNET_ADDRESS *dest)
+void ethernet_debug_address(const char *info, const BACNET_ADDRESS *dest)
 {
     ztest_check_expected_value(info);
     ztest_check_expected_value(dest);

--- a/test/bacnet/datalink/mstp/src/main.c
+++ b/test/bacnet/datalink/mstp/src/main.c
@@ -45,7 +45,9 @@ static uint8_t TxBuffer[MAX_MPDU];
  * @param nbytes number of bytes to send
  */
 void RS485_Send_Frame(
-    struct mstp_port_struct_t *mstp_port, uint8_t *buffer, uint16_t nbytes)
+    struct mstp_port_struct_t *mstp_port,
+    const uint8_t *buffer,
+    uint16_t nbytes)
 {
     (void)mstp_port;
     (void)buffer;
@@ -61,7 +63,7 @@ static FIFO_BUFFER Test_Queue;
  * @param buffer pointer to the data
  * @param len number of bytes to load
  */
-static void Load_Input_Buffer(uint8_t *buffer, size_t len)
+static void Load_Input_Buffer(const uint8_t *buffer, size_t len)
 {
     static bool initialized = false; /* tracks our init */
     if (!initialized) {
@@ -154,7 +156,9 @@ static void Timer_Silence_Reset(void *pArg)
  * @param nbytes number of bytes to send
  */
 void MSTP_Send_Frame(
-    struct mstp_port_struct_t *mstp_port, uint8_t *buffer, uint16_t nbytes)
+    struct mstp_port_struct_t *mstp_port,
+    const uint8_t *buffer,
+    uint16_t nbytes)
 {
     if (mstp_port && mstp_port->OutputBuffer && buffer && (nbytes > 0) &&
         (nbytes <= mstp_port->OutputBufferSize)) {

--- a/test/bacnet/dcc/src/main.c
+++ b/test/bacnet/dcc/src/main.c
@@ -20,7 +20,7 @@
  * @brief Test
  */
 static int dcc_decode_apdu(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     unsigned apdu_size,
     uint8_t *invoke_id,
     uint16_t *timeDuration,
@@ -64,7 +64,7 @@ static void test_DeviceCommunicationControlData(
     uint8_t invoke_id,
     uint16_t timeDuration,
     BACNET_COMMUNICATION_ENABLE_DISABLE enable_disable,
-    BACNET_CHARACTER_STRING *password)
+    const BACNET_CHARACTER_STRING *password)
 {
     uint8_t apdu[480] = { 0 };
     int apdu_size = 0, null_len = 0, test_len = 0;

--- a/test/bacnet/getalarm/src/main.c
+++ b/test/bacnet/getalarm/src/main.c
@@ -24,7 +24,7 @@
  * @return number of bytes decoded
  */
 static int get_alarm_summary_decode_apdu(
-    uint8_t *apdu, unsigned apdu_size, uint8_t *invoke_id)
+    const uint8_t *apdu, unsigned apdu_size, uint8_t *invoke_id)
 {
     if (!apdu) {
         return BACNET_STATUS_ERROR;
@@ -53,7 +53,7 @@ static int get_alarm_summary_decode_apdu(
  * @return number of bytes decoded
  */
 static int get_alarm_summary_ack_decode_apdu(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     int apdu_len,
     uint8_t *invoke_id,
     BACNET_GET_ALARM_SUMMARY_DATA *get_alarm_data)

--- a/test/bacnet/getevent/src/main.c
+++ b/test/bacnet/getevent/src/main.c
@@ -20,7 +20,7 @@
  * @brief Test
  */
 static int getevent_decode_apdu(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     unsigned apdu_size,
     uint8_t *invoke_id,
     BACNET_OBJECT_ID *lastReceivedObjectIdentifier)
@@ -58,7 +58,7 @@ static int getevent_decode_apdu(
 }
 
 static int getevent_ack_decode_apdu(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     int apdu_len, /* total length of the apdu */
     uint8_t *invoke_id,
     BACNET_GET_EVENT_INFORMATION_DATA *get_event_data,

--- a/test/bacnet/iam/src/main.c
+++ b/test/bacnet/iam/src/main.c
@@ -20,7 +20,7 @@
  * @brief Test
  */
 static int iam_decode_apdu(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     uint32_t *pDevice_id,
     unsigned *pMax_apdu,
     int *pSegmentation,

--- a/test/bacnet/ihave/src/main.c
+++ b/test/bacnet/ihave/src/main.c
@@ -19,7 +19,7 @@
 /**
  * @brief Test
  */
-static void testIHaveData(BACNET_I_HAVE_DATA *data)
+static void testIHaveData(const BACNET_I_HAVE_DATA *data)
 {
     uint8_t apdu[480] = { 0 };
     int len = 0;

--- a/test/bacnet/rd/src/main.c
+++ b/test/bacnet/rd/src/main.c
@@ -21,7 +21,7 @@
  * @brief Test
  */
 static int rd_decode_apdu(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     unsigned apdu_size,
     uint8_t *invoke_id,
     BACNET_REINITIALIZED_STATE *state,

--- a/test/bacnet/reject/src/main.c
+++ b/test/bacnet/reject/src/main.c
@@ -21,7 +21,7 @@
  */
 /* decode the whole APDU - mainly used for unit testing */
 static int reject_decode_apdu(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     unsigned apdu_len,
     uint8_t *invoke_id,
     uint8_t *reject_reason)

--- a/test/bacnet/rp/src/main.c
+++ b/test/bacnet/rp/src/main.c
@@ -21,7 +21,7 @@
  * @brief Test
  */
 static int rp_decode_apdu(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     unsigned apdu_size,
     uint8_t *invoke_id,
     BACNET_READ_PROPERTY_DATA *rpdata)

--- a/test/bacnet/timesync/src/main.c
+++ b/test/bacnet/timesync/src/main.c
@@ -21,7 +21,8 @@
  * @brief Test
  */
 static void testTimeSyncRecipientData(
-    BACNET_RECIPIENT_LIST *recipient1, BACNET_RECIPIENT_LIST *recipient2)
+    const BACNET_RECIPIENT_LIST *recipient1,
+    const BACNET_RECIPIENT_LIST *recipient2)
 {
     unsigned i = 0;
 
@@ -124,7 +125,7 @@ static void testTimeSyncRecipient(void)
 }
 
 static int timesync_decode_apdu_service(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     BACNET_UNCONFIRMED_SERVICE service,
     unsigned apdu_len,
     BACNET_DATE *my_date,
@@ -149,7 +150,7 @@ static int timesync_decode_apdu_service(
 }
 
 int timesync_utc_decode_apdu(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     unsigned apdu_len,
     BACNET_DATE *my_date,
     BACNET_TIME *my_time)
@@ -160,7 +161,7 @@ int timesync_utc_decode_apdu(
 }
 
 int timesync_decode_apdu(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     unsigned apdu_len,
     BACNET_DATE *my_date,
     BACNET_TIME *my_time)
@@ -170,7 +171,8 @@ int timesync_decode_apdu(
         my_time);
 }
 
-static void testTimeSyncData(BACNET_DATE *my_date, BACNET_TIME *my_time)
+static void testTimeSyncData(
+    const BACNET_DATE *my_date, const BACNET_TIME *my_time)
 {
     uint8_t apdu[480] = { 0 };
     int len = 0;

--- a/test/bacnet/whohas/src/main.c
+++ b/test/bacnet/whohas/src/main.c
@@ -18,7 +18,7 @@
  * @brief Test
  */
 int whohas_decode_apdu(
-    uint8_t *apdu, unsigned apdu_size, BACNET_WHO_HAS_DATA *data)
+    const uint8_t *apdu, unsigned apdu_size, BACNET_WHO_HAS_DATA *data)
 {
     int len = 0;
 

--- a/test/bacnet/whois/src/main.c
+++ b/test/bacnet/whois/src/main.c
@@ -21,7 +21,10 @@
  * @brief Test
  */
 static int whois_decode_apdu(
-    uint8_t *apdu, unsigned apdu_len, int32_t *pLow_limit, int32_t *pHigh_limit)
+    const uint8_t *apdu,
+    unsigned apdu_len,
+    int32_t *pLow_limit,
+    int32_t *pHigh_limit)
 {
     int len = 0;
 

--- a/test/bacnet/wp/src/main.c
+++ b/test/bacnet/wp/src/main.c
@@ -21,7 +21,7 @@
  * @return number of bytes decoded, or #BACNET_STATUS_ERROR
  */
 static int wp_decode_apdu(
-    uint8_t *apdu,
+    const uint8_t *apdu,
     unsigned apdu_size,
     uint8_t *invoke_id,
     BACNET_WRITE_PROPERTY_DATA *wpdata)
@@ -63,7 +63,7 @@ static int wp_decode_apdu(
     return apdu_len;
 }
 
-static void testWritePropertyTag(BACNET_APPLICATION_DATA_VALUE *value)
+static void testWritePropertyTag(const BACNET_APPLICATION_DATA_VALUE *value)
 {
     BACNET_WRITE_PROPERTY_DATA wpdata = { 0 };
     BACNET_WRITE_PROPERTY_DATA test_data = { 0 };

--- a/test/bacnet/wpm/src/main.c
+++ b/test/bacnet/wpm/src/main.c
@@ -17,7 +17,8 @@
 /**
  * @brief Decode service header for WritePropertyMultiple
  */
-static int wpm_decode_apdu(uint8_t *apdu, unsigned apdu_len, uint8_t *invoke_id)
+static int wpm_decode_apdu(
+    const uint8_t *apdu, unsigned apdu_len, uint8_t *invoke_id)
 {
     int len = 0;
 

--- a/test/unit/bacnet/bacerror/src/fakes/bacdcode.c
+++ b/test/unit/bacnet/bacerror/src/fakes/bacdcode.c
@@ -16,7 +16,7 @@ DEFINE_FAKE_VALUE_FUNC(int, decode_tag_number, uint8_t *, uint8_t *);
 DEFINE_FAKE_VALUE_FUNC(int, bacnet_tag_number_decode, uint8_t *, uint32_t, uint8_t *);
 #endif
 DEFINE_FAKE_VALUE_FUNC(
-    int, decode_tag_number_and_value, uint8_t *, uint8_t *, uint32_t *);
+    int, decode_tag_number_and_value, const uint8_t *, uint8_t *, uint32_t *);
 #if 0
 DEFINE_FAKE_VALUE_FUNC(int, bacnet_tag_number_and_value_decode, uint8_t *, uint32_t, uint8_t *, uint32_t *);
 DEFINE_FAKE_VALUE_FUNC(bool, decode_is_opening_tag_number, uint8_t *, uint8_t);
@@ -86,7 +86,7 @@ DEFINE_FAKE_VALUE_FUNC(int, bacnet_signed_application_decode, uint8_t *, uint16_
 DEFINE_FAKE_VALUE_FUNC(int, bacnet_enumerated_decode, uint8_t *, uint16_t, uint32_t, uint32_t *);
 DEFINE_FAKE_VALUE_FUNC(int, bacnet_enumerated_context_decode, uint8_t *, uint16_t, uint8_t, uint32_t *);
 #endif
-DEFINE_FAKE_VALUE_FUNC(int, decode_enumerated, uint8_t *, uint32_t, uint32_t *);
+DEFINE_FAKE_VALUE_FUNC(int, decode_enumerated, const uint8_t *, uint32_t, uint32_t *);
 #if 0
 DEFINE_FAKE_VALUE_FUNC(int, decode_context_enumerated, uint8_t *, uint8_t, uint32_t *);
 DEFINE_FAKE_VALUE_FUNC(int, encode_bacnet_enumerated, uint8_t *, uint32_t);

--- a/test/unit/bacnet/bacerror/src/fakes/bacdcode.h
+++ b/test/unit/bacnet/bacerror/src/fakes/bacdcode.h
@@ -29,7 +29,7 @@ DECLARE_FAKE_VALUE_FUNC(int, decode_tag_number, uint8_t *, uint8_t *);
 DECLARE_FAKE_VALUE_FUNC(int, bacnet_tag_number_decode, uint8_t *, uint32_t, uint8_t *);
 #endif
 DECLARE_FAKE_VALUE_FUNC(
-    int, decode_tag_number_and_value, uint8_t *, uint8_t *, uint32_t *);
+    int, decode_tag_number_and_value, const uint8_t *, uint8_t *, uint32_t *);
 #if 0
 DECLARE_FAKE_VALUE_FUNC(int, bacnet_tag_number_and_value_decode, uint8_t *, uint32_t, uint8_t *, uint32_t *);
 DECLARE_FAKE_VALUE_FUNC(bool, decode_is_opening_tag_number, uint8_t *, uint8_t);
@@ -100,7 +100,7 @@ DECLARE_FAKE_VALUE_FUNC(int, bacnet_enumerated_decode, uint8_t *, uint16_t, uint
 DECLARE_FAKE_VALUE_FUNC(int, bacnet_enumerated_context_decode, uint8_t *, uint16_t, uint8_t, uint32_t *);
 #endif
 DECLARE_FAKE_VALUE_FUNC(
-    int, decode_enumerated, uint8_t *, uint32_t, uint32_t *);
+    int, decode_enumerated, const uint8_t *, uint32_t, uint32_t *);
 #if 0
 DECLARE_FAKE_VALUE_FUNC(int, decode_context_enumerated, uint8_t *, uint8_t, uint32_t *);
 DECLARE_FAKE_VALUE_FUNC(int, encode_bacnet_enumerated, uint8_t *, uint32_t);

--- a/test/unit/bacnet/bacerror/src/main.c
+++ b/test/unit/bacnet/bacerror/src/main.c
@@ -93,7 +93,7 @@ struct decode_tag_number_and_value_custom_fake_context {
 };
 
 static int decode_tag_number_and_value_custom_fake(
-    uint8_t *apdu, uint8_t *tag_number, uint32_t *value)
+    const uint8_t *apdu, uint8_t *tag_number, uint32_t *value)
 {
     RETURN_HANDLED_CONTEXT(decode_tag_number_and_value,
         struct decode_tag_number_and_value_custom_fake_context,
@@ -125,7 +125,7 @@ struct decode_enumerated_custom_fake_context {
 };
 
 static int decode_enumerated_custom_fake(
-    uint8_t *apdu, uint32_t len_value, uint32_t *value)
+    const uint8_t *apdu, uint32_t len_value, uint32_t *value)
 {
     RETURN_HANDLED_CONTEXT(decode_enumerated,
         struct decode_enumerated_custom_fake_context,

--- a/zephyr/subsys/bacnet_basic/device.c
+++ b/zephyr/subsys/bacnet_basic/device.c
@@ -624,7 +624,7 @@ bool Device_Object_Name(
     return status;
 }
 
-bool Device_Set_Object_Name(BACNET_CHARACTER_STRING *object_name)
+bool Device_Set_Object_Name(const BACNET_CHARACTER_STRING *object_name)
 {
     bool status = false; /*return value */
 
@@ -830,7 +830,7 @@ int Device_Object_List_Element_Encode(
  * Object.
  * @return True on success or else False if not found.
  */
-bool Device_Valid_Object_Name(BACNET_CHARACTER_STRING *object_name1,
+bool Device_Valid_Object_Name(const BACNET_CHARACTER_STRING *object_name1,
     BACNET_OBJECT_TYPE *object_type,
     uint32_t *object_instance)
 {
@@ -1067,7 +1067,7 @@ int Device_Read_Property_Local(BACNET_READ_PROPERTY_DATA *rpdata)
  * @return The length of the APDU on success, else BACNET_STATUS_ERROR
  */
 static int Read_Property_Common(
-    struct object_functions *pObject, BACNET_READ_PROPERTY_DATA *rpdata)
+    const struct object_functions *pObject, BACNET_READ_PROPERTY_DATA *rpdata)
 {
     int apdu_len = BACNET_STATUS_ERROR;
     BACNET_CHARACTER_STRING char_string;


### PR DESCRIPTION
Make most of the code const correct. Note that this probably is kind of breaking change as many functions change which might also be user defined. I still think this should be done and work towards const correct code should continue.

I use clang-tidy and sonarlint to help find places where const could pretty easily applied. Also lot of hand work.

This PR does not yet touch handlers and typedefs of those.

This PR also fix couple issue found during this work. Another one was found because of this work. Now that we have more const correct code analyzers could spot uninitialized values more easily.

Related issue https://github.com/bacnet-stack/bacnet-stack/issues/320