### PR TITLE
Fixed CMakeLists routing option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -865,12 +865,14 @@ if(BACNET_STACK_BUILD_APPS)
   add_executable(error apps/error/main.c)
   target_link_libraries(error PRIVATE ${PROJECT_NAME})
 
-  add_executable(gateway apps/gateway/main.c apps/gateway/gateway.h)
-  target_link_libraries(gateway PRIVATE ${PROJECT_NAME})
-  target_compile_options(gateway PRIVATE
-    # Unreachable code because we have endless loop.
-    $<$<C_COMPILER_ID:MSVC>:/wd4702>
-  )
+  if(BAC_ROUTING)
+    add_executable(gateway apps/gateway/main.c apps/gateway/gateway.h)
+    target_link_libraries(gateway PRIVATE ${PROJECT_NAME})
+    target_compile_options(gateway PRIVATE
+      # Unreachable code because we have endless loop.
+      $<$<C_COMPILER_ID:MSVC>:/wd4702>
+    )
+  endif()
 
   add_executable(getevent apps/getevent/main.c)
   target_link_libraries(getevent PRIVATE ${PROJECT_NAME})


### PR DESCRIPTION
Currently building the `gateway` app with `BAC_ROUTING` off causes the linker to fail, since it depends on implementations in `gw_device.c` (`Add_Routed_Device()` for instance) and `gw_device.c` was being optioned out.

Fixed by adding a check for `BAC_ROUTING` option around the `gateway` app.