### PR TITLE
Add ability to compile with BACNET_PROTOCOL_REVISION<17

### DIFF
--- a/src/bacnet/datalink/dlenv.c
+++ b/src/bacnet/datalink/dlenv.c
@@ -918,6 +918,8 @@ void dlenv_init(void)
         tsm_invokeID_set((uint8_t)strtol(pEnv, NULL, 0));
     }
 #endif
+#if (BACNET_PROTOCOL_REVISION >= 17)
     dlenv_network_port_init();
+#endif
     dlenv_register_as_foreign_device();
 }


### PR DESCRIPTION
Tested with "server"  and BACNET_PROTOCOL_REVISION=16 on Linux

---
```
diff --git a/apps/Makefile b/apps/Makefile
index 8d99fdadb..afde66117 100644
--- a/apps/Makefile
+++ b/apps/Makefile
@@ -189,7 +189,7 @@ BACNET_DEFINES += -DBACAPP_ALL
 BACNET_DEFINES += -DINTRINSIC_REPORTING
 BACNET_DEFINES += -DBACNET_TIME_MASTER
 BACNET_DEFINES += -DBACNET_PROPERTY_LISTS=1
-BACNET_DEFINES += -DBACNET_PROTOCOL_REVISION=24
+BACNET_DEFINES += -DBACNET_PROTOCOL_REVISION=16

 # put all the flags together
 INCLUDES = -I$(BACNET_SRC_DIR) -I$(BACNET_PORT_DIR)
```