### PR TITLE
fix app router

### DIFF
--- a/apps/router/ipmodule.c
+++ b/apps/router/ipmodule.c
@@ -22,7 +22,9 @@ uint8_t test_packet[] = { 0x81, 0x0a, 0x00, 0x16, /* BVLC header */
                           0x00, 0x02, 0x19, 0x55 }; /* APDU */
 #endif
 
-void *dl_ip_thread(void *pArgs)
+/* BUG with optimize Os */
+/* *** bit out of range 0 - FD_SETSIZE on fd_set ***: terminated */
+void __attribute__((optimize("O2"))) * dl_ip_thread(void *pArgs)
 {
     MSGBOX_ID msgboxid;
     BACMSG msg_storage, *bacmsg = NULL;


### PR DESCRIPTION
with optimize Os the program exits with
bit out of range 0 - FD_SETSIZE on fd_set

Disable optimize for size by static set optimize 2

This Fix #793