### PR TITLE
fix app router-ipv6: duplicate symbol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -945,11 +945,8 @@ if(BACNET_STACK_BUILD_APPS)
       router-ipv6
       PRIVATE ${PROJECT_NAME})
     target_compile_options(router-ipv6 PRIVATE
-      # These make this example not totally C90 compatible but it is ok.
-
-      -Wno-declaration-after-statement
-      -Wno-overlength-strings
-      -Wno-variadic-macros
+      # Unreachable code because we have endless loop.
+      $<$<C_COMPILER_ID:MSVC>:/wd4702>
     )
   endif()
 

--- a/apps/router-ipv6/Makefile
+++ b/apps/router-ipv6/Makefile
@@ -13,7 +13,9 @@ TARGET_BIN = ${TARGET}$(TARGET_EXT)
 # BACNET_SRC_DIR is defined in common apps Makefile
 BACNET_OBJECT_DIR = $(BACNET_SRC_DIR)/bacnet/basic/object
 SRC = main.c \
-	$(BACNET_SRC_DIR)/bacnet/basic/npdu/s_router.c
+	$(BACNET_SRC_DIR)/bacnet/basic/npdu/s_router.c \
+	$(BACNET_OBJECT_DIR)/client/device-client.c \
+	$(BACNET_OBJECT_DIR)/netport.c
 
 # WARNINGS, DEBUGGING, OPTIMIZATION are defined in common apps Makefile
 # BACNET_DEFINES is defined in common apps Makefile

--- a/apps/router-ipv6/main.c
+++ b/apps/router-ipv6/main.c
@@ -26,6 +26,7 @@
 #include "bacnet/basic/sys/debug.h"
 #include "bacnet/basic/tsm/tsm.h"
 #include "bacnet/basic/binding/address.h"
+#include "bacnet/basic/object/device.h"
 #include "bacnet/basic/services.h"
 /* port agnostic file */
 #include "bacport.h"
@@ -39,7 +40,6 @@
 
 /* current version of the BACnet stack */
 static const char *BACnet_Version = BACNET_VERSION_TEXT;
-static uint32_t Device_Instance_Number = BACNET_MAX_INSTANCE;
 
 /**
  * 6.6.1 Routing Tables
@@ -1130,17 +1130,6 @@ static void control_c_hooks(void)
 #endif
 
 /**
- * @brief Get the Device object instance number
- * @return The Device object instance number
- * @note This is a proxy function to satisfy the BACnet Stack IPv6 port layer
- * requirements since this application omits a Device object.
- */
-uint32_t Device_Object_Instance_Number(void)
-{
-    return Device_Instance_Number;
-}
-
-/**
  * Main function of simple router demo.
  *
  * @param argc [in] Arg count.
@@ -1158,7 +1147,7 @@ int main(int argc, char *argv[])
     printf("BACnet Simple IP to IPv6 Router Demo\n");
     printf("BACnet Stack Version %s\n", BACnet_Version);
     if (argc > 1) {
-        Device_Instance_Number = strtol(argv[1], NULL, 0);
+        Device_Set_Object_Instance_Number(strtol(argv[1], NULL, 0));
     }
     datalink_init();
     atexit(cleanup);


### PR DESCRIPTION
Makefile use Device_Object_Instance_Number from device-client.c (Device_Object_Instance_Number is not in bacnet.a from Makefile)

Cmake use Device_Object_Instance_Number from libbacnet-stac.a:device.c

This fix #778

With this patch we can turn BACDL_BIP6 on.