### PR TITLE
Make it possible to select multiple datalinks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,33 +46,37 @@ option(
 
 option(
   BACDL_ETHERNET
-  "compile with ethernet support"
+  "compile with ethernet datalink support"
   OFF)
 
 option(
   BACDL_MSTP
-  "compile with mstp support"
+  "compile with mstp datalink support"
   OFF)
 
 option(
   BACDL_ARCNET
-  "compile with arcnet support"
+  "compile with arcnet datalink support"
   OFF)
 
 option(
   BACDL_BIP
-  "compile with ip support"
+  "compile with ip datalink support"
   ON)
 
 option(
   BACDL_BIP6
-  "compile with ipv6 support"
+  "compile with ipv6 datalink support"
   OFF)
 
-option(
-  BACDL_NONE
-  "compile without datalink"
-  OFF)
+if(NOT (BACDL_ETHERNET OR
+        BACDL_MSTP OR
+        BACDL_ARCNET OR
+        BACDL_BIP OR
+        BACDL_BIP6 OR
+        BACDL_CUSTOM))
+  add_definitions(-DBACDL_NONE)
+endif()
 
 set(BACNET_PROTOCOL_REVISION 19)
 
@@ -962,9 +966,9 @@ message(STATUS "BACNET: CMAKE_CXX_COMPILER_VERSION:.....\"${CMAKE_CXX_COMPILER_V
 message(STATUS "BACNET: CMAKE_BUILD_TYPE:...............\"${CMAKE_BUILD_TYPE}\"")
 message(STATUS "BACNET: CMAKE_INSTALL_PREFIX:...........\"${CMAKE_INSTALL_PREFIX}\"")
 message(STATUS "BACNET: BACNET_PROTOCOL_REVISION:.......\"${BACNET_PROTOCOL_REVISION}\"")
+message(STATUS "BACNET: Selected datalinks:")
 message(STATUS "BACNET: BACDL_BIP6:.....................\"${BACDL_BIP6}\"")
 message(STATUS "BACNET: BACDL_BIP:......................\"${BACDL_BIP}\"")
 message(STATUS "BACNET: BACDL_ARCNET:...................\"${BACDL_ARCNET}\"")
 message(STATUS "BACNET: BACDL_MSTP:.....................\"${BACDL_MSTP}\"")
 message(STATUS "BACNET: BACDL_ETHERNET:.................\"${BACDL_ETHERNET}\"")
-message(STATUS "BACNET: BACDL_NONE:.....................\"${BACDL_NONE}\"")

--- a/ports/arduino_uno/datalink.h
+++ b/ports/arduino_uno/datalink.h
@@ -13,7 +13,22 @@
 
 #if defined(BACDL_ETHERNET)
 #include "bacnet/datalink/ethernet.h"
+#endif
+#if defined(BACDL_ARCNET)
+#include "bacnet/datalink/arcnet.h"
+#endif
+#if defined(BACDL_MSTP)
+#include "bacnet/datalink/dlmstp.h"
+#endif
+#if defined(BACDL_BIP)
+#include "bacnet/datalink/bip.h"
+#include "bvlc-arduino.h"
+#endif
+#if defined(BACDL_BIP6)
+#error currently not implemented for Arduino
+#endif
 
+#if defined(BACDL_ETHERNET) && !defined(BACDL_MULTIPLE)
 #define datalink_init ethernet_init
 #define datalink_send_pdu ethernet_send_pdu
 #define datalink_receive ethernet_receive
@@ -21,9 +36,7 @@
 #define datalink_get_broadcast_address ethernet_get_broadcast_address
 #define datalink_get_my_address ethernet_get_my_address
 
-#elif defined(BACDL_ARCNET)
-#include "bacnet/datalink/arcnet.h"
-
+#elif defined(BACDL_ARCNET) && !defined(BACDL_MULTIPLE)
 #define datalink_init arcnet_init
 #define datalink_send_pdu arcnet_send_pdu
 #define datalink_receive arcnet_receive
@@ -31,9 +44,7 @@
 #define datalink_get_broadcast_address arcnet_get_broadcast_address
 #define datalink_get_my_address arcnet_get_my_address
 
-#elif defined(BACDL_MSTP)
-#include "bacnet/datalink/dlmstp.h"
-
+#elif defined(BACDL_MSTP) && !defined(BACDL_MULTIPLE)
 #define datalink_init dlmstp_init
 #define datalink_send_pdu dlmstp_send_pdu
 #define datalink_receive dlmstp_receive
@@ -41,9 +52,7 @@
 #define datalink_get_broadcast_address dlmstp_get_broadcast_address
 #define datalink_get_my_address dlmstp_get_my_address
 
-#elif defined(BACDL_BIP)
-#include "bacnet/datalink/bip.h"
-#include "bvlc-arduino.h"
+#elif defined(BACDL_BIP) && !defined(BACDL_MULTIPLE)
 
 #define datalink_init bip_init
 // #if defined(BBMD_ENABLED) && BBMD_ENABLED
@@ -62,7 +71,7 @@ extern void routed_get_my_address(BACNET_ADDRESS *my_address);
 #define datalink_get_my_address bip_get_my_address
 #endif
 
-#else /* Ie, BACDL_ALL */
+#else /* Ie, BACDL_MULTIPLE */
 #include "bacnet/npdu.h"
 
 #define MAX_HEADER (8)

--- a/src/bacnet/basic/object/netport.c
+++ b/src/bacnet/basic/object/netport.c
@@ -26,7 +26,7 @@
 /* me */
 #include "bacnet/basic/object/netport.h"
 
-#if defined(BACDL_BIP6) || defined(BACDL_ALL)
+#if defined(BACDL_BIP6)
 #include "bacnet/datalink/bvlc6.h"
 #endif
 
@@ -139,17 +139,14 @@ static const int BIP_Port_Properties_Optional[] = {
     PROP_IP_DEFAULT_GATEWAY,
     PROP_IP_DNS_SERVER,
     PROP_IP_DHCP_ENABLE,
-#if (defined(BACDL_ALL) || defined(BACDL_BIP)) && \
-    (BBMD_ENABLED || BBMD_CLIENT_ENABLED)
-#if (BBMD_ENABLED)
+#if defined(BACDL_BIP) && (BBMD_ENABLED)
     PROP_BBMD_ACCEPT_FD_REGISTRATIONS,
     PROP_BBMD_BROADCAST_DISTRIBUTION_TABLE,
     PROP_BBMD_FOREIGN_DEVICE_TABLE,
 #endif
-#if (BBMD_CLIENT_ENABLED)
+#if defined(BACDL_BIP) && (BBMD_CLIENT_ENABLED)
     PROP_FD_BBMD_ADDRESS,
     PROP_FD_SUBSCRIPTION_LIFETIME,
-#endif
 #endif
     -1
 };
@@ -168,17 +165,14 @@ static const int BIP6_Port_Properties_Optional[] = {
     PROP_IPV6_DHCP_LEASE_TIME_REMAINING,
     PROP_IPV6_DHCP_SERVER,
     PROP_IPV6_ZONE_INDEX,
-#if (defined(BACDL_ALL) || defined(BACDL_BIP6)) && \
-    (BBMD_ENABLED || BBMD_CLIENT_ENABLED)
-#if (BBMD_ENABLED)
+#if defined(BACDL_BIP6) && (BBMD_ENABLED)
     PROP_BBMD_ACCEPT_FD_REGISTRATIONS,
     PROP_BBMD_BROADCAST_DISTRIBUTION_TABLE,
     PROP_BBMD_FOREIGN_DEVICE_TABLE,
 #endif
-#if (BBMD_CLIENT_ENABLED)
+#if defined(BACDL_BIP6) && (BBMD_CLIENT_ENABLED)
     PROP_FD_BBMD_ADDRESS,
     PROP_FD_SUBSCRIPTION_LIFETIME,
-#endif
 #endif
     -1
 };
@@ -1654,8 +1648,7 @@ bool Network_Port_BBMD_FD_Table_Set(uint32_t object_instance, void *fdt_head)
     return status;
 }
 
-#if (defined(BACDL_BIP) || defined(BACDL_ALL)) && \
-    (BBMD_ENABLED || BBMD_CLIENT_ENABLED)
+#if defined(BACDL_BIP) && (BBMD_ENABLED || BBMD_CLIENT_ENABLED)
 /**
  * For a given object instance-number, gets the ip-address and port
  * Note: depends on Network_Type being set for this object
@@ -1875,7 +1868,7 @@ bool Network_Port_Remote_BBMD_BIP_Lifetime_Set(
 }
 
 /* IPv6 BBMD related getters and setters */
-#if (defined(BACDL_ALL) || defined(BACDL_BIP6))
+#if defined(BACDL_BIP6)
 
 /**
  * For a given object instance-number, returns the BBMD-Accept-FD-Registrations
@@ -2034,7 +2027,7 @@ bool Network_Port_BBMD_IP6_FD_Table_Set(
     return status;
 }
 
-#if (defined(BACDL_ALL) || defined(BACDL_BIP6)) && (BBMD_CLIENT_ENABLED)
+#if defined(BACDL_BIP6) && (BBMD_CLIENT_ENABLED)
 /**
  * For a given object instance-number, gets the ip-address and port
  * Note: depends on Network_Type being set for this object
@@ -2852,7 +2845,7 @@ static bool Network_Port_FD_BBMD_Address_Write(
         return status;
     }
     switch (Network_Port_Type(object_instance)) {
-#if (defined(BACDL_ALL) || defined(BACDL_BIP))
+#if defined(BACDL_BIP)
         case PORT_TYPE_BIP:
             if (Network_Port_BIP_Mode(object_instance) !=
                 BACNET_IP_MODE_FOREIGN) {
@@ -2876,7 +2869,7 @@ static bool Network_Port_FD_BBMD_Address_Write(
             }
             break;
 #endif
-#if (defined(BACDL_ALL) || defined(BACDL_BIP6))
+#if defined(BACDL_BIP6)
         case PORT_TYPE_BIP6:
             if (Network_Port_BIP6_Mode(object_instance) !=
                 BACNET_IP_MODE_FOREIGN) {
@@ -2936,7 +2929,7 @@ static bool Network_Port_FD_Subscription_Lifetime_Write(
     }
     lifetime = (uint16_t)value;
     switch (Network_Port_Type(object_instance)) {
-#if (defined(BACDL_ALL) || defined(BACDL_BIP))
+#if defined(BACDL_BIP)
         case PORT_TYPE_BIP:
             if (Network_Port_BIP_Mode(object_instance) ==
                 BACNET_IP_MODE_FOREIGN) {
@@ -2952,7 +2945,7 @@ static bool Network_Port_FD_Subscription_Lifetime_Write(
             }
             break;
 #endif
-#if (defined(BACDL_ALL) || defined(BACDL_BIP6))
+#if defined(BACDL_BIP6)
         case PORT_TYPE_BIP6:
             if (Network_Port_BIP6_Mode(object_instance) ==
                 BACNET_IP_MODE_FOREIGN) {
@@ -3076,11 +3069,10 @@ int Network_Port_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata)
     BACNET_BIT_STRING bit_string;
     BACNET_OCTET_STRING octet_string;
     BACNET_CHARACTER_STRING char_string;
-#if (defined(BACDL_ALL) || defined(BACDL_BIP)) && \
-    (BBMD_ENABLED || BBMD_CLIENT_ENABLED)
+#if defined(BACDL_BIP) && (BBMD_ENABLED || BBMD_CLIENT_ENABLED)
     BACNET_IP_ADDRESS ip_address;
 #endif
-#if (defined(BACDL_ALL) || defined(BACDL_BIP6)) && (BBMD_CLIENT_ENABLED)
+#if defined(BACDL_BIP6) && (BBMD_CLIENT_ENABLED)
     BACNET_IP6_ADDRESS ip6_address;
 #endif
     uint8_t *apdu = NULL;
@@ -3238,7 +3230,7 @@ int Network_Port_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata)
                 apdu_len = BACNET_STATUS_ERROR;
             }
             break;
-#if (defined(BACDL_BIP) || defined(BACDL_BIP6) || defined(BACDL_ALL)) && \
+#if (defined(BACDL_BIP) || defined(BACDL_BIP6)) && \
     (BBMD_ENABLED || BBMD_CLIENT_ENABLED)
 #if (BBMD_ENABLED)
         case PROP_BBMD_ACCEPT_FD_REGISTRATIONS:
@@ -3249,14 +3241,14 @@ int Network_Port_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata)
             break;
         case PROP_BBMD_BROADCAST_DISTRIBUTION_TABLE:
             switch (network_type) {
-#if (defined(BACDL_ALL) || defined(BACDL_BIP))
+#if defined(BACDL_BIP)
                 case PORT_TYPE_BIP:
                     apdu_len = bvlc_broadcast_distribution_table_encode(
                         &apdu[0], rpdata->application_data_len,
                         Network_Port_BBMD_BD_Table(rpdata->object_instance));
                     break;
 #endif
-#if (defined(BACDL_ALL) || defined(BACDL_BIP6))
+#if defined(BACDL_BIP6)
                 case PORT_TYPE_BIP6:
                     apdu_len = bvlc6_broadcast_distribution_table_encode(
                         &apdu[0], rpdata->application_data_len,
@@ -3273,14 +3265,14 @@ int Network_Port_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata)
             break;
         case PROP_BBMD_FOREIGN_DEVICE_TABLE:
             switch (network_type) {
-#if (defined(BACDL_ALL) || defined(BACDL_BIP))
+#if defined(BACDL_BIP)
                 case PORT_TYPE_BIP:
                     apdu_len = bvlc_foreign_device_table_encode(
                         &apdu[0], rpdata->application_data_len,
                         Network_Port_BBMD_FD_Table(rpdata->object_instance));
                     break;
 #endif
-#if (defined(BACDL_ALL) || defined(BACDL_BIP6))
+#if defined(BACDL_BIP6)
                 case PORT_TYPE_BIP6:
                     apdu_len = bvlc6_foreign_device_table_encode(
                         &apdu[0], rpdata->application_data_len,
@@ -3299,8 +3291,7 @@ int Network_Port_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata)
 #if (BBMD_CLIENT_ENABLED)
         case PROP_FD_BBMD_ADDRESS:
             switch (network_type) {
-#if (defined(BACDL_BIP) || defined(BACDL_ALL)) && \
-    (BBMD_ENABLED || BBMD_CLIENT_ENABLED)
+#if defined(BACDL_BIP) && (BBMD_ENABLED || BBMD_CLIENT_ENABLED)
                 case PORT_TYPE_BIP:
                     Network_Port_Remote_BBMD_IP_Address_And_Port(
                         rpdata->object_instance, &ip_address);
@@ -3308,7 +3299,7 @@ int Network_Port_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata)
                         &apdu[0], apdu_size, &ip_address);
                     break;
 #endif
-#if (defined(BACDL_ALL) || defined(BACDL_BIP6))
+#if defined(BACDL_BIP6)
                 case PORT_TYPE_BIP6:
                     Network_Port_Remote_BBMD_IP6_Address_And_Port(
                         rpdata->object_instance, &ip6_address);
@@ -3325,7 +3316,7 @@ int Network_Port_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata)
             break;
         case PROP_FD_SUBSCRIPTION_LIFETIME:
             switch (network_type) {
-#if (defined(BACDL_ALL) || defined(BACDL_BIP))
+#if defined(BACDL_BIP)
                 case PORT_TYPE_BIP:
                     apdu_len = encode_application_unsigned(
                         &apdu[0],
@@ -3333,7 +3324,7 @@ int Network_Port_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata)
                             rpdata->object_instance));
                     break;
 #endif
-#if (defined(BACDL_ALL) || defined(BACDL_BIP6))
+#if defined(BACDL_BIP6)
                 case PORT_TYPE_BIP6:
                     apdu_len = encode_application_unsigned(
                         &apdu[0],

--- a/src/bacnet/basic/object/netport.h
+++ b/src/bacnet/basic/object/netport.h
@@ -209,7 +209,7 @@ BACNET_STACK_EXPORT
 bool Network_Port_Remote_BBMD_BIP_Lifetime_Set(
     uint32_t object_instance, uint16_t value);
 
-#if (defined(BACDL_ALL) || defined(BACDL_BIP6))
+#if defined(BACDL_BIP6)
 BACNET_STACK_EXPORT
 bool Network_Port_BBMD_IP6_Accept_FD_Registrations(uint32_t object_instance);
 BACNET_STACK_EXPORT

--- a/src/bacnet/config.h
+++ b/src/bacnet/config.h
@@ -74,35 +74,24 @@
 /* #define MAX_APDU 1476 */
 #if defined(BACDL_BIP)
 #define MAX_APDU 1476
-/* #define MAX_APDU 128 enable this IP for testing
-   readrange so you get the More Follows flag set */
+/* Enable this IP for testing readrange so you get the More Follows flag set */
+/* #define MAX_APDU 128 */
 #elif defined(BACDL_BIP6)
 #define MAX_APDU 1476
-#elif defined(BACDL_ETHERNET)
-#if defined(BACNET_SECURITY)
-#define MAX_APDU 1420
-#else
-#define MAX_APDU 1476
-#endif
-#elif defined(BACDL_ARCNET)
-#if defined(BACNET_SECURITY)
-#define MAX_APDU 412
-#else
-#define MAX_APDU 480
-#endif
-#elif defined(BACDL_MSTP)
-#if defined(BACNET_SECURITY)
-#define MAX_APDU 412
-#else
+#elif defined(BACDL_MSTP) && !defined(BACNET_SECURITY)
 /* note: MS/TP extended frames can be up to 1476 bytes */
 #define MAX_APDU 1476
-#endif
-#else
-#if defined(BACNET_SECURITY)
+#elif defined(BACDL_ETHERNET) && !defined(BACNET_SECURITY)
+#define MAX_APDU 1476
+#elif defined(BACDL_ETHERNET) && defined(BACNET_SECURITY)
+#define MAX_APDU 1420
+#elif !defined(BACNET_SECURITY)
+#define MAX_APDU 480
+#elif defined(BACDL_MSTP) && defined(BACNET_SECURITY)
+/* TODO: Is this really 412 or should it be 480? */
 #define MAX_APDU 412
 #else
-#define MAX_APDU 480
-#endif
+#define MAX_APDU 412
 #endif
 #endif
 

--- a/src/bacnet/config.h
+++ b/src/bacnet/config.h
@@ -21,17 +21,66 @@
 /* Note: these defines can be defined in your makefile or project
    or here or not defined and defaults will be used */
 
-/* declare a single physical layer using your compiler define.
-   see datalink.h for possible defines. */
-#if !(                                                                         \
-    defined(BACDL_ETHERNET) || defined(BACDL_ARCNET) || defined(BACDL_MSTP) || \
-    defined(BACDL_BIP) || defined(BACDL_BIP6) || defined(BACDL_TEST) ||        \
-    defined(BACDL_ALL) || defined(BACDL_NONE) || defined(BACDL_CUSTOM))
+/* Declare a physical layers using your compiler define. See
+   datalink.h for possible defines. */
+
+/* For backward compatibility for old BACDL_ALL */
+#if defined(BACDL_ALL)
+#define BACDL_ETHERNET
+#define BACDL_ARCNET
+#define BACDL_MSTP
+#define BACDL_BIP
+#define BACDL_BIP6
+#endif
+
+#if defined(BACDL_ETHERNET)
+#define BACDL_SOME_DATALINK_ENABLED 1
+#endif
+
+#if defined(BACDL_ARCNET)
+#if defined(BACDL_SOME_DATALINK_ENABLED)
+#define BACDL_MULTIPLE 1
+#endif
+#define BACDL_SOME_DATALINK_ENABLED 1
+#endif
+
+#if defined(BACDL_MSTP)
+#if defined(BACDL_SOME_DATALINK_ENABLED)
+#define BACDL_MULTIPLE 1
+#endif
+#define BACDL_SOME_DATALINK_ENABLED 1
+#endif
+
+#if defined(BACDL_BIP)
+#if defined(BACDL_SOME_DATALINK_ENABLED)
+#define BACDL_MULTIPLE 1
+#endif
+#define BACDL_SOME_DATALINK_ENABLED 1
+#endif
+
+#if defined(BACDL_BIP6)
+#if defined(BACDL_SOME_DATALINK_ENABLED)
+#define BACDL_MULTIPLE 1
+#endif
+#define BACDL_SOME_DATALINK_ENABLED 1
+#endif
+
+#if defined(BACDL_CUSTOM)
+#if defined(BACDL_SOME_DATALINK_ENABLED)
+#define BACDL_MULTIPLE 1
+#endif
+#endif
+
+#if defined(BACDL_SOME_DATALINK_ENABLED) && defined(BACDL_NONE)
+#error "BACDL_NONE is not compatible with other BACDL_ defines"
+#elif !defined(BACDL_SOME_DATALINK_ENABLED) && !defined(BACDL_NONE) && \
+    !defined(BACDL_TEST)
+/* If none of the datalink is enabled let's default to BIP. */
 #define BACDL_BIP
 #endif
 
 /* optional configuration for BACnet/IP datalink layer */
-#if (defined(BACDL_BIP) || defined(BACDL_ALL))
+#if (defined(BACDL_BIP))
 #if !defined(BBMD_ENABLED)
 #define BBMD_ENABLED 1
 #endif

--- a/src/bacnet/datalink/datalink.c
+++ b/src/bacnet/datalink/datalink.c
@@ -9,16 +9,26 @@
  */
 #include "bacnet/datalink/datalink.h"
 
-#if defined(BACDL_ALL) || defined FOR_DOXYGEN
+#if defined(BACDL_MULTIPLE) || defined FOR_DOXYGEN
+#if defined(BACDL_ETHERNET)
 #include "bacnet/datalink/ethernet.h"
+#endif
+#if defined(BACDL_BIP)
 #include "bacnet/datalink/bip.h"
 #include "bacnet/datalink/bvlc.h"
 #include "bacnet/basic/bbmd/h_bbmd.h"
+#endif
+#if defined(BACDL_BIP6)
 #include "bacnet/datalink/bip6.h"
 #include "bacnet/datalink/bvlc6.h"
 #include "bacnet/basic/bbmd6/h_bbmd6.h"
+#endif
+#if defined(BACDL_ARCNET)
 #include "bacnet/datalink/arcnet.h"
+#endif
+#if defined(BACDL_MSTP)
 #include "bacnet/datalink/dlmstp.h"
+#endif
 #include <strings.h> /* for strcasecmp() */
 
 static enum {
@@ -32,19 +42,34 @@ static enum {
 
 void datalink_set(char *datalink_string)
 {
-    if (strcasecmp("bip", datalink_string) == 0) {
-        Datalink_Transport = DATALINK_BIP;
-    } else if (strcasecmp("bip6", datalink_string) == 0) {
-        Datalink_Transport = DATALINK_BIP6;
-    } else if (strcasecmp("ethernet", datalink_string) == 0) {
-        Datalink_Transport = DATALINK_ETHERNET;
-    } else if (strcasecmp("arcnet", datalink_string) == 0) {
-        Datalink_Transport = DATALINK_ARCNET;
-    } else if (strcasecmp("mstp", datalink_string) == 0) {
-        Datalink_Transport = DATALINK_MSTP;
-    } else if (strcasecmp("none", datalink_string) == 0) {
+    if (strcasecmp("none", datalink_string) == 0) {
         Datalink_Transport = DATALINK_NONE;
     }
+#if defined(BACDL_BIP)
+    else if (strcasecmp("bip", datalink_string) == 0) {
+        Datalink_Transport = DATALINK_BIP;
+    }
+#endif
+#if defined(BACDL_BIP6)
+    else if (strcasecmp("bip6", datalink_string) == 0) {
+        Datalink_Transport = DATALINK_BIP6;
+    }
+#endif
+#if defined(BACDL_ETHERNET)
+    else if (strcasecmp("ethernet", datalink_string) == 0) {
+        Datalink_Transport = DATALINK_ETHERNET;
+    }
+#endif
+#if defined(BACDL_ARCNET)
+    else if (strcasecmp("arcnet", datalink_string) == 0) {
+        Datalink_Transport = DATALINK_ARCNET;
+    }
+#endif
+#if defined(BACDL_MSTP)
+    else if (strcasecmp("mstp", datalink_string) == 0) {
+        Datalink_Transport = DATALINK_MSTP;
+    }
+#endif
 }
 
 bool datalink_init(char *ifname)
@@ -55,21 +80,31 @@ bool datalink_init(char *ifname)
         case DATALINK_NONE:
             status = true;
             break;
+#if defined(BACDL_ARCNET)
         case DATALINK_ARCNET:
             status = arcnet_init(ifname);
             break;
+#endif
+#if defined(BACDL_ETHERNET)
         case DATALINK_ETHERNET:
             status = ethernet_init(ifname);
             break;
+#endif
+#if defined(BACDL_BIP)
         case DATALINK_BIP:
             status = bip_init(ifname);
             break;
+#endif
+#if defined(BACDL_BIP6)
         case DATALINK_BIP6:
             status = bip6_init(ifname);
             break;
+#endif
+#if defined(BACDL_MSTP)
         case DATALINK_MSTP:
             status = dlmstp_init(ifname);
             break;
+#endif
         default:
             break;
     }
@@ -89,21 +124,31 @@ int datalink_send_pdu(
         case DATALINK_NONE:
             bytes = pdu_len;
             break;
+#if defined(BACDL_ARCNET)
         case DATALINK_ARCNET:
             bytes = arcnet_send_pdu(dest, npdu_data, pdu, pdu_len);
             break;
+#endif
+#if defined(BACDL_ETHERNET)
         case DATALINK_ETHERNET:
             bytes = ethernet_send_pdu(dest, npdu_data, pdu, pdu_len);
             break;
+#endif
+#if defined(BACDL_BIP)
         case DATALINK_BIP:
             bytes = bip_send_pdu(dest, npdu_data, pdu, pdu_len);
             break;
+#endif
+#if defined(BACDL_BIP6)
         case DATALINK_BIP6:
             bytes = bip6_send_pdu(dest, npdu_data, pdu, pdu_len);
             break;
+#endif
+#if defined(BACDL_MSTP)
         case DATALINK_MSTP:
             bytes = dlmstp_send_pdu(dest, npdu_data, pdu, pdu_len);
             break;
+#endif
         default:
             break;
     }
@@ -119,21 +164,31 @@ uint16_t datalink_receive(
     switch (Datalink_Transport) {
         case DATALINK_NONE:
             break;
+#if defined(BACDL_ARCNET)
         case DATALINK_ARCNET:
             bytes = arcnet_receive(src, pdu, max_pdu, timeout);
             break;
+#endif
+#if defined(BACDL_ETHERNET)
         case DATALINK_ETHERNET:
             bytes = ethernet_receive(src, pdu, max_pdu, timeout);
             break;
+#endif
+#if defined(BACDL_BIP)
         case DATALINK_BIP:
             bytes = bip_receive(src, pdu, max_pdu, timeout);
             break;
+#endif
+#if defined(BACDL_BIP6)
         case DATALINK_BIP6:
             bytes = bip6_receive(src, pdu, max_pdu, timeout);
             break;
+#endif
+#if defined(BACDL_MSTP)
         case DATALINK_MSTP:
             bytes = dlmstp_receive(src, pdu, max_pdu, timeout);
             break;
+#endif
         default:
             break;
     }
@@ -146,21 +201,31 @@ void datalink_cleanup(void)
     switch (Datalink_Transport) {
         case DATALINK_NONE:
             break;
+#if defined(BACDL_ARCNET)
         case DATALINK_ARCNET:
             arcnet_cleanup();
             break;
+#endif
+#if defined(BACDL_ETHERNET)
         case DATALINK_ETHERNET:
             ethernet_cleanup();
             break;
+#endif
+#if defined(BACDL_BIP)
         case DATALINK_BIP:
             bip_cleanup();
             break;
+#endif
+#if defined(BACDL_BIP6)
         case DATALINK_BIP6:
             bip6_cleanup();
             break;
+#endif
+#if defined(BACDL_MSTP)
         case DATALINK_MSTP:
             dlmstp_cleanup();
             break;
+#endif
         default:
             break;
     }
@@ -171,21 +236,31 @@ void datalink_get_broadcast_address(BACNET_ADDRESS *dest)
     switch (Datalink_Transport) {
         case DATALINK_NONE:
             break;
+#if defined(BACDL_ARCNET)
         case DATALINK_ARCNET:
             arcnet_get_broadcast_address(dest);
             break;
+#endif
+#if defined(BACDL_ETHERNET)
         case DATALINK_ETHERNET:
             ethernet_get_broadcast_address(dest);
             break;
+#endif
+#if defined(BACDL_BIP)
         case DATALINK_BIP:
             bip_get_broadcast_address(dest);
             break;
+#endif
+#if defined(BACDL_BIP6)
         case DATALINK_BIP6:
             bip6_get_broadcast_address(dest);
             break;
+#endif
+#if defined(BACDL_MSTP)
         case DATALINK_MSTP:
             dlmstp_get_broadcast_address(dest);
             break;
+#endif
         default:
             break;
     }
@@ -196,21 +271,31 @@ void datalink_get_my_address(BACNET_ADDRESS *my_address)
     switch (Datalink_Transport) {
         case DATALINK_NONE:
             break;
+#if defined(BACDL_ARCNET)
         case DATALINK_ARCNET:
             arcnet_get_my_address(my_address);
             break;
+#endif
+#if defined(BACDL_ETHERNET)
         case DATALINK_ETHERNET:
             ethernet_get_my_address(my_address);
             break;
+#endif
+#if defined(BACDL_BIP)
         case DATALINK_BIP:
             bip_get_my_address(my_address);
             break;
+#endif
+#if defined(BACDL_BIP6)
         case DATALINK_BIP6:
             bip6_get_my_address(my_address);
             break;
+#endif
+#if defined(BACDL_MSTP)
         case DATALINK_MSTP:
             dlmstp_get_my_address(my_address);
             break;
+#endif
         default:
             break;
     }
@@ -222,21 +307,31 @@ void datalink_set_interface(char *ifname)
         case DATALINK_NONE:
             (void)ifname;
             break;
+#if defined(BACDL_ARCNET)
         case DATALINK_ARCNET:
             (void)ifname;
             break;
+#endif
+#if defined(BACDL_ETHERNET)
         case DATALINK_ETHERNET:
             (void)ifname;
             break;
+#endif
+#if defined(BACDL_BIP)
         case DATALINK_BIP:
             (void)ifname;
             break;
+#endif
+#if defined(BACDL_BIP6)
         case DATALINK_BIP6:
             (void)ifname;
             break;
+#endif
+#if defined(BACDL_MSTP)
         case DATALINK_MSTP:
             (void)ifname;
             break;
+#endif
         default:
             break;
     }
@@ -247,18 +342,28 @@ void datalink_maintenance_timer(uint16_t seconds)
     switch (Datalink_Transport) {
         case DATALINK_NONE:
             break;
+#if defined(BACDL_ARCNET)
         case DATALINK_ARCNET:
             break;
+#endif
+#if defined(BACDL_ETHERNET)
         case DATALINK_ETHERNET:
             break;
+#endif
+#if defined(BACDL_BIP)
         case DATALINK_BIP:
             bvlc_maintenance_timer(seconds);
             break;
+#endif
+#if defined(BACDL_BIP6)
         case DATALINK_BIP6:
             bvlc6_maintenance_timer(seconds);
             break;
+#endif
+#if defined(BACDL_MSTP)
         case DATALINK_MSTP:
             break;
+#endif
         default:
             break;
     }

--- a/src/bacnet/datalink/datalink.c
+++ b/src/bacnet/datalink/datalink.c
@@ -29,7 +29,9 @@
 #if defined(BACDL_MSTP)
 #include "bacnet/datalink/dlmstp.h"
 #endif
+#ifdef HAVE_STRINGS_H
 #include <strings.h> /* for strcasecmp() */
+#endif
 
 static enum {
     DATALINK_NONE = 0,

--- a/src/bacnet/datalink/datalink.h
+++ b/src/bacnet/datalink/datalink.h
@@ -14,6 +14,25 @@
 
 #if defined(BACDL_ETHERNET)
 #include "bacnet/datalink/ethernet.h"
+#endif
+#if defined(BACDL_ARCNET)
+#include "bacnet/datalink/arcnet.h"
+#endif
+#if defined(BACDL_MSTP)
+#include "bacnet/datalink/dlmstp.h"
+#endif
+#if defined(BACDL_BIP)
+#include "bacnet/datalink/bip.h"
+#include "bacnet/datalink/bvlc.h"
+#include "bacnet/basic/bbmd/h_bbmd.h"
+#endif
+#if defined(BACDL_BIP6)
+#include "bacnet/datalink/bip6.h"
+#include "bacnet/datalink/bvlc6.h"
+#include "bacnet/basic/bbmd6/h_bbmd6.h"
+#endif
+
+#if defined(BACDL_ETHERNET) && !defined(BACDL_MULTIPLE)
 #define MAX_MPDU ETHERNET_MPDU_MAX
 
 #define datalink_init ethernet_init
@@ -24,8 +43,7 @@
 #define datalink_get_my_address ethernet_get_my_address
 #define datalink_maintenance_timer(s)
 
-#elif defined(BACDL_ARCNET)
-#include "bacnet/datalink/arcnet.h"
+#elif defined(BACDL_ARCNET) && !defined(BACDL_MULTIPLE)
 #define MAX_MPDU ARCNET_MPDU_MAX
 
 #define datalink_init arcnet_init
@@ -36,8 +54,7 @@
 #define datalink_get_my_address arcnet_get_my_address
 #define datalink_maintenance_timer(s)
 
-#elif defined(BACDL_MSTP)
-#include "bacnet/datalink/dlmstp.h"
+#elif defined(BACDL_MSTP) && !defined(BACDL_MULTIPLE)
 #define MAX_MPDU DLMSTP_MPDU_MAX
 
 #define datalink_init dlmstp_init
@@ -48,10 +65,7 @@
 #define datalink_get_my_address dlmstp_get_my_address
 #define datalink_maintenance_timer(s)
 
-#elif defined(BACDL_BIP)
-#include "bacnet/datalink/bip.h"
-#include "bacnet/datalink/bvlc.h"
-#include "bacnet/basic/bbmd/h_bbmd.h"
+#elif defined(BACDL_BIP) && !defined(BACDL_MULTIPLE)
 #define MAX_MPDU BIP_MPDU_MAX
 
 #define datalink_init bip_init
@@ -74,10 +88,7 @@ void routed_get_my_address(BACNET_ADDRESS *my_address);
 #endif
 #define datalink_maintenance_timer(s) bvlc_maintenance_timer(s)
 
-#elif defined(BACDL_BIP6)
-#include "bacnet/datalink/bip6.h"
-#include "bacnet/datalink/bvlc6.h"
-#include "bacnet/basic/bbmd6/h_bbmd6.h"
+#elif defined(BACDL_BIP6) && !defined(BACDL_MULTIPLE)
 #define MAX_MPDU BIP6_MPDU_MAX
 
 #define datalink_init bip6_init
@@ -88,7 +99,7 @@ void routed_get_my_address(BACNET_ADDRESS *my_address);
 #define datalink_get_my_address bip6_get_my_address
 #define datalink_maintenance_timer(s) bvlc6_maintenance_timer(s)
 
-#elif defined(BACDL_ALL) || defined(BACDL_NONE) || defined(BACDL_CUSTOM)
+#elif !defined(BACDL_TEST) /* Multiple, none or custom datalink */
 #include "bacnet/npdu.h"
 
 #define MAX_HEADER (8)

--- a/src/bacnet/datalink/dlenv.c
+++ b/src/bacnet/datalink/dlenv.c
@@ -551,6 +551,12 @@ void dlenv_maintenance_timer(uint16_t elapsed_seconds)
  */
 void dlenv_init(void)
 {
+#if defined(BACDL_BIP)
+    BACNET_IP_ADDRESS addr;
+#endif
+#if defined(BACDL_BIP6)
+    BACNET_IP6_ADDRESS addr6;
+#endif
     char *pEnv = NULL;
 
 #if defined(BACDL_MULTIPLE)
@@ -562,7 +568,6 @@ void dlenv_init(void)
     }
 #endif
 #if defined(BACDL_BIP6)
-    BACNET_IP6_ADDRESS addr6;
     pEnv = getenv("BACNET_BIP6_DEBUG");
     if (pEnv) {
         bip6_debug_enable();
@@ -588,7 +593,6 @@ void dlenv_init(void)
     }
 #endif
 #if defined(BACDL_BIP)
-    BACNET_IP_ADDRESS addr;
     pEnv = getenv("BACNET_IP_DEBUG");
     if (pEnv) {
         bip_debug_enable();

--- a/src/bacnet/datalink/dlenv.c
+++ b/src/bacnet/datalink/dlenv.c
@@ -562,7 +562,7 @@ void dlenv_init(void)
     }
 #endif
 #if defined(BACDL_BIP6)
-    BACNET_IP6_ADDRESS addr;
+    BACNET_IP6_ADDRESS addr6;
     pEnv = getenv("BACNET_BIP6_DEBUG");
     if (pEnv) {
         bip6_debug_enable();
@@ -571,14 +571,14 @@ void dlenv_init(void)
     pEnv = getenv("BACNET_BIP6_BROADCAST");
     if (pEnv) {
         bvlc6_address_set(
-            &addr, (uint16_t)strtol(pEnv, NULL, 0), 0, 0, 0, 0, 0, 0,
+            &addr6, (uint16_t)strtol(pEnv, NULL, 0), 0, 0, 0, 0, 0, 0,
             BIP6_MULTICAST_GROUP_ID);
-        bip6_set_broadcast_addr(&addr);
+        bip6_set_broadcast_addr(&addr6);
     } else {
         bvlc6_address_set(
-            &addr, BIP6_MULTICAST_SITE_LOCAL, 0, 0, 0, 0, 0, 0,
+            &addr6, BIP6_MULTICAST_SITE_LOCAL, 0, 0, 0, 0, 0, 0,
             BIP6_MULTICAST_GROUP_ID);
-        bip6_set_broadcast_addr(&addr);
+        bip6_set_broadcast_addr(&addr6);
     }
     pEnv = getenv("BACNET_BIP6_PORT");
     if (pEnv) {

--- a/src/bacnet/datalink/dlenv.c
+++ b/src/bacnet/datalink/dlenv.c
@@ -553,7 +553,7 @@ void dlenv_init(void)
 {
     char *pEnv = NULL;
 
-#if defined(BACDL_ALL)
+#if defined(BACDL_MULTIPLE)
     pEnv = getenv("BACNET_DATALINK");
     if (pEnv) {
         datalink_set(pEnv);


### PR DESCRIPTION
Before we could define all, one or none datalinks. Improve this so that we can actually just select multiple datalinks. Also now we can take out configure option BACDL_NONE. We just define that, if none is selected.

I choose to do most of the magic in config.h file so that people will not be depended from CMake. Note that I have not test zephyr part. I would be very happy if someone can test that as I do not understand that part yet.

Note that currently when selecting BACNET_STACK_BUILD_APPS and BACDL_BIP6 router-ipv6 will fail to build. This has already been there and will be fixed in other PR.

Releted issues:
  - https://github.com/bacnet-stack/bacnet-stack/issues/644
  - https://github.com/bacnet-stack/bacnet-stack/issues/205