### PR TITLE
Fix couple compiler warnings

### DIFF
--- a/ports/linux/bip6.c
+++ b/ports/linux/bip6.c
@@ -15,21 +15,38 @@
 #include "bacnet/datalink/bip6.h"
 #include "bacnet/basic/object/device.h"
 #include "bacnet/basic/bbmd6/h_bbmd6.h"
+#if DEBUG_ENABLED
+#include "bacnet/basic/sys/debug.h"
+#endif
 #include "bacport.h"
 
 /* enable debugging */
 static bool BIP6_Debug = false;
-#if PRINT_ENABLED
-#include <stdarg.h>
-#include <stdio.h>
-#define PRINTF(...) \
-    if (BIP6_Debug) { \
-        fprintf(stderr,__VA_ARGS__); \
-        fflush(stderr); \
+
+/**
+ * @brief Conditionally use the debug_printf function
+ * 
+ * @param stream - file stream to print to
+ * @param format - printf format string
+ * @param ... - variable arguments
+ * @note This function is only works if
+ * PRINT_ENABLED and BIP6_Debug is non-zero
+ */
+static void debug_fprintf_bip6(FILE *stream, const char *format, ...)
+{
+#if DEBUG_ENABLED
+    va_list ap;
+
+    if (BIP6_Debug) {
+        va_start(ap, format);
+        debug_fprintf(stream, format, ap);
+        va_end(ap);
     }
 #else
-#define PRINTF(...)
+    (void)stream;
+    (void)format;
 #endif
+}
 
 /**
  * @brief Print the IPv6 address with debug info
@@ -38,7 +55,7 @@ static bool BIP6_Debug = false;
  */
 static void debug_print_ipv6(const char *str, const struct in6_addr *addr)
 {
-    PRINTF("BIP6: %s "
+    debug_fprintf_bip6(stdout, "BIP6: %s "
         "%02x%02x:%02x%02x:%02x%02x:%02x%02x:"
         "%02x%02x:%02x%02x:%02x%02x:%02x%02x\n",
         str, (int)addr->s6_addr[0], (int)addr->s6_addr[1],
@@ -84,12 +101,12 @@ void bip6_set_interface(char *ifname)
         exit(1);
     }
     ifa_tmp = ifa;
-    if (BIP6_Debug) {
-        PRINTF("BIP6: seeking interface: %s\n", ifname);
-    }
+    debug_fprintf_bip6(stdout, "BIP6: seeking interface: %s\n", ifname);
+
     while (ifa_tmp) {
         if ((ifa_tmp->ifa_addr) && (ifa_tmp->ifa_addr->sa_family == AF_INET6)) {
-            PRINTF("BIP6: found interface: %s\n", ifa_tmp->ifa_name);
+            debug_fprintf_bip6(
+                stdout, "BIP6: found interface: %s\n",ifa_tmp->ifa_name);
         }
         if ((ifa_tmp->ifa_addr) && (ifa_tmp->ifa_addr->sa_family == AF_INET6) &&
             (strcasecmp(ifa_tmp->ifa_name, ifname) == 0)) {
@@ -110,7 +127,7 @@ void bip6_set_interface(char *ifname)
         ifa_tmp = ifa_tmp->ifa_next;
     }
     if (!found) {
-        PRINTF("BIP6: unable to set interface: %s\n", ifname);
+        debug_fprintf_bip6(stderr, "BIP6: unable to set interface: %s\n", ifname);
         exit(1);
     }
 }
@@ -398,7 +415,7 @@ bool bip6_init(char *ifname)
     if (BIP6_Addr.port == 0) {
         bip6_set_port(0xBAC0U);
     }
-    PRINTF("BIP6: IPv6 UDP port: 0x%04X\n", BIP6_Addr.port);
+    debug_fprintf_bip6(stdout, "BIP6: IPv6 UDP port: 0x%04X\n", BIP6_Addr.port);
     if (BIP6_Broadcast_Addr.address[0] == 0) {
         bvlc6_address_set(&BIP6_Broadcast_Addr, BIP6_MULTICAST_SITE_LOCAL, 0, 0,
             0, 0, 0, 0, BIP6_MULTICAST_GROUP_ID);

--- a/src/bacnet/basic/service/h_get_alarm_sum.c
+++ b/src/bacnet/basic/service/h_get_alarm_sum.c
@@ -126,7 +126,7 @@ GET_ALARM_SUMMARY_ABORT:
         /*fprintf(stderr, "Failed to send PDU (%s)!\n", strerror(errno)); */
     }
 #else
-    bytes_sent = bytes_sent;
+    (void)bytes_sent;
 #endif
 
     return;

--- a/src/bacnet/basic/sys/platform.h
+++ b/src/bacnet/basic/sys/platform.h
@@ -52,6 +52,9 @@
 #ifndef strncasecmp
 #define strncasecmp _strnicmp
 #endif
+#ifndef __inline__
+#define __inline__ __inline
+#endif
 #if (_MSC_VER < 1900)
 #include <stdio.h>
 #include <stdarg.h>

--- a/src/bacnet/basic/ucix/ucix.c
+++ b/src/bacnet/basic/ucix/ucix.c
@@ -15,7 +15,7 @@
 
 static struct uci_ptr ptr;
 
-static inline int ucix_get_ptr(struct uci_context *ctx,
+static __inline__ int ucix_get_ptr(struct uci_context *ctx,
     const char *p,
     const char *s,
     const char *o,

--- a/src/bacnet/datalink/mstp.c
+++ b/src/bacnet/datalink/mstp.c
@@ -44,7 +44,7 @@
 #if defined(PRINT_ENABLED_RECEIVE)
 #define printf_receive debug_printf
 #else
-static inline void printf_receive(const char *format, ...)
+static __inline__ void printf_receive(const char *format, ...)
 {
     (void)format;
 }
@@ -53,7 +53,7 @@ static inline void printf_receive(const char *format, ...)
 #if defined(PRINT_ENABLED_RECEIVE_DATA)
 #define printf_receive_data debug_printf
 #else
-static inline void printf_receive_data(const char *format, ...)
+static __inline__ void printf_receive_data(const char *format, ...)
 {
     (void)format;
 }
@@ -62,7 +62,7 @@ static inline void printf_receive_data(const char *format, ...)
 #if defined(PRINT_ENABLED_RECEIVE_ERRORS)
 #define printf_receive_error debug_printf
 #else
-static inline void printf_receive_error(const char *format, ...)
+static __inline__ void printf_receive_error(const char *format, ...)
 {
     (void)format;
 }
@@ -71,7 +71,7 @@ static inline void printf_receive_error(const char *format, ...)
 #if defined(PRINT_ENABLED_MASTER)
 #define printf_master debug_printf
 #else
-static inline void printf_master(const char *format, ...)
+static __inline__ void printf_master(const char *format, ...)
 {
     (void)format;
 }


### PR DESCRIPTION
I play with compile flags. I found out that PRINT_ENABLE=0 and BACDL_BIP6=ON triggers some compiler warnings. Fix these so we have cleaner build with all configurations.