### PR TITLE
DCC initiation disabled, only proceess and initiate allowed services

### DIFF
--- a/src/bacnet/basic/service/h_apdu.c
+++ b/src/bacnet/basic/service/h_apdu.c
@@ -497,9 +497,8 @@ void apdu_retries_set(uint8_t value)
    shall be processed and no messages shall be initiated.
    When the initiation of communications is disabled,
    only DeviceCommunicationControl, ReinitializeDevice,
-   ConfirmedAuditNotification, UnconfirmedAuditNotification,
-   WhoIs APDUs shall be processed and I-Am initiated and
-   responses returned as required... */
+   ConfirmedAuditNotification APDUs shall be processed
+   and responses returned as required... */
 static bool apdu_confirmed_dcc_disabled(uint8_t service_choice)
 {
     bool status = false;
@@ -517,11 +516,7 @@ static bool apdu_confirmed_dcc_disabled(uint8_t service_choice)
         switch (service_choice) {
             case SERVICE_CONFIRMED_DEVICE_COMMUNICATION_CONTROL:
             case SERVICE_CONFIRMED_REINITIALIZE_DEVICE:
-            /* WhoIs will be processed and I-Am initiated as response. */
-            case SERVICE_UNCONFIRMED_WHO_IS:
-            case SERVICE_UNCONFIRMED_WHO_HAS:
             case SERVICE_CONFIRMED_AUDIT_NOTIFICATION:
-            case SERVICE_UNCONFIRMED_AUDIT_NOTIFICATION:
                 break;
             default:
                 status = true;
@@ -539,7 +534,8 @@ static bool apdu_confirmed_dcc_disabled(uint8_t service_choice)
  * If the request is valid and the 'Enable/Disable' parameter is
  * DISABLE_INITIATION, the responding BACnet-user shall
  * discontinue the initiation of messages except for I-Am
- * requests issued in accordance with the Who-Is service procedure.
+ * requests issued in accordance with the Who-Is service procedure
+ * UnconfirmedAuditNotification.
  *
  * @param service_choice  Service, like SERVICE_UNCONFIRMED_WHO_IS
  *
@@ -558,6 +554,7 @@ static bool apdu_unconfirmed_dcc_disabled(uint8_t service_choice)
         switch (service_choice) {
             case SERVICE_UNCONFIRMED_WHO_IS:
             case SERVICE_UNCONFIRMED_WHO_HAS:
+            case SERVICE_UNCONFIRMED_AUDIT_NOTIFICATION:
                 break;
             default:
                 status = true;

--- a/src/bacnet/basic/service/h_apdu.c
+++ b/src/bacnet/basic/service/h_apdu.c
@@ -512,6 +512,7 @@ static bool apdu_confirmed_dcc_disabled(uint8_t service_choice)
                 status = true;
                 break;
         }
+#if (BACNET_PROTOCOL_REVISION >= 20)
     } else if (dcc_communication_initiation_disabled()) {
         switch (service_choice) {
             case SERVICE_CONFIRMED_DEVICE_COMMUNICATION_CONTROL:
@@ -522,6 +523,7 @@ static bool apdu_confirmed_dcc_disabled(uint8_t service_choice)
                 status = true;
                 break;
         }
+#endif
     }
 
     return status;
@@ -554,7 +556,9 @@ static bool apdu_unconfirmed_dcc_disabled(uint8_t service_choice)
         switch (service_choice) {
             case SERVICE_UNCONFIRMED_WHO_IS:
             case SERVICE_UNCONFIRMED_WHO_HAS:
+#if (BACNET_PROTOCOL_REVISION >= 20)
             case SERVICE_UNCONFIRMED_AUDIT_NOTIFICATION:
+#endif
                 break;
             default:
                 status = true;

--- a/src/bacnet/basic/service/h_apdu.c
+++ b/src/bacnet/basic/service/h_apdu.c
@@ -535,7 +535,7 @@ static bool apdu_confirmed_dcc_disabled(uint8_t service_choice)
  * DISABLE_INITIATION, the responding BACnet-user shall
  * discontinue the initiation of messages except for I-Am
  * requests issued in accordance with the Who-Is service procedure
- * UnconfirmedAuditNotification.
+ * and UnconfirmedAuditNotification requests.
  *
  * @param service_choice  Service, like SERVICE_UNCONFIRMED_WHO_IS
  *

--- a/src/bacnet/basic/service/h_apdu.c
+++ b/src/bacnet/basic/service/h_apdu.c
@@ -496,8 +496,10 @@ void apdu_retries_set(uint8_t value)
    only DeviceCommunicationControl and ReinitializeDevice APDUs
    shall be processed and no messages shall be initiated.
    When the initiation of communications is disabled,
-   all APDUs shall be processed and responses returned as
-   required... */
+   only DeviceCommunicationControl, ReinitializeDevice,
+   ConfirmedAuditNotification, UnconfirmedAuditNotification,
+   WhoIs APDUs shall be processed and I-Am initiated and
+   responses returned as required... */
 static bool apdu_confirmed_dcc_disabled(uint8_t service_choice)
 {
     bool status = false;
@@ -506,6 +508,20 @@ static bool apdu_confirmed_dcc_disabled(uint8_t service_choice)
         switch (service_choice) {
             case SERVICE_CONFIRMED_DEVICE_COMMUNICATION_CONTROL:
             case SERVICE_CONFIRMED_REINITIALIZE_DEVICE:
+                break;
+            default:
+                status = true;
+                break;
+        }
+    } else if (dcc_communication_initiation_disabled()) {
+        switch (service_choice) {
+            case SERVICE_CONFIRMED_DEVICE_COMMUNICATION_CONTROL:
+            case SERVICE_CONFIRMED_REINITIALIZE_DEVICE:
+            /* WhoIs will be processed and I-Am initiated as response. */
+            case SERVICE_UNCONFIRMED_WHO_IS:
+            case SERVICE_UNCONFIRMED_WHO_HAS:
+            case SERVICE_CONFIRMED_AUDIT_NOTIFICATION:
+            case SERVICE_UNCONFIRMED_AUDIT_NOTIFICATION:
                 break;
             default:
                 status = true;


### PR DESCRIPTION
DeviceCommunicationControl initiation disabled, allows only
- DeviceCommunicationControl
- ReinitializeDevice
- ConfirmedAuditNotification
- UnconfirmedAuditNotification
- WhoIs 
- I-Am services