### PR TITLE
Merge pull request #100 from se-apc/devel/forwarded-address-resolution

### DIFF
--- a/src/bacnet/basic/bbmd6/h_bbmd6.c
+++ b/src/bacnet/basic/bbmd6/h_bbmd6.c
@@ -32,7 +32,7 @@
 #endif
 #endif
 
-static bool BVLC6_Debug;
+static bool BVLC6_Debug = false;
 #if PRINT_ENABLED
 #include <stdarg.h>
 #include <stdio.h>
@@ -627,6 +627,46 @@ static void bbmd6_address_resolution_handler(
 }
 
 /**
+ * Handler for Forwarded-Address-Resolution
+ *
+ * @param addr - BACnet/IPv6 source address any NAK or reply back to.
+ * @param pdu - The received NPDU+APDU buffer.
+ * @param pdu_len - How many bytes in NPDU+APDU buffer.
+ */
+static void bbmd6_forwarded_address_resolution_handler(
+    const BACNET_IP6_ADDRESS *addr, const uint8_t *pdu, uint16_t pdu_len)
+{
+    int function_len = 0;
+    uint32_t vmac_src = 0;
+    uint32_t vmac_target = 0;
+    uint32_t vmac_me = 0;
+    BACNET_IP6_ADDRESS bip6_address = {
+        0,
+    };
+
+    if (addr && pdu) {
+        PRINTF("BIP6: Received Forwarded-Address-Resolution.\n");
+        if (bbmd6_address_match_self(addr)) {
+            /* ignore messages from my IPv6 address */
+        } else {
+            function_len = bvlc6_decode_forwarded_address_resolution(
+                pdu, pdu_len, &vmac_src, &vmac_target, &bip6_address);
+            if (function_len) {
+                bbmd6_add_vmac(vmac_src, addr);
+                vmac_me = Device_Object_Instance_Number();
+                if (vmac_target == vmac_me) {
+                    /* The Address-Resolution-ACK message is unicast
+                       to the B/IPv6 node that originally initiated
+                       the Address-Resolution message. */
+                    bvlc6_send_address_resolution_ack(
+                        &bip6_address, vmac_me, vmac_src);
+                }
+            }
+        }
+    }
+}
+
+/**
  * Handler for Address-Resolution-ACK
  *
  * @param addr - BACnet/IPv6 source address any NAK or reply back to.
@@ -824,6 +864,7 @@ int bvlc6_bbmd_disabled_handler(
                    the message was not received from a BBMD which is in
                    the receiving BBMD's BDT, no BVLC-Result shall be
                    returned and the message shall be discarded. */
+                bbmd6_forwarded_address_resolution_handler(addr, pdu, pdu_len);
                 break;
             case BVLC6_ADDRESS_RESOLUTION:
                 /* Upon receipt of a BVLL Address-Resolution message


### PR DESCRIPTION
Implementation of Forwarded-Address-Resulution handler.



Addressing the following BTL test cases:

12.4.3.1.3 Execute Forwarded-Address-Resolution
Purpose: To verify that an IUT, operating as a foreign device, will process a Forwarded-Address-Resolution message.
Test Concept: The TD, acting as a BBMD, sends a Forwarded-Address-Resolution message to the IUT on behalf of device
D2. It is verified that the IUT responds to D2 with an Address-Resolution message.
Test Steps:

    TRANSMIT DA = IUT, SA = TD,
    Forwarded-Address-Resolution,
    Original-Source-Virtual-Address = D2,
    Target-Virtual-Address = IUT
    Original-Source-B/IPv6-Address = D2
    RECEIVE
    DA = D2, SA = IUT
    Address-Resolution-ACK,
    Source-Virtual-Address = IUT,
    Destination-Virtual-Address = D2
    CHECK (The IUT does not issue any Forwarded-Address-Resolution BVLCs)

12.4.2.1.5 Execute Forwarded-Address-Resolution
Purpose: To verify that an IUT, operating in normal IPv6 mode, will process a Forwarded-Address-Resolution message.
Test Concept: The TD, acting as a BBMD, sends a Forwarded-Address-Resolution message to the IUT on behalf of device
D2. It is verified that the IUT responds to D2 with an Address-Resolution message.

    TRANSMIT DA = IUT, SA = TD,
    Forwarded-Address-Resolution,
    Original-Source-Virtual-Address = D2,
    Target-Virtual-Address = IUT
    Original-Source-B/IPv6-Address = D2
    RECEIVE DA = D2, SA = IUT
    Address-Resolution-ACK,
    Source-Virtual-Address = IUT,
    Destination-Virtual-Address = D2
    CHECK (The IUT does not issue any Forwarded-Address-Resolution BVLCs)

