### PR TITLE
av.c, write present value: If type is not valid, don't overwrite error code

### DIFF
--- a/src/bacnet/basic/object/av.c
+++ b/src/bacnet/basic/object/av.c
@@ -950,10 +950,6 @@ bool Analog_Value_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
                     wp_data->error_class = ERROR_CLASS_PROPERTY;
                     wp_data->error_code = ERROR_CODE_VALUE_OUT_OF_RANGE;
                 }
-            } else {
-                status = false;
-                wp_data->error_class = ERROR_CLASS_PROPERTY;
-                wp_data->error_code = ERROR_CODE_VALUE_OUT_OF_RANGE;
             }
             break;
         case PROP_OUT_OF_SERVICE:


### PR DESCRIPTION
If trying to write with an invalid type, INVALID_DATA_TYPE should be returned instead of VALUE_OUT_OF_RANGE