### PR TITLE
Fixed DeviceCommunicationControl deprecated DISABLE handling

### DIFF
--- a/src/bacnet/basic/service/h_dcc.c
+++ b/src/bacnet/basic/service/h_dcc.c
@@ -148,6 +148,24 @@ void handler_device_communication_control(
         }
         goto DCC_ABORT;
     }
+#if (BACNET_PROTOCOL_REVISION >= 20)
+    if (state == COMMUNICATION_DISABLE) {
+        /*  If the request is valid and the 'Enable/Disable'
+            parameter is the deprecated value DISABLE, return the error
+            SERVICES, SERVICE_REQUEST_DENIED */
+        len = bacerror_encode_apdu(
+            &Handler_Transmit_Buffer[pdu_len], service_data->invoke_id,
+            SERVICE_CONFIRMED_DEVICE_COMMUNICATION_CONTROL,
+            ERROR_CLASS_SERVICES, ERROR_CODE_SERVICE_REQUEST_DENIED);
+#if PRINT_ENABLED
+        fprintf(
+            stderr,
+            "DeviceCommunicationControl: "
+            "Sending Error - DISABLE has been deprecated.\n");
+#endif
+        goto DCC_ABORT;
+    }
+#endif
     if (state >= MAX_BACNET_COMMUNICATION_ENABLE_DISABLE) {
         len = reject_encode_apdu(
             &Handler_Transmit_Buffer[pdu_len], service_data->invoke_id,


### PR DESCRIPTION
Fixed DeviceCommunicationControl service handler to return Service Request Denied when the DISABLE parameter is given in protocol-revision 20 or higher builds.