### PR TITLE
PROP_RELIABILITY added to MSI and MSV as they answer to read request

### DIFF
--- a/src/bacnet/basic/object/ms-input.c
+++ b/src/bacnet/basic/object/ms-input.c
@@ -53,8 +53,8 @@ static const int Properties_Required[] = {
     PROP_OUT_OF_SERVICE,    PROP_NUMBER_OF_STATES, -1
 };
 
-static const int Properties_Optional[] = { PROP_DESCRIPTION, PROP_STATE_TEXT,
-                                           -1 };
+static const int Properties_Optional[] = { PROP_DESCRIPTION, PROP_RELIABILITY,
+                                           PROP_STATE_TEXT, -1 };
 
 static const int Properties_Proprietary[] = { -1 };
 

--- a/src/bacnet/basic/object/msv.c
+++ b/src/bacnet/basic/object/msv.c
@@ -53,8 +53,8 @@ static const int Properties_Required[] = {
     PROP_OUT_OF_SERVICE,    PROP_NUMBER_OF_STATES, -1
 };
 
-static const int Properties_Optional[] = { PROP_DESCRIPTION, PROP_STATE_TEXT,
-                                           -1 };
+static const int Properties_Optional[] = { PROP_DESCRIPTION, PROP_RELIABILITY,
+                                           PROP_STATE_TEXT, -1 };
 
 static const int Properties_Proprietary[] = { -1 };
 


### PR DESCRIPTION
Read request worked but write request gave "unknown property" error.

PROP_RELIABILITY is already (at least) in AI and AV (meaning that it make sense to add it to MSI and MSV rather than removing its reading).