### PR TITLE
Fix the MSTP turnaround delay implementation.

### DIFF
--- a/ports/bsd/rs485.c
+++ b/ports/bsd/rs485.c
@@ -399,7 +399,7 @@ void RS485_Send_Frame(
     const uint8_t *buffer, /* frame to send (up to 501 bytes of data) */
     uint16_t nbytes)
 { /* number of bytes of data (up to 501) */
-    uint32_t turnaround_time = Tturnaround * 1000;
+    uint32_t turnaround_time_usec = Tturnaround * 1000000UL;
     uint32_t baud;
     ssize_t written = 0;
     int greska;
@@ -412,7 +412,7 @@ void RS485_Send_Frame(
         baud = RS485_Get_Baud_Rate();
         /* sleeping for turnaround time is necessary to give other devices
            time to change from sending to receiving state. */
-        usleep(turnaround_time / baud);
+        usleep(turnaround_time_usec / baud);
         /*
            On  success,  the  number of bytes written are returned (zero
            indicates nothing was written).  On error, -1  is  returned,  and
@@ -438,7 +438,7 @@ void RS485_Send_Frame(
         baud = RS485_Get_Port_Baud_Rate(mstp_port);
         /* sleeping for turnaround time is necessary to give other devices
            time to change from sending to receiving state. */
-        usleep(turnaround_time / baud);
+        usleep(turnaround_time_usec / baud);
         /*
            On  success,  the  number of bytes written are returned (zero
            indicates nothing was written).  On error, -1  is  returned,  and

--- a/ports/linux/rs485.c
+++ b/ports/linux/rs485.c
@@ -358,7 +358,7 @@ void RS485_Send_Frame(
     const uint8_t *buffer, /* frame to send (up to 501 bytes of data) */
     uint16_t nbytes)
 { /* number of bytes of data (up to 501) */
-    uint32_t turnaround_time = Tturnaround * 1000;
+    uint32_t turnaround_time_usec = Tturnaround * 1000000UL;
     uint32_t baud;
     ssize_t written = 0;
     int greska;
@@ -371,7 +371,7 @@ void RS485_Send_Frame(
         baud = RS485_Get_Baud_Rate();
         /* sleeping for turnaround time is necessary to give other devices
            time to change from sending to receiving state. */
-        usleep(turnaround_time / baud);
+        usleep(turnaround_time_usec / baud);
         /*
            On  success,  the  number of bytes written are returned (zero
            indicates nothing was written).  On error, -1  is  returned,  and
@@ -397,7 +397,7 @@ void RS485_Send_Frame(
         baud = RS485_Get_Port_Baud_Rate(mstp_port);
         /* sleeping for turnaround time is necessary to give other devices
            time to change from sending to receiving state. */
-        usleep(turnaround_time / baud);
+        usleep(turnaround_time_usec / baud);
         /*
            On  success,  the  number of bytes written are returned (zero
            indicates nothing was written).  On error, -1  is  returned,  and


### PR DESCRIPTION
The usleep() function takes microseconds, not milliseconds. So, T_turnaround needs to be calculated in microseconds. If we don't do this, at a baud rate of 9600, we end up waiting 4 microseconds instead of 4 milliseconds, which goes against the rule.