### PR TITLE
fix EXC_BAD_ACCESS in datalink_set() strcasecmp()

### DIFF
--- a/src/bacnet/datalink/dlenv.c
+++ b/src/bacnet/datalink/dlenv.c
@@ -564,7 +564,19 @@ void dlenv_init(void)
     if (pEnv) {
         datalink_set(pEnv);
     } else {
-        datalink_set(NULL);
+#if defined(BACDL_BIP)
+        datalink_set("bip");
+#elif defined(BACDL_BIP6)
+        datalink_set("bip6");
+#elif defined(BACDL_MSTP)
+        datalink_set("mstp");
+#elif defined(BACDL_ETHERNET)
+        datalink_set("ethernet");
+#elif defined(BACDL_ARCNET)
+        datalink_set("arcnet");
+#else
+        datalink_set("none");
+#endif
     }
 #endif
 #if defined(BACDL_BIP6)


### PR DESCRIPTION
If -DBACDL_MULTIPLE and runtime env BACNET_DATALINK is null '''
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0) frame #0: 0x00007ff819a0e782 libsystem_c.dylib`strcasecmp_l + 91 '''

Set default datalink with priority bip,bip6,mstp,ethernet,arcnet