### PR TITLE
Added instance check to Device_Object_Name_Copy

### DIFF
--- a/src/bacnet/basic/object/device.c
+++ b/src/bacnet/basic/object/device.c
@@ -1260,7 +1260,10 @@ bool Device_Object_Name_Copy(
 
     pObject = Device_Objects_Find_Functions(object_type);
     if ((pObject != NULL) && (pObject->Object_Name != NULL)) {
-        found = pObject->Object_Name(object_instance, object_name);
+        if(pObject->Object_Valid_Instance && pObject->Object_Valid_Instance(object_instance))
+        {
+            found = pObject->Object_Name(object_instance, object_name);
+        }
     }
 
     return found;


### PR DESCRIPTION
In device.c - Device_Object_Name_Copy function, instance number check is missing before calling function for fetching the Object_Name. This was used by handler_who_has.

Added a condition to check whether the object_instance is valid then call Object_Name for valid object_instance.