### PR TITLE
Add and fix compiler warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,12 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macOS-latest]
-
+        project: [root, test]
+        exclude:
+          # Currently does not build. Need to be fixed at some point.
+          - os: windows-latest
+            project: test
+  
     steps:
     - uses: actions/checkout@v4
 
@@ -37,10 +42,16 @@ jobs:
       # and build directories, but this is only available with CMake 3.13 and higher.
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
       run: |
-        if [[ "$RUNNER_OS" == "Windows" ]]; then
-          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+        if [ "${{ matrix.project }}" == "test" ]; then
+          source_dir=$GITHUB_WORKSPACE/test
         else
-          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_FLAGS="-Werror"
+          source_dir=$GITHUB_WORKSPACE
+        fi
+
+        if [[ "$RUNNER_OS" == "Windows" ]]; then
+          cmake $source_dir -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+        else
+          cmake $source_dir -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_FLAGS="-Werror"
         fi
 
     - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,12 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source
       # and build directories, but this is only available with CMake 3.13 and higher.
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: |
+        if [[ "$RUNNER_OS" == "Windows" ]]; then
+          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+        else
+          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_FLAGS="-Werror"
+        fi
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,16 +103,30 @@ endif()
 
 if (CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "AppleClang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
   add_compile_options(-Wall -Wextra -pedantic)
+  # Add more warnings
   add_compile_options(-Wfloat-equal -Wconversion)
-  add_compile_options(-Wredundant-decls -Wswitch-default)
+  add_compile_options(-Wfloat-conversion -Wdouble-promotion)
+  add_compile_options(-Wredundant-decls -Wmissing-declarations)
+  add_compile_options(-Wswitch-default)
   add_compile_options(-Wunused-variable)
-  # don't warn about conversion, sign, compares, long long and attributes
-  # since they are common in embedded
+  add_compile_options(-Wcast-qual)
+
+  # Don't warn about conversion, sign, compares since they are common in
+  # embedded
   add_compile_options(-Wno-sign-conversion -Wno-conversion)
-  add_compile_options(-Wno-sign-compare -Wno-long-long)
-  add_compile_options(-Wno-attributes)
-  # don't warn about implicit fallthrough since it's common in network protocols
-  add_compile_options(-Wno-implicit-fallthrough)
+  add_compile_options(-Wno-sign-compare)
+
+  # Just noise from clang
+  if (CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "AppleClang")
+    add_compile_options(-Wno-gnu-zero-variadic-macro-arguments)
+  endif()
+
+  # Should be fixed in a future.
+  add_compile_options(-Wno-cast-qual)
+  add_compile_options(-Wno-double-promotion)
+  add_compile_options(-Wno-float-conversion)
+  add_compile_options(-Wno-missing-declarations)
+  add_compile_options(-Wno-unused-but-set-variable)
 endif()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "AppleClang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")

--- a/apps/apdu/main.c
+++ b/apps/apdu/main.c
@@ -198,7 +198,7 @@ static void print_help(char *filename)
  * @param buffer [in] The buffer to store the binary data.
  * @param buffer_len [in] The size of the buffer.
  */
-void Send_APDU_To_Network(
+static void Send_APDU_To_Network(
     BACNET_ADDRESS *target_address, uint8_t *buffer, size_t buffer_len)
 {
     int pdu_len = 0;

--- a/apps/server-discover/main.c
+++ b/apps/server-discover/main.c
@@ -58,7 +58,7 @@ static bool Print_Summary = false;
 /**
  * @brief Print the list of discovered devices and their objects
  */
-void print_discovered_devices(void)
+static void print_discovered_devices(void)
 {
     unsigned int device_index = 0;
     unsigned int device_count = 0;

--- a/ports/bsd/bip6.c
+++ b/ports/bsd/bip6.c
@@ -294,7 +294,7 @@ uint16_t bip6_receive(
     int max = 0;
     struct timeval select_timeout;
     struct sockaddr_in6 sin = { 0 };
-    BACNET_IP6_ADDRESS addr = { { 0 } };
+    BACNET_IP6_ADDRESS addr = { 0 };
     socklen_t sin_len = sizeof(sin);
     int received_bytes = 0;
     int offset = 0;

--- a/ports/linux/bip-init.c
+++ b/ports/linux/bip-init.c
@@ -493,7 +493,7 @@ static int get_local_ifr_ioctl(char *ifname, struct ifreq *ifr, int request)
  */
 int bip_get_local_address_ioctl(char *ifname, struct in_addr *addr, int request)
 {
-    struct ifreq ifr = { { { 0 } }, { { 0 } } };
+    struct ifreq ifr = { 0 };
     struct sockaddr_in *tcpip_address;
     int rv; /* return value */
 

--- a/ports/linux/bip6.c
+++ b/ports/linux/bip6.c
@@ -284,7 +284,7 @@ uint16_t bip6_receive(
     int max = 0;
     struct timeval select_timeout;
     struct sockaddr_in6 sin = { 0 };
-    BACNET_IP6_ADDRESS addr = { { 0 } };
+    BACNET_IP6_ADDRESS addr = { 0 };
     socklen_t sin_len = sizeof(sin);
     int received_bytes = 0;
     int offset = 0;

--- a/ports/linux/dlmstp_linux.c
+++ b/ports/linux/dlmstp_linux.c
@@ -40,7 +40,7 @@
         if (x < 0xFFFF)               \
             x++;                      \
     }
-uint32_t Timer_Silence(void *poPort)
+static uint32_t Timer_Silence(void *poPort)
 {
     struct timeval now, tmp_diff;
     SHARED_MSTP_DATA *poSharedData;
@@ -62,7 +62,7 @@ uint32_t Timer_Silence(void *poPort)
     return (res >= 0 ? res : -res);
 }
 
-void Timer_Silence_Reset(void *poPort)
+static void Timer_Silence_Reset(void *poPort)
 {
     SHARED_MSTP_DATA *poSharedData;
     struct mstp_port_struct_t *mstp_port = (struct mstp_port_struct_t *)poPort;
@@ -77,7 +77,7 @@ void Timer_Silence_Reset(void *poPort)
     gettimeofday(&poSharedData->start, NULL);
 }
 
-void get_abstime(struct timespec *abstime, unsigned long milliseconds)
+static void get_abstime(struct timespec *abstime, unsigned long milliseconds)
 {
     struct timeval now, offset, result;
 
@@ -196,7 +196,7 @@ uint16_t dlmstp_receive(
     return pdu_len;
 }
 
-void *dlmstp_receive_fsm_task(void *pArg)
+static void *dlmstp_receive_fsm_task(void *pArg)
 {
     bool received_frame;
     SHARED_MSTP_DATA *poSharedData;
@@ -231,7 +231,7 @@ void *dlmstp_receive_fsm_task(void *pArg)
     return NULL;
 }
 
-void *dlmstp_master_fsm_task(void *pArg)
+static void *dlmstp_master_fsm_task(void *pArg)
 {
     uint32_t silence = 0;
     bool run_master = false;
@@ -385,7 +385,7 @@ void MSTP_Send_Frame(
     RS485_Send_Frame(mstp_port, buffer, nbytes);
 }
 
-bool dlmstp_compare_data_expecting_reply(
+static bool dlmstp_compare_data_expecting_reply(
     uint8_t *request_pdu,
     uint16_t request_pdu_len,
     uint8_t src_address,

--- a/ports/xplained/bacnet.c
+++ b/ports/xplained/bacnet.c
@@ -137,7 +137,7 @@ static void bacnet_test_task(void)
  **************************************************************************/
 void bacnet_task(void)
 {
-    struct mstp_rx_packet pkt = { { 0 } };
+    struct mstp_rx_packet pkt = { 0 };
     bool pdu_available = false;
 
     /* hello, World! */

--- a/ports/zephyr/bip-init.c
+++ b/ports/zephyr/bip-init.c
@@ -289,7 +289,7 @@ uint16_t bip_receive(
     int max = 0;
     struct zsock_timeval select_timeout;
     struct sockaddr_in sin = { 0 };
-    BACNET_IP_ADDRESS addr = { { 0 } };
+    BACNET_IP_ADDRESS addr = { 0 };
     socklen_t sin_len = sizeof(sin);
     int received_bytes = 0;
     int offset = 0;

--- a/ports/zephyr/bip6-init.c
+++ b/ports/zephyr/bip6-init.c
@@ -364,7 +364,7 @@ uint16_t bip6_receive(
     int max = 0;
     struct zsock_timeval select_timeout;
     struct sockaddr_in6 sin = { 0 };
-    BACNET_IP6_ADDRESS addr = { { 0 } };
+    BACNET_IP6_ADDRESS addr = { 0 };
     socklen_t sin_len = sizeof(sin);
     int received_bytes = 0;
     int offset = 0;

--- a/src/bacnet/bacapp.c
+++ b/src/bacnet/bacapp.c
@@ -1893,7 +1893,7 @@ int bacapp_snprintf_shift(int len, char **buf, size_t *buf_size)
  * @param value - value to be printed
  * @return number of characters written to the string
  */
-int bacapp_snprintf_shed_level(
+static int bacapp_snprintf_shed_level(
     char *str, size_t str_len, BACNET_SHED_LEVEL *value)
 {
     int length = 0;
@@ -3552,7 +3552,7 @@ static bool strtod_checked(const char *s, double *out)
  * @param argv [in] The string to parse
  * @return True on success, else False
  */
-bool bacnet_scale_from_ascii(BACNET_SCALE *value, const char *argv)
+static bool bacnet_scale_from_ascii(BACNET_SCALE *value, const char *argv)
 {
     bool status = false;
     int count;
@@ -3591,7 +3591,8 @@ bool bacnet_scale_from_ascii(BACNET_SCALE *value, const char *argv)
  * @param argv [in] The string to parse
  * @return True on success, else False
  */
-bool bacnet_shed_level_from_ascii(BACNET_SHED_LEVEL *value, const char *argv)
+static bool bacnet_shed_level_from_ascii(
+    BACNET_SHED_LEVEL *value, const char *argv)
 {
     bool status = false;
     int count;

--- a/src/bacnet/basic/bbmd6/h_bbmd6.c
+++ b/src/bacnet/basic/bbmd6/h_bbmd6.c
@@ -843,7 +843,7 @@ int bvlc6_bbmd_enabled_handler(BACNET_IP6_ADDRESS *addr,
     uint16_t npdu_len = 0;
     bool send_result = false;
     uint16_t offset = 0;
-    BACNET_IP6_ADDRESS fwd_address = { { 0 } };
+    BACNET_IP6_ADDRESS fwd_address = { 0 };
 
     header_len =
         bvlc6_decode_header(mtu, mtu_len, &message_type, &message_length);

--- a/src/bacnet/basic/client/bac-discover.c
+++ b/src/bacnet/basic/client/bac-discover.c
@@ -728,7 +728,7 @@ static void bacnet_read_property_reply(uint32_t device_id,
  * @param device_id - Device ID from discovered device
  * @param device_data - Pointer to the device data structure
  */
-void bacnet_discover_device_fsm(
+static void bacnet_discover_device_fsm(
     uint32_t device_id, BACNET_DEVICE_DATA *device_data)
 {
     KEY key = 0;

--- a/src/bacnet/basic/object/ai.h
+++ b/src/bacnet/basic/object/ai.h
@@ -96,6 +96,14 @@ extern "C" {
         char *new_name);
 
     BACNET_STACK_EXPORT
+    BACNET_RELIABILITY Analog_Input_Reliability(
+        uint32_t object_instance);
+    BACNET_STACK_EXPORT
+    bool Analog_Input_Reliability_Set(
+        uint32_t object_instance,
+        BACNET_RELIABILITY value);
+
+    BACNET_STACK_EXPORT
     bool Analog_Input_Units_Set(
         uint32_t instance,
         uint16_t units);

--- a/src/bacnet/basic/object/bacfile.c
+++ b/src/bacnet/basic/object/bacfile.c
@@ -524,11 +524,11 @@ bool bacfile_read_only_set(
 }
 
 /**
- * @brief For a given object instance-number, return the flag
+ * @brief
  * @param  object_instance - object-instance number of the object
- * @return  true if the property is true
+ * @param  bdatetime
  */
-void bacfile_modification_date(
+static void bacfile_modification_date(
     uint32_t object_instance, BACNET_DATE_TIME *bdatetime)
 {
     struct object_data *pObject;

--- a/src/bacnet/basic/object/bi.h
+++ b/src/bacnet/basic/object/bi.h
@@ -152,6 +152,13 @@ extern "C" {
         binary_input_write_present_value_callback cb);
 
     BACNET_STACK_EXPORT
+    bool Binary_Input_Write_Enabled(uint32_t instance);
+    BACNET_STACK_EXPORT
+    void Binary_Input_Write_Enable(uint32_t instance);
+    BACNET_STACK_EXPORT
+    void Binary_Input_Write_Disable(uint32_t instance);
+
+    BACNET_STACK_EXPORT
     uint32_t Binary_Input_Create(
         uint32_t object_instance);
     BACNET_STACK_EXPORT

--- a/src/bacnet/basic/object/bv.h
+++ b/src/bacnet/basic/object/bv.h
@@ -110,6 +110,16 @@ extern "C" {
     bool Binary_Value_Present_Value_Set(
         uint32_t instance,
         BACNET_BINARY_PV value);
+    BACNET_STACK_EXPORT
+    void Binary_Value_Write_Present_Value_Callback_Set(
+        binary_value_write_present_value_callback cb);
+
+    BACNET_STACK_EXPORT
+    bool Binary_Value_Write_Enabled(uint32_t instance);
+    BACNET_STACK_EXPORT
+    void Binary_Value_Write_Enable(uint32_t instance);
+    BACNET_STACK_EXPORT
+    void Binary_Value_Write_Disable(uint32_t instance);
 
     BACNET_STACK_EXPORT
     bool Binary_Value_Out_Of_Service(

--- a/src/bacnet/basic/object/ms-input.h
+++ b/src/bacnet/basic/object/ms-input.h
@@ -79,6 +79,9 @@ extern "C" {
     bool Multistate_Input_Present_Value_Set(
         uint32_t object_instance,
         uint32_t value);
+    BACNET_STACK_EXPORT
+    void Multistate_Input_Write_Present_Value_Callback_Set(
+        multistate_input_write_present_value_callback cb);
 
     BACNET_STACK_EXPORT
     bool Multistate_Input_Change_Of_Value(

--- a/src/bacnet/basic/object/msv.h
+++ b/src/bacnet/basic/object/msv.h
@@ -78,6 +78,9 @@ extern "C" {
     bool Multistate_Value_Present_Value_Set(
         uint32_t object_instance,
         uint32_t value);
+    BACNET_STACK_EXPORT
+    void Multistate_Value_Write_Present_Value_Callback_Set(
+        multistate_value_write_present_value_callback cb);
 
     BACNET_STACK_EXPORT
     bool Multistate_Value_Change_Of_Value(
@@ -126,6 +129,14 @@ extern "C" {
     char *Multistate_Value_State_Text(
         uint32_t object_instance,
         uint32_t state_index);
+
+    BACNET_STACK_EXPORT
+    BACNET_RELIABILITY Multistate_Value_Reliability(
+        uint32_t object_instance);
+    BACNET_STACK_EXPORT
+    bool Multistate_Value_Reliability_Set(
+        uint32_t object_instance,
+        BACNET_RELIABILITY value);
 
     BACNET_STACK_EXPORT
     uint32_t Multistate_Value_Create(

--- a/src/bacnet/basic/object/netport.c
+++ b/src/bacnet/basic/object/netport.c
@@ -3033,7 +3033,7 @@ bool Network_Port_MSTP_Max_Info_Frames_Set(
  * @param  object_property [in] BACnet object property
  * @return true if the object property is a BACnetARRAY datatype
  */
-bool Network_Port_BACnetArray_Property(BACNET_PROPERTY_ID object_property)
+static bool Network_Port_BACnetArray_Property(BACNET_PROPERTY_ID object_property)
 {
     bool status = false;
 

--- a/src/bacnet/basic/object/structured_view.h
+++ b/src/bacnet/basic/object/structured_view.h
@@ -76,6 +76,12 @@ Structured_View_Subordinate_List(uint32_t object_instance);
 BACNET_STACK_EXPORT
 void Structured_View_Subordinate_List_Set(
     uint32_t object_instance, BACNET_SUBORDINATE_DATA *subordinate_list);
+BACNET_STACK_EXPORT
+BACNET_SUBORDINATE_DATA *
+Structured_View_Subordinate_List_Member(
+    uint32_t object_instance, BACNET_ARRAY_INDEX array_index);
+BACNET_STACK_EXPORT
+unsigned int Structured_View_Subordinate_List_Count(uint32_t object_instance);
 
 BACNET_STACK_EXPORT
 BACNET_RELATIONSHIP
@@ -83,6 +89,19 @@ Structured_View_Default_Subordinate_Relationship(uint32_t object_instance);
 BACNET_STACK_EXPORT
 bool Structured_View_Default_Subordinate_Relationship_Set(
     uint32_t object_instance, BACNET_RELATIONSHIP relationship);
+
+BACNET_STACK_EXPORT
+int Structured_View_Subordinate_List_Element_Encode(
+    uint32_t object_instance, BACNET_ARRAY_INDEX array_index, uint8_t *apdu);
+BACNET_STACK_EXPORT
+int Structured_View_Subordinate_Annotations_Element_Encode(
+    uint32_t object_instance, BACNET_ARRAY_INDEX array_index, uint8_t *apdu);
+BACNET_STACK_EXPORT
+int Structured_View_Subordinate_Node_Types_Element_Encode(
+    uint32_t object_instance, BACNET_ARRAY_INDEX array_index, uint8_t *apdu);
+BACNET_STACK_EXPORT
+int Structured_View_Subordinate_Relationships_Element_Encode(
+    uint32_t object_instance, BACNET_ARRAY_INDEX array_index, uint8_t *apdu);
 
 BACNET_STACK_EXPORT
 BACNET_DEVICE_OBJECT_REFERENCE *

--- a/src/bacnet/basic/object/time_value.h
+++ b/src/bacnet/basic/object/time_value.h
@@ -72,7 +72,7 @@ BACNET_STACK_EXPORT
 bool Time_Value_Out_Of_Service_Set(uint32_t object_instance, bool oos_flag);
 
 BACNET_STACK_EXPORT
-char *Time_Description(uint32_t object_instance);
+char *Time_Value_Description(uint32_t object_instance);
 BACNET_STACK_EXPORT
 bool Time_Value_Description_Set(uint32_t object_instance, char *new_name);
 

--- a/src/bacnet/getevent.c
+++ b/src/bacnet/getevent.c
@@ -65,6 +65,7 @@ size_t getevent_service_request_encode(
  * @param lastReceivedObjectIdentifier  Object identifier
  *
  * @return Bytes encoded.
+ * @deprecated Use getevent_apdu_encode() instead
  */
 int getevent_encode_apdu(uint8_t *apdu,
     uint8_t invoke_id,

--- a/src/bacnet/getevent.h
+++ b/src/bacnet/getevent.h
@@ -45,6 +45,7 @@ extern "C" {
         uint8_t *apdu,
         BACNET_OBJECT_ID *lastReceivedObjectIdentifier);
 
+    BACNET_STACK_DEPRECATED("Use getevent_apdu_encode() instead")
     BACNET_STACK_EXPORT
     int getevent_encode_apdu(
         uint8_t * apdu,

--- a/src/bacnet/getevent.h
+++ b/src/bacnet/getevent.h
@@ -41,6 +41,11 @@ extern "C" {
 #endif /* __cplusplus */
 
     BACNET_STACK_EXPORT
+    int getevent_apdu_encode(
+        uint8_t *apdu,
+        BACNET_OBJECT_ID *lastReceivedObjectIdentifier);
+
+    BACNET_STACK_EXPORT
     int getevent_encode_apdu(
         uint8_t * apdu,
         uint8_t invoke_id,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,20 +12,34 @@ endif()
 
 # Set the compiler options
 if (CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
-    add_definitions(-fprofile-arcs -ftest-coverage)
-    add_compile_options(-g -O0 -W -fprofile-arcs -ftest-coverage)
+    add_compile_options(-g -O0 -fprofile-arcs -ftest-coverage)
     # enable all relevant warnings that find bugs
     add_compile_options(-Werror)
     add_compile_options(-Wall -Wextra -pedantic)
     add_compile_options(-Wfloat-equal -Wconversion)
-    add_compile_options(-Wredundant-decls -Wswitch-default)
-    add_compile_options(-Wunused-variable -Wdouble-promotion)
+    add_compile_options(-Wfloat-conversion -Wdouble-promotion)
+    add_compile_options(-Wredundant-decls -Wmissing-declarations)
+    add_compile_options(-Wswitch-default)
+    add_compile_options(-Wunused-variable)
+    add_compile_options(-Wcast-qual)
+
     # don't warn about conversion, sign, compares, long long and attributes
     # since they are common in embedded
     add_compile_options(-Wno-sign-conversion -Wno-conversion)
-    add_compile_options(-Wno-sign-compare -Wno-long-long -Wno-attributes)
-    # don't warn about implicit fallthrough since it's common in network protocols
-    add_compile_options(-Wno-implicit-fallthrough)
+    add_compile_options(-Wno-sign-compare)
+
+    # Just noise from clang
+    if (CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "AppleClang")
+      add_compile_options(-Wno-gnu-zero-variadic-macro-arguments)
+    endif()
+
+    # Should be fixed in the future
+    add_compile_options(-Wno-cast-qual)
+    add_compile_options(-Wno-double-promotion)
+    add_compile_options(-Wno-float-conversion)
+    add_compile_options(-Wno-missing-declarations)
+    add_compile_options(-Wno-unused-but-set-variable)
+    
     add_link_options(-fprofile-arcs -ftest-coverage)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,6 @@ endif()
 if (CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
     add_compile_options(-g -O0 -fprofile-arcs -ftest-coverage)
     # enable all relevant warnings that find bugs
-    add_compile_options(-Werror)
     add_compile_options(-Wall -Wextra -pedantic)
     add_compile_options(-Wfloat-equal -Wconversion)
     add_compile_options(-Wfloat-conversion -Wdouble-promotion)

--- a/test/bacnet/bacpropstates/src/main.c
+++ b/test/bacnet/bacpropstates/src/main.c
@@ -22,7 +22,7 @@
 #if defined(CONFIG_ZTEST_NEW_API)
 ZTEST(bacpropstates_tests, testPropStates)
 #else
-void testPropStates(void)
+static void testPropStates(void)
 #endif
 {
     BACNET_PROPERTY_STATE data = { 0 };

--- a/test/bacnet/basic/object/command/src/main.c
+++ b/test/bacnet/basic/object/command/src/main.c
@@ -49,7 +49,7 @@ static void test_object_command(void)
     pAction->Property_Array_Index = BACNET_ARRAY_ALL;
     pAction->Priority = 16;
     pAction->Value.tag = BACNET_APPLICATION_TAG_REAL;
-    pAction->Value.type.Real = 3.14159;
+    pAction->Value.type.Real = 3.14159f;
     pAction->Post_Delay = 0;
     pAction->Quit_On_Failure = false;
     pAction->Write_Successful = false;

--- a/test/bacnet/basic/sys/color_rgb/src/main.c
+++ b/test/bacnet/basic/sys/color_rgb/src/main.c
@@ -109,31 +109,31 @@ static void test_color_rgb_xy(void)
 
     /* functions without gamma correction */
     color_rgb_from_ascii(&red, &green, &blue, "black");
-    test_color_rgb_xy_unit(red, green, blue, 0.0, 0.0, 0);
+    test_color_rgb_xy_unit(red, green, blue, 0.0f, 0.0f, 0);
     color_rgb_from_ascii(&red, &green, &blue, "white");
-    test_color_rgb_xy_unit(red, green, blue, 0.313, 0.329, 255);
+    test_color_rgb_xy_unit(red, green, blue, 0.313f, 0.329f, 255);
     color_rgb_from_ascii(&red, &green, &blue, "blue");
-    test_color_rgb_xy_unit(red, green, blue, 0.157, 0.017, 5);
+    test_color_rgb_xy_unit(red, green, blue, 0.157f, 0.017f, 5);
     color_rgb_from_ascii(&red, &green, &blue, "green");
-    test_color_rgb_xy_unit(red, green, blue, 0.115, 0.826, 95);
+    test_color_rgb_xy_unit(red, green, blue, 0.115f, 0.826f, 95);
     color_rgb_from_ascii(&red, &green, &blue, "red");
-    test_color_rgb_xy_unit(red, green, blue, 0.735, 0.265, 59);
+    test_color_rgb_xy_unit(red, green, blue, 0.735f, 0.265f, 59);
     color_rgb_from_ascii(&red, &green, &blue, "maroon");
-    test_color_rgb_xy_unit(red, green, blue, 0.735, 0.265, 29);
+    test_color_rgb_xy_unit(red, green, blue, 0.735f, 0.265f, 29);
 
     /* functions with gamma correction */
     color_rgb_from_ascii(&red, &green, &blue, "black");
-    test_color_rgb_xy_gamma_unit(red, green, blue, 0.0, 0.0, 0);
+    test_color_rgb_xy_gamma_unit(red, green, blue, 0.0f, 0.0f, 0);
     color_rgb_from_ascii(&red, &green, &blue, "white");
-    test_color_rgb_xy_gamma_unit(red, green, blue, 0.313, 0.329, 255);
+    test_color_rgb_xy_gamma_unit(red, green, blue, 0.313f, 0.329f, 255);
     color_rgb_from_ascii(&red, &green, &blue, "blue");
-    test_color_rgb_xy_gamma_unit(red, green, blue, 0.157, 0.017, 5);
+    test_color_rgb_xy_gamma_unit(red, green, blue, 0.157f, 0.017f, 5);
     color_rgb_from_ascii(&red, &green, &blue, "green");
-    test_color_rgb_xy_gamma_unit(red, green, blue, 0.115, 0.826, 40);
+    test_color_rgb_xy_gamma_unit(red, green, blue, 0.115f, 0.826f, 40);
     color_rgb_from_ascii(&red, &green, &blue, "red");
-    test_color_rgb_xy_gamma_unit(red, green, blue, 0.735, 0.265, 59);
+    test_color_rgb_xy_gamma_unit(red, green, blue, 0.735f, 0.265f, 59);
     color_rgb_from_ascii(&red, &green, &blue, "maroon");
-    test_color_rgb_xy_gamma_unit(red, green, blue, 0.735, 0.265, 12);
+    test_color_rgb_xy_gamma_unit(red, green, blue, 0.735f, 0.265f, 12);
 }
 
 /**

--- a/test/bacnet/property/src/main.c
+++ b/test/bacnet/property/src/main.c
@@ -20,7 +20,7 @@
 #if defined(CONFIG_ZTEST_NEW_API)
 ZTEST(property_tests, testPropList)
 #else
-void testPropList(void)
+static void testPropList(void)
 #endif
 {
     unsigned i = 0, j = 0;

--- a/test/bacnet/wp/src/main.c
+++ b/test/bacnet/wp/src/main.c
@@ -217,9 +217,9 @@ static void testWriteProperty(void)
     testWritePropertyTag(&value);
     value.type.Real = 1.0;
     testWritePropertyTag(&value);
-    value.type.Real = 3.14159;
+    value.type.Real = 3.14159f;
     testWritePropertyTag(&value);
-    value.type.Real = -3.14159;
+    value.type.Real = -3.14159f;
     testWritePropertyTag(&value);
 
     value.tag = BACNET_APPLICATION_TAG_ENUMERATED;

--- a/test/bacnet/wpm/src/main.c
+++ b/test/bacnet/wpm/src/main.c
@@ -69,7 +69,7 @@ static void testWritePropertyMultiple(void)
     property_value[0].propertyIdentifier = PROP_PRESENT_VALUE;
     property_value[0].propertyArrayIndex = 0;
     property_value[0].value.tag = BACNET_APPLICATION_TAG_REAL;
-    property_value[0].value.type.Real = 3.14159;
+    property_value[0].value.type.Real = 3.14159f;
     property_value[0].value.next = NULL;
     property_value[0].priority = 0;
 
@@ -80,7 +80,7 @@ static void testWritePropertyMultiple(void)
     property_value[1].propertyIdentifier = PROP_PRESENT_VALUE;
     property_value[1].propertyArrayIndex = 0;
     property_value[1].value.tag = BACNET_APPLICATION_TAG_REAL;
-    property_value[1].value.type.Real = 1.41421;
+    property_value[1].value.type.Real = 1.41421f;
     property_value[1].value.next = NULL;
     property_value[1].priority = 0;
 

--- a/test/ztest/src/ztest.c
+++ b/test/ztest/src/ztest.c
@@ -422,7 +422,7 @@ void z_ztest_run_test_suite(const char *name, struct unit_test *suite)
 	test_status = (test_status || fail) ? 1 : 0;
 }
 
-void end_report(void)
+static void end_report(void)
 {
 	if (test_status) {
 		TC_END_REPORT(TC_FAIL);


### PR DESCRIPTION
Add some new compiler warnings which are used with some users. Currently we basically ignore those but this is lot easier for users of this project.

I also made it so that warnings should not get passed anymore in CI with CMake build. Our main matrix build also builds tests. I have to disable windows build for tests as it did not go through. It got like zillion errors.