### PR TITLE
fix router-ipv6 make  Device_Object_Instance_Number() static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -945,14 +945,8 @@ if(BACNET_STACK_BUILD_APPS)
       apps/router-ipv6/main.c)
     target_link_libraries(
       router-ipv6
-      PRIVATE ${PROJECT_NAME})
-    target_compile_options(router-ipv6 PRIVATE
-      # These make this example not totally C90 compatible but it is ok.
-
-      -Wno-declaration-after-statement
-      -Wno-overlength-strings
-      -Wno-variadic-macros
-    )
+      PRIVATE ${PROJECT_NAME}
+      "-zmuldefs")
   endif()
 
   add_executable(scov apps/scov/main.c)


### PR DESCRIPTION
compile error duplicate symbol '_Device_Object_Instance_Number' This fix #778