### PR TITLE
Fix a warning with arm-none-eabi-gcc on hostnport.c

### DIFF
--- a/src/bacnet/hostnport.c
+++ b/src/bacnet/hostnport.c
@@ -708,7 +708,7 @@ bool bacnet_bdt_entry_from_ascii(BACNET_BDT_ENTRY *value, const char *argv)
             p = 0xBAC0U;
         }
         name = argv;
-        if (name && isalnum(name[0])) {
+        if (name && isalnum((unsigned char)name[0])) {
             value->bbmd_address.host_ip_address = false;
             value->bbmd_address.host_name = true;
             characterstring_init(


### PR DESCRIPTION
Fix this:
src/bacnet$ arm-none-eabi-gcc -Wall -I.. hostnport.c -c 
In file included from hostnport.c:13:
hostnport.c: In function 'bacnet_bdt_entry_from_ascii': hostnport.c:711:33: warning: array subscript has type 'char' [-Wchar-subscripts]
  711 |         if (name && isalnum(name[0])) {
      |