### PR TITLE
Segmentation feature for Server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,11 @@ option(
   BACDL_BSC
   "compile with secure-connect support"
   OFF)
+ 
+option(
+  BACNET_SEGMENTATION_ENABLED
+  "enable segmentation"
+  ON)
 
 if(NOT (BACDL_ETHERNET OR
         BACDL_MSTP OR
@@ -629,6 +634,8 @@ add_library(${PROJECT_NAME}
   src/bacnet/rp.h
   src/bacnet/rpm.c
   src/bacnet/rpm.h
+  $<$<BOOL:${BACNET_SEGMENTATION_ENABLED}>:src/bacnet/segmentack.c>
+  $<$<BOOL:${BACNET_SEGMENTATION_ENABLED}>:src/bacnet/segmentack.h>
   src/bacnet/timestamp.c
   src/bacnet/timestamp.h
   src/bacnet/timesync.c
@@ -673,6 +680,7 @@ target_compile_definitions(
   $<$<BOOL:${BACDL_NONE}>:BACDL_NONE>
   $<$<BOOL:${BACNET_PROPERTY_LISTS}>:BACNET_PROPERTY_LISTS=1>
   $<$<BOOL:${BAC_ROUTING}>:BAC_ROUTING>
+  $<$<BOOL:${BACNET_SEGMENTATION_ENABLED}>:BACNET_SEGMENTATION_ENABLED>
   $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:BACNET_STACK_STATIC_DEFINE>
   PRIVATE
   PRINT_ENABLED=1)
@@ -1148,3 +1156,4 @@ message(STATUS "BACNET: BACDL_BSC:......................\"${BACDL_BSC}\"")
 message(STATUS "BACNET: BACDL_ARCNET:...................\"${BACDL_ARCNET}\"")
 message(STATUS "BACNET: BACDL_MSTP:.....................\"${BACDL_MSTP}\"")
 message(STATUS "BACNET: BACDL_ETHERNET:.................\"${BACDL_ETHERNET}\"")
+message(STATUS "BACNET: BACNET_SEGMENTATION_ENABLED:....\"${BACNET_SEGMENTATION_ENABLED}\"")

--- a/apps/server/main.c
+++ b/apps/server/main.c
@@ -23,6 +23,7 @@
 #include "bacnet/iam.h"
 #include "bacnet/npdu.h"
 #include "bacnet/version.h"
+#include "bacnet/bacdef.h"
 /* some demo stuff needed */
 #include "bacnet/basic/binding/address.h"
 #include "bacnet/basic/services.h"
@@ -374,6 +375,15 @@ int main(int argc, char *argv[])
         printf("BACnet Device Name: %s\n", DeviceName.value);
     }
     dlenv_init();
+
+#if BACNET_SEGMENTATION_ENABLED
+    Handler_Transmit_Buffer = (uint8_t *)malloc(MAX_PDU_SEND * sizeof(uint8_t));
+    Temp_Buf_rpm = (uint8_t *)malloc((MAX_PDU_SEND - MAX_NPDU) * sizeof(uint8_t));
+#else
+    Handler_Transmit_Buffer = (uint8_t *)malloc(MAX_PDU * sizeof(uint8_t));
+    Temp_Buf_rpm = (uint8_t *)malloc(MAX_APDU * sizeof(uint8_t));
+#endif
+
     atexit(datalink_cleanup);
     /* broadcast an I-Am on startup */
     Send_I_Am(&Handler_Transmit_Buffer[0]);

--- a/src/bacnet/apdu.h
+++ b/src/bacnet/apdu.h
@@ -32,6 +32,23 @@ typedef struct _confirmed_service_ack_data {
     uint8_t proposed_window_number;
 } BACNET_CONFIRMED_SERVICE_ACK_DATA;
 
+#if BACNET_SEGMENTATION_ENABLED
+typedef struct BACnet_Apdu_Fixed_Header {
+    /* pdu type Confirmed Request or Complex ACK */
+    uint8_t pdu_type;
+    union {
+        /* Data for pdu type PDU_TYPE_CONFIRMED_SERVICE_REQUEST */
+        struct _confirmed_service_data request_data;
+        /* Data for pdu type PDU_TYPE_COMPLEX_ACK */
+        struct _confirmed_service_ack_data ack_data;
+        /* Common data for both types */
+        struct _confirmed_service_ack_data common_data;
+    } service_data;
+    /* Service number */
+    uint8_t service_choice;
+} BACNET_APDU_FIXED_HEADER;
+#endif
+
 uint8_t apdu_network_priority(void);
 void apdu_network_priority_set(uint8_t pri);
 

--- a/src/bacnet/bacdef.h
+++ b/src/bacnet/bacdef.h
@@ -187,6 +187,9 @@ typedef struct BACnet_Object_Id {
 #define MAX_NPDU (1 + 1 + 2 + 1 + MAX_MAC_LEN + 2 + 1 + MAX_MAC_LEN + 1 + 1 + 2)
 #define MAX_PDU (MAX_APDU + MAX_NPDU)
 
+#if BACNET_SEGMENTATION_ENABLED
+#define MAX_PDU_SEND ((MAX_APDU * MAX_SEGMENTS_ACCEPTED) + MAX_NPDU) 
+#endif
 #define BACNET_ID_VALUE(bacnet_object_instance, bacnet_object_type)         \
     ((((bacnet_object_type) & BACNET_MAX_OBJECT) << BACNET_INSTANCE_BITS) | \
      ((bacnet_object_instance) & BACNET_MAX_INSTANCE))

--- a/src/bacnet/basic/binding/address.c
+++ b/src/bacnet/basic/binding/address.c
@@ -45,6 +45,10 @@ static struct Address_Cache_Entry {
     uint8_t Flags;
     uint32_t device_id;
     unsigned max_apdu;
+#if BACNET_SEGMENTATION_ENABLED
+    uint8_t segmentation;
+    uint16_t maxsegments;
+#endif
     BACNET_ADDRESS address;
     uint32_t TimeToLive;
 } Address_Cache[MAX_ADDRESS_CACHE];
@@ -346,9 +350,18 @@ void address_set_device_TTL(
  * @param device_id  Device-Id
  * @param max_apdu  Pointer to a variable, taking the maximum APDU size.
  * @param src  Pointer to address structure for return.
+ * @param segmentation  Pointer to a variable, taking the BACNET_SEGMENTATION flag.
+ * @param maxsegments  Pointer to a variable, taking the maximum segments.
  */
 bool address_get_by_device(
-    uint32_t device_id, unsigned *max_apdu, BACNET_ADDRESS *src)
+    uint32_t device_id,
+    unsigned *max_apdu,
+    BACNET_ADDRESS *src
+#if BACNET_SEGMENTATION_ENABLED
+    ,uint8_t *segmentation
+    ,uint16_t *maxsegments
+#endif
+)
 {
     struct Address_Cache_Entry *pMatch;
     bool found = false; /* return value */
@@ -364,6 +377,10 @@ bool address_get_by_device(
                 if (max_apdu) {
                     *max_apdu = pMatch->max_apdu;
                 }
+#if BACNET_SEGMENTATION_ENABLED                
+                *segmentation = pMatch->segmentation;
+                *maxsegments = pMatch->maxsegments;
+#endif
                 /* Prove we found it */
                 found = true;
             }

--- a/src/bacnet/basic/binding/address.h
+++ b/src/bacnet/basic/binding/address.h
@@ -41,7 +41,14 @@ void address_remove_device(uint32_t device_id);
 
 BACNET_STACK_EXPORT
 bool address_get_by_device(
-    uint32_t device_id, unsigned *max_apdu, BACNET_ADDRESS *src);
+    uint32_t device_id,
+    unsigned *max_apdu,
+    BACNET_ADDRESS *src
+#if BACNET_SEGMENTATION_ENABLED
+    ,uint8_t *segmentation
+    ,uint16_t *maxsegments
+#endif
+);
 
 BACNET_STACK_EXPORT
 bool address_get_by_index(

--- a/src/bacnet/basic/object/device.c
+++ b/src/bacnet/basic/object/device.c
@@ -1043,7 +1043,11 @@ uint8_t Device_Protocol_Revision(void)
 
 BACNET_SEGMENTATION Device_Segmentation_Supported(void)
 {
+#if BACNET_SEGMENTATION_ENABLED
+    return SEGMENTATION_BOTH;
+#else
     return SEGMENTATION_NONE;
+#endif
 }
 
 uint32_t Device_Database_Revision(void)

--- a/src/bacnet/basic/service/h_apdu.h
+++ b/src/bacnet/basic/service/h_apdu.h
@@ -162,6 +162,33 @@ void apdu_handler(
     uint8_t *apdu, /* APDU data */
     uint16_t pdu_len); /* for confirmed messages */
 
+#if BACNET_SEGMENTATION_ENABLED
+BACNET_STACK_EXPORT
+uint16_t apdu_segment_timeout(void);
+
+BACNET_STACK_EXPORT
+void apdu_segment_timeout_set(uint16_t milliseconds);
+
+BACNET_STACK_EXPORT
+int apdu_encode_fixed_header(
+    uint8_t *apdu, BACNET_APDU_FIXED_HEADER *fixed_pdu_header);
+
+BACNET_STACK_EXPORT
+void apdu_init_fixed_header(
+    BACNET_APDU_FIXED_HEADER *fixed_pdu_header,
+    uint8_t pdu_type,
+    uint8_t invoke_id,
+    uint8_t service,
+    int max_apdu);
+
+BACNET_STACK_EXPORT
+void max_segments_accepted_set(uint8_t maxSegments);
+
+BACNET_STACK_EXPORT
+uint8_t max_segments_accepted_get(void);
+#endif
+
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/src/bacnet/basic/service/h_dcc.c
+++ b/src/bacnet/basic/service/h_dcc.c
@@ -108,7 +108,9 @@ void handler_device_communication_control(
         debug_print("DeviceCommunicationControl: "
                     "Missing Required Parameter. Sending Reject!\n");
         goto DCC_FAILURE;
-    } else if (service_data->segmented_message) {
+    }
+    #if !BACNET_SEGMENTATION_ENABLED
+     else if (service_data->segmented_message) {
         len = abort_encode_apdu(
             &Handler_Transmit_Buffer[pdu_len], service_data->invoke_id,
             ABORT_REASON_SEGMENTATION_NOT_SUPPORTED, true);
@@ -116,6 +118,7 @@ void handler_device_communication_control(
                     "Sending Abort - segmented message.\n");
         goto DCC_FAILURE;
     }
+    #endif
     /* decode the service request only */
     len = dcc_decode_service_request(
         service_request, service_len, &timeDuration, &state, &password);

--- a/src/bacnet/basic/service/h_rd.c
+++ b/src/bacnet/basic/service/h_rd.c
@@ -71,13 +71,16 @@ void handler_reinitialize_device(
         debug_print("ReinitializeDevice: Missing Required Parameter. "
                     "Sending Reject!\n");
         goto RD_ABORT;
-    } else if (service_data->segmented_message) {
+    } 
+    #if !BACNET_SEGMENTATION_ENABLED
+    else if (service_data->segmented_message) {
         len = abort_encode_apdu(
             &Handler_Transmit_Buffer[pdu_len], service_data->invoke_id,
             ABORT_REASON_SEGMENTATION_NOT_SUPPORTED, true);
         debug_print("ReinitializeDevice: Sending Abort - segmented message.\n");
         goto RD_ABORT;
     }
+    #endif
     /* decode the service request only */
     len = rd_decode_service_request(
         service_request, service_len, &rd_data.state, &rd_data.password);

--- a/src/bacnet/basic/service/h_rp.c
+++ b/src/bacnet/basic/service/h_rp.c
@@ -38,7 +38,7 @@
  * by a call to apdu_set_confirmed_handler().
  * This handler builds a response packet, which is
  * - an Abort if
- *   - the message is segmented
+ *   - the message is segmented, when BACNET_SEGMENTATION_ENABLED is OFF(SEGMENTATION_NONE)
  *   - if decoding fails
  *   - if the response would be too large
  * - the result from Device_Read_Property(), if it succeeds
@@ -66,6 +66,13 @@ void handler_read_property(
     bool error = true; /* assume that there is an error */
     int bytes_sent = 0;
     BACNET_ADDRESS my_address;
+#if BACNET_SEGMENTATION_ENABLED
+    BACNET_APDU_FIXED_HEADER apdu_fixed_header;
+    int apdu_header_len = 3;
+    int buffer_size = MAX_PDU_SEND;
+#else
+    int buffer_size = MAX_PDU;
+#endif
 
     /* configure default error code as an abort since it is common */
     rpdata.error_code = ERROR_CODE_ABORT_SEGMENTATION_NOT_SUPPORTED;
@@ -82,10 +89,12 @@ void handler_read_property(
         len = BACNET_STATUS_REJECT;
         rpdata.error_code = ERROR_CODE_REJECT_MISSING_REQUIRED_PARAMETER;
         debug_print("RP: Missing Required Parameter. Sending Reject!\n");
+ #if !BACNET_SEGMENTATION_ENABLED
     } else if (service_data->segmented_message) {
         /* we don't support segmentation - send an abort */
         len = BACNET_STATUS_ABORT;
         debug_print("RP: Segmented message.  Sending Abort!\n");
+#endif
     } else {
         len = rp_decode_service_request(service_request, service_len, &rpdata);
         if (len <= 0) {
@@ -116,6 +125,13 @@ void handler_read_property(
                 rpdata.object_instance = Network_Port_Index_To_Instance(0);
             }
 #endif
+
+#if BACNET_SEGMENTATION_ENABLED
+            apdu_init_fixed_header(
+                &apdu_fixed_header, PDU_TYPE_COMPLEX_ACK,
+                service_data->invoke_id, SERVICE_CONFIRMED_READ_PROPERTY,
+                service_data->max_resp);
+#endif
             apdu_len = rp_ack_encode_apdu_init(
                 &Handler_Transmit_Buffer[npdu_len], service_data->invoke_id,
                 &rpdata);
@@ -123,7 +139,7 @@ void handler_read_property(
             rpdata.application_data =
                 &Handler_Transmit_Buffer[npdu_len + apdu_len];
             rpdata.application_data_len =
-                sizeof(Handler_Transmit_Buffer) - (npdu_len + apdu_len);
+                buffer_size - (npdu_len + apdu_len);
             if (!read_property_bacnet_array_valid(&rpdata)) {
                 len = BACNET_STATUS_ERROR;
             } else {
@@ -135,6 +151,30 @@ void handler_read_property(
                     &Handler_Transmit_Buffer[npdu_len + apdu_len]);
                 apdu_len += len;
                 if (apdu_len > service_data->max_resp) {
+#if BACNET_SEGMENTATION_ENABLED
+                    if (service_data->segmented_response_accepted) {
+
+                        npdu_encode_npdu_data(
+                            &npdu_data, true, MESSAGE_PRIORITY_NORMAL);
+                        npdu_len = npdu_encode_pdu(
+                            &Handler_Transmit_Buffer[0], src, &my_address,
+                            &npdu_data);
+                        
+                        tsm_set_complexack_transaction(
+                            src, &npdu_data, &apdu_fixed_header, service_data,
+                            &Handler_Transmit_Buffer[npdu_len + apdu_header_len],
+                            (apdu_len - apdu_header_len));
+                        error = false;
+                        return;
+                    }
+                    else
+                    {
+                        //segmented response not accepted by the client
+                        rpdata.error_code =
+                            ERROR_CODE_ABORT_SEGMENTATION_NOT_SUPPORTED;
+                        len = BACNET_STATUS_ABORT;
+                    }
+#else
                     /* too big for the sender - send an abort!
                        Setting of error code needed here as read property
                        processing may have overridden the default set at start
@@ -143,6 +183,7 @@ void handler_read_property(
                         ERROR_CODE_ABORT_SEGMENTATION_NOT_SUPPORTED;
                     len = BACNET_STATUS_ABORT;
                     debug_print("RP: Message too large.\n");
+#endif
                 } else {
                     debug_print("RP: Sending Ack!\n");
                     error = false;

--- a/src/bacnet/basic/service/h_rpm.c
+++ b/src/bacnet/basic/service/h_rpm.c
@@ -12,6 +12,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 /* BACnet Stack defines - first */
 #include "bacnet/bacdef.h"
 /* BACnet Stack API */
@@ -33,7 +34,7 @@
 #include "bacnet/basic/sys/debug.h"
 #include "bacnet/datalink/datalink.h"
 
-static uint8_t Temp_Buf[MAX_APDU] = { 0 };
+uint8_t *Temp_Buf_rpm;
 
 /**
  * @brief Fetches the lists of properties (array of BACNET_PROPERTY_ID's) for
@@ -124,6 +125,7 @@ static int RPM_Encode_Property(
     size_t copy_len = 0;
     int apdu_len = 0;
     BACNET_READ_PROPERTY_DATA rpdata;
+    uint8_t Temp_Buf[MAX_APDU];
 
     len = rpm_ack_encode_apdu_object_property(
         &Temp_Buf[0], rpmdata->object_property, rpmdata->array_index);
@@ -189,9 +191,8 @@ static int RPM_Encode_Property(
  * by a call to apdu_set_confirmed_handler().
  * This handler builds a response packet, which is
  * - an Abort if
- *   - the message is segmented
+ *   - the message is segmented, when BACNET_SEGMENTATION_ENABLED is OFF(SEGMENTATION_NONE)
  *   - if decoding fails
- *   - if the response would be too large
  * - the result from each included read request, if it succeeds
  * - an Error if processing fails for all, or individual errors if only some
  * fail, or there isn't enough room in the APDU to fit the data.
@@ -220,6 +221,13 @@ void handler_read_property_multiple(
     int apdu_len = 0;
     int npdu_len = 0;
     int error = 0;
+#if BACNET_SEGMENTATION_ENABLED
+    BACNET_APDU_FIXED_HEADER apdu_fixed_header;
+    int apdu_header_len = 3;
+    int sizeOfBuffer = MAX_PDU_SEND - MAX_NPDU;
+#else
+    int sizeOfBuffer = MAX_APDU;
+#endif
 
     if (service_data) {
         datalink_get_my_address(&my_address);
@@ -230,10 +238,12 @@ void handler_read_property_multiple(
             rpmdata.error_code = ERROR_CODE_REJECT_MISSING_REQUIRED_PARAMETER;
             error = BACNET_STATUS_REJECT;
             debug_print("RPM: Missing Required Parameter. Sending Reject!\n");
+#if !BACNET_SEGMENTATION_ENABLED
         } else if (service_data->segmented_message) {
             rpmdata.error_code = ERROR_CODE_ABORT_SEGMENTATION_NOT_SUPPORTED;
             error = BACNET_STATUS_ABORT;
             debug_print("RPM: Segmented message. Sending Abort!\r\n");
+#endif
         } else {
             /* decode apdu request & encode apdu reply
                encode complex ack, invoke id, service choice */
@@ -279,14 +289,19 @@ void handler_read_property_multiple(
                 }
 #endif
                 /* Stick this object id into the reply - if it will fit */
-                len = rpm_ack_encode_apdu_object_begin(&Temp_Buf[0], &rpmdata);
+                len = rpm_ack_encode_apdu_object_begin(&Temp_Buf_rpm[0], &rpmdata);
                 copy_len = memcopy(
-                    &Handler_Transmit_Buffer[npdu_len], &Temp_Buf[0], apdu_len,
-                    len, MAX_APDU);
+                    &Handler_Transmit_Buffer[npdu_len], &Temp_Buf_rpm[0], apdu_len,
+                    len, sizeOfBuffer);
                 if (copy_len == 0) {
                     debug_print("RPM: Response too big!\n");
+#if !BACNET_SEGMENTATION_ENABLED
                     rpmdata.error_code =
                         ERROR_CODE_ABORT_SEGMENTATION_NOT_SUPPORTED;
+#else
+                    rpmdata.error_code =
+                        ERROR_CODE_ABORT_BUFFER_OVERFLOW;
+#endif
                     error = BACNET_STATUS_ABORT;
                     berror = true;
                     break;
@@ -321,7 +336,7 @@ void handler_read_property_multiple(
                                 rpmdata.object_type, rpmdata.object_instance)) {
                             len = RPM_Encode_Property(
                                 &Handler_Transmit_Buffer[npdu_len],
-                                (uint16_t)apdu_len, MAX_APDU, &rpmdata);
+                                (uint16_t)apdu_len, sizeOfBuffer, &rpmdata);
                             if (len > 0) {
                                 apdu_len += len;
                             } else {
@@ -336,18 +351,23 @@ void handler_read_property_multiple(
                             /* No array index options for this special property.
                                Encode error for this object property response */
                             len = rpm_ack_encode_apdu_object_property(
-                                &Temp_Buf[0], rpmdata.object_property,
+                                &Temp_Buf_rpm[0], rpmdata.object_property,
                                 rpmdata.array_index);
 
                             copy_len = memcopy(
                                 &Handler_Transmit_Buffer[npdu_len],
-                                &Temp_Buf[0], apdu_len, len, MAX_APDU);
+                                &Temp_Buf_rpm[0], apdu_len, len, sizeOfBuffer);
 
                             if (copy_len == 0) {
                                 debug_print(
                                     "RPM: Too full to encode property!\n");
+#if !BACNET_SEGMENTATION_ENABLED
                                 rpmdata.error_code =
                                     ERROR_CODE_ABORT_SEGMENTATION_NOT_SUPPORTED;
+#else
+                                rpmdata.error_code =
+                                    ERROR_CODE_ABORT_BUFFER_OVERFLOW;
+#endif
                                 error = BACNET_STATUS_ABORT;
                                 /* The berror flag ensures that
                                    both loops will be broken! */
@@ -357,17 +377,22 @@ void handler_read_property_multiple(
 
                             apdu_len += len;
                             len = rpm_ack_encode_apdu_object_property_error(
-                                &Temp_Buf[0], ERROR_CLASS_PROPERTY,
+                                &Temp_Buf_rpm[0], ERROR_CLASS_PROPERTY,
                                 ERROR_CODE_PROPERTY_IS_NOT_AN_ARRAY);
 
                             copy_len = memcopy(
                                 &Handler_Transmit_Buffer[npdu_len],
-                                &Temp_Buf[0], apdu_len, len, MAX_APDU);
+                                &Temp_Buf_rpm[0], apdu_len, len, sizeOfBuffer);
 
                             if (copy_len == 0) {
                                 debug_print("RPM: Too full to encode error!\n");
+#if !BACNET_SEGMENTATION_ENABLED
                                 rpmdata.error_code =
                                     ERROR_CODE_ABORT_SEGMENTATION_NOT_SUPPORTED;
+#else
+                                rpmdata.error_code =
+                                    ERROR_CODE_ABORT_BUFFER_OVERFLOW;
+#endif
                                 error = BACNET_STATUS_ABORT;
                                 /* The berror flag ensures that
                                    both loops will be broken! */
@@ -396,7 +421,7 @@ void handler_read_property_multiple(
                                         rpmdata.object_instance)) {
                                     len = RPM_Encode_Property(
                                         &Handler_Transmit_Buffer[npdu_len],
-                                        (uint16_t)apdu_len, MAX_APDU, &rpmdata);
+                                        (uint16_t)apdu_len, sizeOfBuffer, &rpmdata);
                                     if (len > 0) {
                                         apdu_len += len;
                                     } else {
@@ -418,7 +443,7 @@ void handler_read_property_multiple(
                                             special_object_property, index);
                                     len = RPM_Encode_Property(
                                         &Handler_Transmit_Buffer[npdu_len],
-                                        (uint16_t)apdu_len, MAX_APDU, &rpmdata);
+                                        (uint16_t)apdu_len, sizeOfBuffer, &rpmdata);
                                     if (len > 0) {
                                         apdu_len += len;
                                     } else {
@@ -437,7 +462,7 @@ void handler_read_property_multiple(
                         /* handle an individual property */
                         len = RPM_Encode_Property(
                             &Handler_Transmit_Buffer[npdu_len],
-                            (uint16_t)apdu_len, MAX_APDU, &rpmdata);
+                            (uint16_t)apdu_len, sizeOfBuffer, &rpmdata);
                         if (len > 0) {
                             apdu_len += len;
                         } else {
@@ -456,15 +481,20 @@ void handler_read_property_multiple(
                         /* Reached end of property list so cap the result list
                          */
                         decode_len++;
-                        len = rpm_ack_encode_apdu_object_end(&Temp_Buf[0]);
+                        len = rpm_ack_encode_apdu_object_end(&Temp_Buf_rpm[0]);
                         copy_len = memcopy(
-                            &Handler_Transmit_Buffer[npdu_len], &Temp_Buf[0],
-                            apdu_len, len, MAX_APDU);
+                            &Handler_Transmit_Buffer[npdu_len], &Temp_Buf_rpm[0],
+                            apdu_len, len, sizeOfBuffer);
                         if (copy_len == 0) {
                             debug_print(
                                 "RPM: Too full to encode object end!\n");
+#if !BACNET_SEGMENTATION_ENABLED
                             rpmdata.error_code =
                                 ERROR_CODE_ABORT_SEGMENTATION_NOT_SUPPORTED;
+#else
+                            rpmdata.error_code =
+                                ERROR_CODE_ABORT_BUFFER_OVERFLOW;
+#endif
                             error = BACNET_STATUS_ABORT;
                             /* The berror flag ensures that
                                both loops will be broken! */
@@ -488,11 +518,40 @@ void handler_read_property_multiple(
             /* If not having an error so far, check the remaining space. */
             if (!berror) {
                 if (apdu_len > service_data->max_resp) {
+#if BACNET_SEGMENTATION_ENABLED
+                    if (service_data->segmented_response_accepted) {
+                        apdu_init_fixed_header(
+                            &apdu_fixed_header, PDU_TYPE_COMPLEX_ACK,
+                            service_data->invoke_id,
+                            SERVICE_CONFIRMED_READ_PROP_MULTIPLE,
+                            service_data->max_resp);
+
+                        npdu_encode_npdu_data(
+                            &npdu_data, true, MESSAGE_PRIORITY_NORMAL);
+                        npdu_len = npdu_encode_pdu(
+                            &Handler_Transmit_Buffer[0], src, &my_address,
+                            &npdu_data);
+
+                        tsm_set_complexack_transaction(
+                            src, &npdu_data, &apdu_fixed_header, service_data,
+                            &Handler_Transmit_Buffer
+                                [npdu_len + apdu_header_len],
+                            (apdu_len - apdu_header_len));
+                        error = false;
+                        return;
+                    } else {
+                        // segmented response not accepted by the client
+                        rpmdata.error_code =
+                            ERROR_CODE_ABORT_SEGMENTATION_NOT_SUPPORTED;
+                        error = BACNET_STATUS_ABORT;
+                    }
+#else
                     /* too big for the sender - send an abort */
                     rpmdata.error_code =
                         ERROR_CODE_ABORT_SEGMENTATION_NOT_SUPPORTED;
                     error = BACNET_STATUS_ABORT;
                     debug_print("RPM: Message too large.  Sending Abort!\n");
+#endif
                 }
             }
         }

--- a/src/bacnet/basic/service/h_rpm.h
+++ b/src/bacnet/basic/service/h_rpm.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif /* __cplusplus */
 
+extern uint8_t *Temp_Buf_rpm;
+
 BACNET_STACK_EXPORT
 void handler_read_property_multiple(
     uint8_t *service_request,

--- a/src/bacnet/basic/service/h_wp.c
+++ b/src/bacnet/basic/service/h_wp.c
@@ -73,13 +73,16 @@ void handler_write_property(
             REJECT_REASON_MISSING_REQUIRED_PARAMETER);
         debug_print("WP: Missing Required Parameter. Sending Reject!\n");
         bcontinue = false;
-    } else if (service_data->segmented_message) {
+    }
+ #if !BACNET_SEGMENTATION_ENABLED
+    else if (service_data->segmented_message) {
         len = abort_encode_apdu(
             &Handler_Transmit_Buffer[pdu_len], service_data->invoke_id,
             ABORT_REASON_SEGMENTATION_NOT_SUPPORTED, true);
         debug_print("WP: Segmented message.  Sending Abort!\n");
         bcontinue = false;
     }
+ #endif
     if (bcontinue) {
         /* decode the service request only */
         len = wp_decode_service_request(service_request, service_len, &wp_data);

--- a/src/bacnet/basic/service/h_wpm.c
+++ b/src/bacnet/basic/service/h_wpm.c
@@ -150,11 +150,13 @@ void handler_write_property_multiple(
         len = BACNET_STATUS_REJECT;
         debug_print("WPM: Missing Required Parameter. "
                     "Sending Reject!\n");
+#if !BACNET_SEGMENTATION_ENABLED
     } else if (service_data->segmented_message) {
         wp_data.error_code = ERROR_CODE_ABORT_SEGMENTATION_NOT_SUPPORTED;
         len = BACNET_STATUS_ABORT;
         debug_print("WPM: Segmented message. "
                     "Sending Abort!\n");
+#endif
     } else {
         /* first time - detect malformed request before writing any data */
         len = write_property_multiple_decode(

--- a/src/bacnet/basic/service/s_ack_alarm.c
+++ b/src/bacnet/basic/service/s_ack_alarm.c
@@ -102,9 +102,18 @@ uint8_t Send_Alarm_Acknowledgement(
     unsigned max_apdu = 0;
     uint8_t invoke_id = 0;
     bool status = false;
+#if BACNET_SEGMENTATION_ENABLED
+    uint8_t segmentation = 0;
+    uint16_t maxsegments = 0;
+#endif
 
     /* is the device bound? */
-    status = address_get_by_device(device_id, &max_apdu, &dest);
+    status = address_get_by_device(
+        device_id, &max_apdu, &dest
+#if BACNET_SEGMENTATION_ENABLED
+        , &segmentation, &maxsegments
+#endif
+    );
     if (status) {
         if (sizeof(Handler_Transmit_Buffer) < max_apdu) {
             max_apdu = sizeof(Handler_Transmit_Buffer);

--- a/src/bacnet/basic/service/s_arfs.c
+++ b/src/bacnet/basic/service/s_arfs.c
@@ -38,6 +38,10 @@ uint8_t Send_Atomic_Read_File_Stream(
     bool status = false;
     int len = 0;
     int pdu_len = 0;
+#if BACNET_SEGMENTATION_ENABLED
+    uint8_t segmentation = 0;
+    uint16_t maxsegments = 0;
+#endif
     int bytes_sent = 0;
     BACNET_ATOMIC_READ_FILE_DATA data;
 
@@ -47,7 +51,12 @@ uint8_t Send_Atomic_Read_File_Stream(
     }
 
     /* is the device bound? */
-    status = address_get_by_device(device_id, &max_apdu, &dest);
+    status = address_get_by_device(
+        device_id, &max_apdu, &dest
+#if BACNET_SEGMENTATION_ENABLED
+        ,&segmentation, &maxsegments
+#endif
+    );
     /* is there a tsm available? */
     if (status) {
         invoke_id = tsm_next_free_invokeID();

--- a/src/bacnet/basic/service/s_awfs.c
+++ b/src/bacnet/basic/service/s_awfs.c
@@ -38,6 +38,10 @@ uint8_t Send_Atomic_Write_File_Stream(
     bool status = false;
     int len = 0;
     int pdu_len = 0;
+#if BACNET_SEGMENTATION_ENABLED
+    uint8_t segmentation = 0;
+    uint16_t maxsegments = 0;
+#endif
     int bytes_sent = 0;
     BACNET_ATOMIC_WRITE_FILE_DATA data;
 
@@ -46,7 +50,12 @@ uint8_t Send_Atomic_Write_File_Stream(
         return 0;
     }
     /* is the device bound? */
-    status = address_get_by_device(device_id, &max_apdu, &dest);
+    status = address_get_by_device(
+        device_id, &max_apdu, &dest
+#if BACNET_SEGMENTATION_ENABLED
+        ,&segmentation, &maxsegments
+#endif
+    );
     /* is there a tsm available? */
     if (status) {
         invoke_id = tsm_next_free_invokeID();

--- a/src/bacnet/basic/service/s_cevent.c
+++ b/src/bacnet/basic/service/s_cevent.c
@@ -98,9 +98,18 @@ uint8_t Send_CEvent_Notify(
     unsigned max_apdu = 0;
     uint8_t invoke_id = 0;
     bool status = false;
+#if BACNET_SEGMENTATION_ENABLED
+    uint8_t segmentation = 0;
+    uint16_t maxsegments = 0;
+#endif
 
     /* is the device bound? */
-    status = address_get_by_device(device_id, &max_apdu, &dest);
+    status = address_get_by_device(
+        device_id, &max_apdu, &dest
+#if BACNET_SEGMENTATION_ENABLED
+        ,&segmentation, &maxsegments
+#endif
+    );
     if (status) {
         if (sizeof(Handler_Transmit_Buffer) < max_apdu) {
             max_apdu = sizeof(Handler_Transmit_Buffer);

--- a/src/bacnet/basic/service/s_cov.c
+++ b/src/bacnet/basic/service/s_cov.c
@@ -106,13 +106,22 @@ uint8_t Send_COV_Subscribe(
     int len = 0;
     int pdu_len = 0;
     int bytes_sent = 0;
+#if BACNET_SEGMENTATION_ENABLED
+    uint8_t segmentation = 0;
+    uint16_t maxsegments = 0;
+#endif
     BACNET_NPDU_DATA npdu_data;
 
     if (!dcc_communication_enabled()) {
         return 0;
     }
     /* is the device bound? */
-    status = address_get_by_device(device_id, &max_apdu, &dest);
+    status = address_get_by_device(
+        device_id, &max_apdu, &dest
+#if BACNET_SEGMENTATION_ENABLED
+        , &segmentation, &maxsegments
+#endif
+    );
     /* is there a tsm available? */
     if (status) {
         invoke_id = tsm_next_free_invokeID();

--- a/src/bacnet/basic/service/s_create_object.c
+++ b/src/bacnet/basic/service/s_create_object.c
@@ -56,12 +56,21 @@ uint8_t Send_Create_Object_Request_Data(
     BACNET_CREATE_OBJECT_DATA data = { 0 };
     BACNET_NPDU_DATA npdu_data = { 0 };
     uint8_t service = SERVICE_CONFIRMED_CREATE_OBJECT;
+#if BACNET_SEGMENTATION_ENABLED
+    uint8_t segmentation = 0;
+    uint16_t maxsegments = 0;
+#endif
 
     if (!dcc_communication_enabled()) {
         return 0;
     }
     /* is the device bound? */
-    status = address_get_by_device(device_id, &max_apdu, &dest);
+    status = address_get_by_device(
+        device_id, &max_apdu, &dest
+#if BACNET_SEGMENTATION_ENABLED
+        ,&segmentation, &maxsegments
+#endif
+    );
     /* is there a tsm available? */
     if (status) {
         invoke_id = tsm_next_free_invokeID();

--- a/src/bacnet/basic/service/s_dcc.c
+++ b/src/bacnet/basic/service/s_dcc.c
@@ -46,6 +46,10 @@ uint8_t Send_Device_Communication_Control_Request(
     bool status = false;
     int len = 0;
     int pdu_len = 0;
+#if BACNET_SEGMENTATION_ENABLED
+    uint8_t segmentation = 0;
+    uint16_t maxsegments = 0;
+#endif
     int bytes_sent = 0;
     BACNET_CHARACTER_STRING password_string;
     BACNET_NPDU_DATA npdu_data;
@@ -56,7 +60,12 @@ uint8_t Send_Device_Communication_Control_Request(
     }
 
     /* is the device bound? */
-    status = address_get_by_device(device_id, &max_apdu, &dest);
+    status = address_get_by_device(
+        device_id, &max_apdu, &dest
+#if BACNET_SEGMENTATION_ENABLED
+        ,&segmentation, &maxsegments
+#endif
+    );
     /* is there a tsm available? */
     if (status) {
         invoke_id = tsm_next_free_invokeID();

--- a/src/bacnet/basic/service/s_delete_object.c
+++ b/src/bacnet/basic/service/s_delete_object.c
@@ -53,12 +53,21 @@ uint8_t Send_Delete_Object_Request(
     BACNET_DELETE_OBJECT_DATA data = { 0 };
     BACNET_NPDU_DATA npdu_data = { 0 };
     uint8_t service = SERVICE_CONFIRMED_DELETE_OBJECT;
+#if BACNET_SEGMENTATION_ENABLED
+    uint8_t segmentation = 0;
+    uint16_t maxsegments = 0;
+#endif
 
     if (!dcc_communication_enabled()) {
         return 0;
     }
     /* is the device bound? */
-    status = address_get_by_device(device_id, &max_apdu, &dest);
+    status = address_get_by_device(
+        device_id, &max_apdu, &dest
+#if BACNET_SEGMENTATION_ENABLED
+        ,&segmentation, &maxsegments
+#endif
+    );
     /* is there a tsm available? */
     if (status) {
         invoke_id = tsm_next_free_invokeID();

--- a/src/bacnet/basic/service/s_get_alarm_sum.c
+++ b/src/bacnet/basic/service/s_get_alarm_sum.c
@@ -77,9 +77,18 @@ uint8_t Send_Get_Alarm_Summary(uint32_t device_id)
     unsigned max_apdu = 0;
     uint8_t invoke_id = 0;
     bool status = false;
+#if BACNET_SEGMENTATION_ENABLED
+    uint8_t segmentation = 0;
+    uint16_t maxsegments = 0;
+#endif
 
     /* is the device bound? */
-    status = address_get_by_device(device_id, &max_apdu, &dest);
+    status = address_get_by_device(
+        device_id, &max_apdu, &dest
+#if BACNET_SEGMENTATION_ENABLED
+        ,&segmentation, &maxsegments
+#endif
+    );
     if (status) {
         invoke_id = Send_Get_Alarm_Summary_Address(&dest, max_apdu);
     }

--- a/src/bacnet/basic/service/s_get_event.c
+++ b/src/bacnet/basic/service/s_get_event.c
@@ -84,9 +84,18 @@ uint8_t Send_Get_Event_Information(
     unsigned max_apdu = 0;
     uint8_t invoke_id = 0;
     bool status = false;
+#if BACNET_SEGMENTATION_ENABLED
+    uint8_t segmentation = 0;
+    uint16_t maxsegments = 0;
+#endif
 
     /* is the device bound? */
-    status = address_get_by_device(device_id, &max_apdu, &dest);
+    status = address_get_by_device(
+        device_id, &max_apdu, &dest
+#if BACNET_SEGMENTATION_ENABLED
+        ,&segmentation, &maxsegments
+#endif
+    );
     if (status) {
         invoke_id = Send_Get_Event_Information_Address(
             &dest, max_apdu, lastReceivedObjectIdentifier);

--- a/src/bacnet/basic/service/s_iam.c
+++ b/src/bacnet/basic/service/s_iam.c
@@ -85,7 +85,7 @@ int iam_encode_pdu(
     /* encode the APDU portion of the packet */
     len = iam_encode_apdu(
         &buffer[pdu_len], Device_Object_Instance_Number(), MAX_APDU,
-        SEGMENTATION_NONE, Device_Vendor_Identifier());
+        Device_Segmentation_Supported(), Device_Vendor_Identifier());
     pdu_len += len;
 
     return pdu_len;
@@ -153,7 +153,7 @@ int iam_unicast_encode_pdu(
     /* encode the APDU portion of the packet */
     apdu_len = iam_encode_apdu(
         &buffer[npdu_len], Device_Object_Instance_Number(), MAX_APDU,
-        SEGMENTATION_NONE, Device_Vendor_Identifier());
+        Device_Segmentation_Supported(), Device_Vendor_Identifier());
     pdu_len = npdu_len + apdu_len;
 
     return pdu_len;

--- a/src/bacnet/basic/service/s_list_element.c
+++ b/src/bacnet/basic/service/s_list_element.c
@@ -62,6 +62,10 @@ uint8_t Send_List_Element_Request_Data(
     int len = 0;
     int pdu_len = 0;
     int bytes_sent = 0;
+#if BACNET_SEGMENTATION_ENABLED
+    uint8_t segmentation = 0;
+    uint16_t maxsegments = 0;
+#endif
     BACNET_LIST_ELEMENT_DATA data;
     BACNET_NPDU_DATA npdu_data;
 
@@ -69,7 +73,12 @@ uint8_t Send_List_Element_Request_Data(
         return 0;
     }
     /* is the device bound? */
-    status = address_get_by_device(device_id, &max_apdu, &dest);
+    status = address_get_by_device(
+        device_id, &max_apdu, &dest
+#if BACNET_SEGMENTATION_ENABLED
+        ,&segmentation, &maxsegments
+#endif
+    );
     /* is there a tsm available? */
     if (status) {
         invoke_id = tsm_next_free_invokeID();

--- a/src/bacnet/basic/service/s_lso.c
+++ b/src/bacnet/basic/service/s_lso.c
@@ -42,6 +42,10 @@ Send_Life_Safety_Operation_Data(uint32_t device_id, const BACNET_LSO_DATA *data)
     bool status = false;
     int len = 0;
     int pdu_len = 0;
+#if BACNET_SEGMENTATION_ENABLED
+    uint8_t segmentation = 0;
+    uint16_t maxsegments = 0;
+#endif
     int bytes_sent = 0;
     BACNET_NPDU_DATA npdu_data;
 
@@ -49,7 +53,12 @@ Send_Life_Safety_Operation_Data(uint32_t device_id, const BACNET_LSO_DATA *data)
         return 0;
     }
     /* is the device bound? */
-    status = address_get_by_device(device_id, &max_apdu, &dest);
+    status = address_get_by_device(
+        device_id, &max_apdu, &dest
+#if BACNET_SEGMENTATION_ENABLED
+        ,&segmentation, &maxsegments
+#endif
+    );
     /* is there a tsm available? */
     if (status) {
         invoke_id = tsm_next_free_invokeID();

--- a/src/bacnet/basic/service/s_rd.c
+++ b/src/bacnet/basic/service/s_rd.c
@@ -43,6 +43,10 @@ uint8_t Send_Reinitialize_Device_Request(
     bool status = false;
     int len = 0;
     int pdu_len = 0;
+#if BACNET_SEGMENTATION_ENABLED
+    uint8_t segmentation = 0;
+    uint16_t maxsegments = 0;
+#endif
     int bytes_sent = 0;
     BACNET_CHARACTER_STRING password_string;
     BACNET_NPDU_DATA npdu_data;
@@ -52,7 +56,12 @@ uint8_t Send_Reinitialize_Device_Request(
         return 0;
     }
     /* is the device bound? */
-    status = address_get_by_device(device_id, &max_apdu, &dest);
+    status = address_get_by_device(
+        device_id, &max_apdu, &dest
+#if BACNET_SEGMENTATION_ENABLED
+        ,&segmentation, &maxsegments
+#endif
+    );
     /* is there a tsm available? */
     if (status) {
         invoke_id = tsm_next_free_invokeID();

--- a/src/bacnet/basic/service/s_readrange.c
+++ b/src/bacnet/basic/service/s_readrange.c
@@ -42,6 +42,10 @@ uint8_t Send_ReadRange_Request(
     bool status = false;
     int len = 0;
     int pdu_len = 0;
+#if BACNET_SEGMENTATION_ENABLED
+    uint8_t segmentation = 0;
+    uint16_t maxsegments = 0;
+#endif
     int bytes_sent = 0;
     BACNET_NPDU_DATA npdu_data;
 
@@ -49,7 +53,12 @@ uint8_t Send_ReadRange_Request(
         return 0;
     }
     /* is the device bound? */
-    status = address_get_by_device(device_id, &max_apdu, &dest);
+    status = address_get_by_device(
+        device_id, &max_apdu, &dest
+#if BACNET_SEGMENTATION_ENABLED
+        ,&segmentation, &maxsegments
+#endif
+    );
     /* is there a tsm available? */
     if (status) {
         invoke_id = tsm_next_free_invokeID();

--- a/src/bacnet/basic/service/s_rp.c
+++ b/src/bacnet/basic/service/s_rp.c
@@ -132,9 +132,18 @@ uint8_t Send_Read_Property_Request(
     unsigned max_apdu = 0;
     uint8_t invoke_id = 0;
     bool status = false;
+#if BACNET_SEGMENTATION_ENABLED
+    uint8_t segmentation = 0;
+    uint16_t maxsegments = 0;
+#endif
 
     /* is the device bound? */
-    status = address_get_by_device(device_id, &max_apdu, &dest);
+    status = address_get_by_device(
+        device_id, &max_apdu, &dest
+#if BACNET_SEGMENTATION_ENABLED
+        ,&segmentation, &maxsegments
+#endif
+    );
     if (status) {
         invoke_id = Send_Read_Property_Request_Address(
             &dest, max_apdu, object_type, object_instance, object_property,

--- a/src/bacnet/basic/service/s_rpm.c
+++ b/src/bacnet/basic/service/s_rpm.c
@@ -48,6 +48,10 @@ uint8_t Send_Read_Property_Multiple_Request(
     bool status = false;
     int len = 0;
     int pdu_len = 0;
+#if BACNET_SEGMENTATION_ENABLED
+    uint8_t segmentation = 0;
+    uint16_t maxsegments = 0;
+#endif
     int bytes_sent = 0;
     BACNET_NPDU_DATA npdu_data;
 
@@ -55,7 +59,12 @@ uint8_t Send_Read_Property_Multiple_Request(
         return 0;
     }
     /* is the device bound? */
-    status = address_get_by_device(device_id, &max_apdu, &dest);
+    status = address_get_by_device(
+        device_id, &max_apdu, &dest
+#if BACNET_SEGMENTATION_ENABLED
+        ,&segmentation, &maxsegments
+#endif
+    );
     /* is there a tsm available? */
     if (status) {
         invoke_id = tsm_next_free_invokeID();

--- a/src/bacnet/basic/service/s_wp.c
+++ b/src/bacnet/basic/service/s_wp.c
@@ -49,6 +49,10 @@ uint8_t Send_Write_Property_Request_Data(
     int len = 0;
     int pdu_len = 0;
     int bytes_sent = 0;
+#if BACNET_SEGMENTATION_ENABLED
+    uint8_t segmentation = 0;
+    uint16_t maxsegments = 0;
+#endif
     BACNET_WRITE_PROPERTY_DATA data;
     BACNET_NPDU_DATA npdu_data;
 
@@ -56,7 +60,12 @@ uint8_t Send_Write_Property_Request_Data(
         return 0;
     }
     /* is the device bound? */
-    status = address_get_by_device(device_id, &max_apdu, &dest);
+    status = address_get_by_device(
+        device_id, &max_apdu, &dest
+#if BACNET_SEGMENTATION_ENABLED
+        ,&segmentation, &maxsegments
+#endif
+    );
     /* is there a tsm available? */
     if (status) {
         invoke_id = tsm_next_free_invokeID();

--- a/src/bacnet/basic/service/s_wpm.c
+++ b/src/bacnet/basic/service/s_wpm.c
@@ -48,6 +48,10 @@ uint8_t Send_Write_Property_Multiple_Request(
     bool status = false;
     int len = 0;
     int pdu_len = 0;
+#if BACNET_SEGMENTATION_ENABLED
+    uint8_t segmentation = 0;
+    uint16_t maxsegments = 0;
+#endif
     int bytes_sent = 0;
     BACNET_NPDU_DATA npdu_data;
 
@@ -56,7 +60,12 @@ uint8_t Send_Write_Property_Multiple_Request(
         return 0;
     }
     /* is the device bound? */
-    status = address_get_by_device(device_id, &max_apdu, &dest);
+    status = address_get_by_device(
+        device_id, &max_apdu, &dest
+#if BACNET_SEGMENTATION_ENABLED
+        ,&segmentation, &maxsegments
+#endif
+    );
     /* is there a tsm available? */
     if (status) {
         invoke_id = tsm_next_free_invokeID();

--- a/src/bacnet/basic/tsm/tsm.c
+++ b/src/bacnet/basic/tsm/tsm.c
@@ -19,10 +19,30 @@
 #include "bacnet/datalink/datalink.h"
 #include "bacnet/basic/services.h"
 #include "bacnet/basic/binding/address.h"
+#if BACNET_SEGMENTATION_ENABLED
+#include <stdlib.h>
+#include "bacnet/segmentack.h"
+#include "bacnet/abort.h"
+
+#define DEFAULT_WINDOW_SIZE 32
+
+#ifndef max
+#define max(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+#ifndef min
+#define min(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+
+/*Number of Duplicate Segments Received. */
+static uint8_t Duplicate_Count = 0;
+
+/* Indirection of state machine data with peer unique id values */
+static BACNET_TSM_INDIRECT_DATA TSM_Peer_Ids[MAX_TSM_PEERS];
+#endif // BACNET_SEGMENTATION_ENABLED
 
 /** @file tsm.c  BACnet Transaction State Machine operations  */
 /* FIXME: modify basic service handlers to use TSM rather than this buffer! */
-uint8_t Handler_Transmit_Buffer[MAX_PDU];
+uint8_t *Handler_Transmit_Buffer;
 
 #if (MAX_TSM_TRANSACTIONS)
 /* Really only needed for segmented messages */
@@ -289,49 +309,6 @@ bool tsm_get_transaction_pdu(
     return found;
 }
 
-/** Called once a millisecond or slower.
- *  This function calls the handler for a
- *  timeout 'Timeout_Function', if necessary.
- *
- * @param milliseconds - Count of milliseconds passed, since the last call.
- */
-void tsm_timer_milliseconds(uint16_t milliseconds)
-{
-    unsigned i = 0; /* counter */
-
-    BACNET_TSM_DATA *plist = &TSM_List[0];
-
-    for (i = 0; i < MAX_TSM_TRANSACTIONS; i++, plist++) {
-        if (plist->state == TSM_STATE_AWAIT_CONFIRMATION) {
-            if (plist->RequestTimer > milliseconds) {
-                plist->RequestTimer -= milliseconds;
-            } else {
-                plist->RequestTimer = 0;
-            }
-            /* AWAIT_CONFIRMATION */
-            if (plist->RequestTimer == 0) {
-                if (plist->RetryCount < apdu_retries()) {
-                    plist->RequestTimer = apdu_timeout();
-                    plist->RetryCount++;
-                    datalink_send_pdu(
-                        &plist->dest, &plist->npdu_data, &plist->apdu[0],
-                        plist->apdu_len);
-                } else {
-                    /* note: the invoke id has not been cleared yet
-                       and this indicates a failed message:
-                       IDLE and a valid invoke id */
-                    plist->state = TSM_STATE_IDLE;
-                    if (plist->InvokeID != 0) {
-                        if (Timeout_Function) {
-                            Timeout_Function(plist->InvokeID);
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
 /** Frees the invokeID and sets its state to IDLE
  *
  * @param invokeID  Invoke-ID
@@ -389,5 +366,1011 @@ bool tsm_invoke_id_failed(uint8_t invokeID)
     }
 
     return status;
+}
+
+#if BACNET_SEGMENTATION_ENABLED
+void segmentack_pdu_send(
+    BACNET_ADDRESS *dest,
+    bool negativeack,
+    bool server,
+    uint8_t invoke_id,
+    uint8_t sequence_number,
+    uint8_t actual_window_size)
+{
+    int pdu_len = 0;
+    BACNET_NPDU_DATA npdu_data;
+    int bytes_sent;
+    BACNET_ADDRESS my_address;
+    int apdu_len = 0;
+    int npdu_len = 0;
+    uint8_t Transmit_Buffer[MAX_PDU] = { 0 };
+    datalink_get_my_address(&my_address);
+    npdu_encode_npdu_data(&npdu_data, false, MESSAGE_PRIORITY_NORMAL);
+    npdu_len = npdu_encode_pdu(&Transmit_Buffer[0], dest, &my_address, &npdu_data);
+    apdu_len = segmentack_encode_apdu(
+        &Transmit_Buffer[npdu_len], negativeack, server, invoke_id,
+        sequence_number, actual_window_size);
+    pdu_len = apdu_len + npdu_len;
+    bytes_sent = datalink_send_pdu(dest, &npdu_data, &Transmit_Buffer[0], pdu_len);
+#if PRINT_ENABLED
+    fprintf(stderr, "bytes sent=%d\n", bytes_sent);
+#endif
+}
+
+/* theorical size of apdu fixed header */
+uint32_t
+get_apdu_header_typical_size(BACNET_APDU_FIXED_HEADER *header, bool segmented)
+{
+    int segmented_ack = 5;
+    int unsegmented_ack = 3;
+    int segmented_request = 6;
+    int unsegmented_request = 4;
+    switch (header->pdu_type) {
+        case PDU_TYPE_COMPLEX_ACK:
+            return segmented ? segmented_ack : unsegmented_ack;
+        case PDU_TYPE_CONFIRMED_SERVICE_REQUEST:
+            return segmented ? segmented_request : unsegmented_request;
+        default:
+            break;
+    }
+    return unsegmented_ack;
+}
+
+/* Free allocated blob data */
+void free_blob(BACNET_TSM_DATA *data)
+{
+    /* Free received data blobs */
+    if (data->apdu_blob) {
+        free(data->apdu_blob);
+    }
+    data->apdu_blob = NULL;
+    data->apdu_blob_allocated = 0;
+    data->apdu_blob_size = 0;
+    /* Free sent data blobs */
+    if (data->apdu) {
+        free(data->apdu);
+    }
+    data->apdu = NULL;
+    data->apdu_len = 0;
+}
+
+/* keeps allocated blob data, but reset data & current size */
+void reset_blob(BACNET_TSM_DATA *data)
+{
+    data->apdu_blob_size = 0;
+}
+
+/* allocate new data if necessary, keeps existing bytes */
+void ensure_extra_blob_size(BACNET_TSM_DATA *data, uint32_t allocation_unit)
+{
+    if (!allocation_unit) { /* NOP */
+        return;
+    }
+    /* allocation needed ? */
+    if ((!data->apdu_blob) || (!data->apdu_blob_allocated) ||
+        ((allocation_unit + data->apdu_blob_size) >
+         data->apdu_blob_allocated)) {
+        /* stupid idiot allocation algorithm : space allocated shall augment
+         * exponentially */
+        /* (nb: here there may be extra space remaining) */
+        uint8_t *apdu_new_blob =
+            calloc(1, data->apdu_blob_allocated + allocation_unit);
+        /* recopy old data */
+        if (data->apdu_blob_size) {
+            memcpy(apdu_new_blob, data->apdu_blob, data->apdu_blob_size);
+        }
+        /* new values */
+        if (data->apdu_blob) {
+            free(data->apdu_blob);
+        }
+        data->apdu_blob = apdu_new_blob;
+        data->apdu_blob_allocated = data->apdu_blob_allocated + allocation_unit;
+    }
+}
+
+/* add new data to current blob (allocate extra space if necessary) */
+void add_blob_data(BACNET_TSM_DATA *data, uint8_t *bdata, uint32_t data_len)
+{
+    ensure_extra_blob_size(data, data_len);
+    memcpy(&data->apdu_blob[data->apdu_blob_size], bdata, data_len);
+    data->apdu_blob_size += data_len;
+}
+
+/* gets current blob data */
+uint8_t *get_blob_data(BACNET_TSM_DATA *data, uint16_t *data_len)
+{
+    *data_len = data->apdu_blob_size;
+    return data->apdu_blob;
+}
+
+/* Copy new data to current APDU sending blob data */
+void copy_apdu_blob_data(
+    BACNET_TSM_DATA *data, uint8_t *bdata, uint32_t data_len)
+{
+    if (data->apdu) {
+        free(data->apdu);
+    }
+    data->apdu = NULL;
+    data->apdu = calloc(1, data_len);
+    if (data->apdu != NULL)
+    {
+        memcpy(data->apdu, bdata, data_len);
+        data->apdu_len = data_len;
+    }
+}
+
+/* gets Nth packet data to send in a segmented operation, or get the only data
+ * packet in unsegmented world. */
+uint8_t *get_apdu_blob_data_segment(
+    BACNET_TSM_DATA *data, int segment_number, uint32_t *data_len)
+{
+    /* Data is splitted in N blocks of, at maximum, ( APDU_MAX - APDU_HEADER )
+     * bytes */
+    bool segmented =
+        data->apdu_fixed_header.service_data.common_data.segmented_message;
+    int header_size =
+        get_apdu_header_typical_size(&data->apdu_fixed_header, segmented);
+    int block_request_size = (data->apdu_maximum_length - header_size);
+    block_request_size = block_request_size;
+    int data_position = segment_number * block_request_size;
+    int remaining_size = (int)data->apdu_len - data_position;
+    *data_len = (uint32_t)max(0, min(remaining_size, block_request_size));
+    return data->apdu + data_position;
+}
+
+/** Clear TSM Peer data */
+void tsm_clear_peer_id(uint8_t InternalInvokeID)
+{
+    int ix;
+
+    /* look for a matching internal invoke ID */
+    for (ix = 0; ix < MAX_TSM_PEERS; ix++) {
+        /* see if it matches the internal number */
+        if (TSM_Peer_Ids[ix].InternalInvokeID == InternalInvokeID) {
+            TSM_Peer_Ids[ix].InternalInvokeID = 0;
+        }
+    }
+}
+
+/* frees the invokeID and sets its state to IDLE */
+void tsm_free_invoke_id_check(
+    uint8_t invokeID, BACNET_ADDRESS *peer_address, bool cleanup)
+{
+    uint8_t index;
+
+    index = tsm_find_invokeID_index(invokeID);
+
+    if ((index < MAX_TSM_TRANSACTIONS) &&
+        (!peer_address || address_match(peer_address, &TSM_List[index].dest))) {
+        /* check "double-free" cases */
+        TSM_List[index].state = TSM_STATE_IDLE;
+        /* Clear Peer data, if any. Lookup with our internal ID status. */
+        tsm_clear_peer_id(invokeID);
+        /* flag slot as "unused" */
+        TSM_List[index].InvokeID = 0;
+
+        if (cleanup) {
+            /* Release segmented data */
+            free_blob(&TSM_List[index]);
+        }
+    }
+}
+
+/** Finds (optionally creates) an existing peer data */
+static BACNET_TSM_INDIRECT_DATA *
+tsm_get_peer_id_data(BACNET_ADDRESS *src, uint8_t invokeID, bool createPeerId)
+{
+    int ix;
+    int index;
+    int free_ix_found = -1;
+    BACNET_TSM_INDIRECT_DATA *item = NULL;
+
+    /* look for an empty slot, or a matching (address,peer invoke ID) */
+    for (ix = 0; ix < MAX_TSM_PEERS && !item; ix++) {
+        /* not free : see if it matches */
+        if (TSM_Peer_Ids[ix].InternalInvokeID != 0) {
+            if (invokeID == TSM_Peer_Ids[ix].PeerInvokeID &&
+                address_match(src, &TSM_Peer_Ids[ix].PeerAddress)) {
+                item = &TSM_Peer_Ids[ix];
+            }
+        } else if (free_ix_found < 0) {
+            /* mark free slot found */
+            free_ix_found = ix;
+        }
+    }
+
+    /* create new data */
+    if ((!item) && createPeerId && (free_ix_found > -1)) {
+        /* memorize peer data */
+        TSM_Peer_Ids[free_ix_found].PeerInvokeID = invokeID;
+        TSM_Peer_Ids[free_ix_found].PeerAddress = *src;
+        /* create an internal TSM slot (with internal invokeID number which is
+         * not relevant) */
+        TSM_Peer_Ids[free_ix_found].InternalInvokeID = tsm_next_free_invokeID();
+        index = tsm_find_invokeID_index(
+            TSM_Peer_Ids[free_ix_found].InternalInvokeID);
+        if (index < MAX_TSM_TRANSACTIONS) {
+            /* explicitely memorize peer InvokeID */
+            TSM_List[index].InvokeID =
+                TSM_Peer_Ids[free_ix_found].InternalInvokeID;
+            TSM_List[index].dest = *src;
+            item = &TSM_Peer_Ids[free_ix_found];
+        } else {
+            /* problem : reset slot (NULL returned) */
+            TSM_Peer_Ids[free_ix_found].InternalInvokeID = 0;
+        }
+    }
+
+    return item;
+}
+
+/** Associates a Peer address and invoke ID with our TSM
+@returns A local InvokeID unique number, 0 in case of error. */
+uint8_t tsm_get_peer_id(BACNET_ADDRESS *src, uint8_t invokeID)
+{
+    BACNET_TSM_INDIRECT_DATA *peer_data;
+    peer_data = tsm_get_peer_id_data(src, invokeID, true);
+    if (peer_data) {
+        return peer_data->InternalInvokeID;
+    }
+    return 0;
+}
+
+bool DuplicateInWindow(
+    BACNET_TSM_DATA *tsm_data,
+    uint8_t seqA,
+    uint32_t first_sequence_number,
+    uint32_t last_sequence_number)
+{
+    uint8_t received_count =
+        (last_sequence_number - first_sequence_number) % 256;
+    if (received_count > tsm_data->ActualWindowSize) {
+        return false;
+    } else if ((seqA - first_sequence_number) % 256 <= received_count) {
+        return true;
+    } else if (
+        (received_count == 0) &&
+        ((first_sequence_number - seqA) % 256 <= tsm_data->ActualWindowSize)) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool duplicate_segment_received(
+    uint8_t index,
+    BACNET_CONFIRMED_SERVICE_DATA *service_data,
+    BACNET_ADDRESS *src)
+{
+    BACNET_NPDU_DATA npdu_data;
+    bool isDuplicate = false;
+    uint8_t Ndup = TSM_List[index].ActualWindowSize;
+    // DuplicateSegmentReceived
+    if (Duplicate_Count < Ndup) {
+        TSM_List[index].SegmentTimer = apdu_segment_timeout();
+        Duplicate_Count++;
+        isDuplicate = true;
+    }
+    // TooManyDuplicateSegmentsReceived
+    else if (Duplicate_Count == Ndup) {
+        npdu_encode_npdu_data(&npdu_data, false, MESSAGE_PRIORITY_NORMAL);
+        segmentack_pdu_send(
+            src, true, true, service_data->invoke_id,
+            TSM_List[index].LastSequenceNumber,
+            TSM_List[index].ActualWindowSize);
+        TSM_List[index].SegmentTimer = apdu_segment_timeout();
+        TSM_List[index].InitialSequenceNumber =
+            TSM_List[index].LastSequenceNumber;
+        Duplicate_Count = 0;
+        isDuplicate = true;
+    }
+    return isDuplicate;
+}
+
+/* send an Abort-PDU message because of incorrect segment/PDU received */
+void abort_pdu_send(
+    uint8_t invoke_id, BACNET_ADDRESS *dest, uint8_t reason, bool server)
+{
+    int pdu_len = 0;
+    BACNET_NPDU_DATA npdu_data;
+    int bytes_sent;
+    BACNET_ADDRESS my_address;
+    int apdu_len = 0;
+    int npdu_len = 0;
+    uint8_t Transmit_Buffer[MAX_PDU] = { 0 };
+
+    datalink_get_my_address(&my_address);
+    npdu_encode_npdu_data(&npdu_data, false, MESSAGE_PRIORITY_NORMAL);
+    npdu_len = npdu_encode_pdu(&Transmit_Buffer[0], dest, &my_address, &npdu_data);
+    apdu_len = abort_encode_apdu(
+        &Transmit_Buffer[npdu_len], invoke_id, reason, server);
+    pdu_len = apdu_len + npdu_len;
+    bytes_sent = datalink_send_pdu(dest, &npdu_data, &Transmit_Buffer[0], pdu_len);
+}
+
+/** We received a segment of a ConfirmedService packet, check TSM state and
+ * reassemble the full packet */
+bool tsm_set_segmented_confirmed_service_received(
+    BACNET_ADDRESS *src,
+    BACNET_CONFIRMED_SERVICE_DATA *service_data,
+    uint8_t *internal_invoke_id,
+    uint8_t **pservice_request, /* IN/OUT */
+    uint16_t *pservice_request_len /* IN/OUT */
+)
+{
+    uint8_t index;
+    uint8_t *service_request = *pservice_request;
+    uint32_t service_request_len = *pservice_request_len;
+    bool result = false;
+    bool ack_needed = false;
+    uint8_t internal_service_id = tsm_get_peer_id(src, service_data->invoke_id);
+    *internal_invoke_id = internal_service_id;
+    if (!internal_service_id) {
+        /* failed : could not allocate enough slot for this transaction */
+        abort_pdu_send(
+            service_data->invoke_id, src,
+            ABORT_REASON_PREEMPTED_BY_HIGHER_PRIORITY_TASK, true);
+        return false;
+    }
+    index = tsm_find_invokeID_index(internal_service_id);
+    if (index >= MAX_TSM_TRANSACTIONS) { /* shall not fail */
+        abort_pdu_send(service_data->invoke_id, src, ABORT_REASON_OTHER, true);
+        return false;
+    }
+    /* check states */
+    switch (TSM_List[index].state) {
+            /* Initial state: ConfirmedSegmentReceived */
+        case TSM_STATE_IDLE:
+            /* We never stay in IDLE state */
+            TSM_List[index].state = TSM_STATE_SEGMENTED_REQUEST_SERVER;
+            /* First time : Compute Actual WindowSize */
+            /* we automatically accept the proposed window size */
+            TSM_List[index].ActualWindowSize =
+                TSM_List[index].ProposedWindowSize =
+                    service_data->proposed_window_number;
+            /* Init sequence numbers */
+            TSM_List[index].InitialSequenceNumber = 0;
+            TSM_List[index].LastSequenceNumber = 0;
+            /* resets counters */
+            TSM_List[index].RetryCount = 0;
+            TSM_List[index].SegmentRetryCount = 0;
+            TSM_List[index].ReceivedSegmentsCount = 1;
+            /* stop unsegmented timer */
+            TSM_List[index].RequestTimer = 0; /* unused */
+            /* start the segmented timer */
+            TSM_List[index].SegmentTimer = apdu_segment_timeout() * 4;
+            /* reset memorized data */
+            reset_blob(&TSM_List[index]);
+            
+            // ConfirmedSegmentedReceivedWindowSizeOutofRange
+            if (service_data->sequence_number == 0 &&
+                (TSM_List[index].ProposedWindowSize == 0 ||
+                 TSM_List[index].ProposedWindowSize > 127)) {
+                abort_pdu_send(
+                    service_data->invoke_id, src,
+                    ABORT_REASON_WINDOW_SIZE_OUT_OF_RANGE, true);
+
+                TSM_List[index].state = TSM_STATE_IDLE;
+
+                break;
+            }
+
+            /* Test : sequence number MUST be 0 */
+            /* UnexpectedPDU_Received */
+            if (service_data->sequence_number != 0) {
+                /* Release data */
+                free_blob(&TSM_List[index]);
+                /* Abort */
+                abort_pdu_send(
+                    service_data->invoke_id, src,
+                    ABORT_REASON_INVALID_APDU_IN_THIS_STATE, true);
+                /* We must free invoke_id ! */
+                tsm_free_invoke_id_check(internal_service_id, NULL, true);
+            } else {
+                /* Okay : memorize data */
+                add_blob_data(
+                    &TSM_List[index], service_request, service_request_len);
+                /* We ACK the first segment of the segmented message */
+                segmentack_pdu_send(
+                    src, false, true, service_data->invoke_id,
+                    TSM_List[index].LastSequenceNumber,
+                    TSM_List[index].ActualWindowSize);
+            }
+            break;
+            /* New segments  */
+        case TSM_STATE_SEGMENTED_REQUEST_SERVER:
+            /* reset the segment timer */
+            TSM_List[index].RequestTimer = 0; /* unused */
+            /* ANSI/ASHRAE 135-2008 5.4.5.2 SEGMENTED_REQUEST / Timeout */
+            /* If SegmentTimer becomes greater than Tseg times four, [...] enter
+             * IDLE state */
+            TSM_List[index].SegmentTimer = apdu_segment_timeout() * 4;
+            /* Sequence number MUST be (LastSequenceNumber+1 modulo 256) */
+
+            if (TSM_List[index].SegmentTimer > apdu_timeout()) {
+                abort_pdu_send(
+                    service_data->invoke_id, src,
+                    ABORT_REASON_APPLICATION_EXCEEDED_REPLY_TIME, true);
+
+                /* Enter IDLE state */
+                TSM_List[index].state = TSM_STATE_IDLE;
+            }
+
+            // DuplicateSegmentReceived
+            if ((service_data->sequence_number !=
+                 (uint8_t)(TSM_List[index].LastSequenceNumber + 1) % 256))
+
+            {
+                if (DuplicateInWindow(
+                        &TSM_List[index], service_data->sequence_number,
+                        (TSM_List[index].InitialSequenceNumber) % 256,
+                        TSM_List[index].LastSequenceNumber)) {
+                    // DuplicateSegmentReceived
+                    if (duplicate_segment_received(index, service_data, src)) {
+                        // state is in TSM_STATE_SEGMENTED_REQUEST_SERVER
+                        break;
+                    }
+                } else {
+                    /* Recoverable Error: SegmentReceivedOutOfOrder */
+                    /* ACK of last segment correctly received. */
+                    segmentack_pdu_send(
+                        src, true, true, service_data->invoke_id,
+                        TSM_List[index].LastSequenceNumber,
+                        TSM_List[index].ActualWindowSize);
+
+                    Duplicate_Count = 0;
+                }
+            } else {
+                /* Count maximum segments */
+                if (++TSM_List[index].ReceivedSegmentsCount >
+                    MAX_SEGMENTS_ACCEPTED) {
+                    /* ABORT: SegmentReceivedOutOfSpace */
+                    abort_pdu_send(
+                        service_data->invoke_id, src,
+                        ABORT_REASON_BUFFER_OVERFLOW, true);
+                    /* Release data */
+                    free_blob(&TSM_List[index]);
+                    /* Enter IDLE state */
+                    TSM_List[index].state = TSM_STATE_IDLE;
+                    /* We must free invoke_id ! */
+                    tsm_free_invoke_id_check(internal_service_id, NULL, true);
+                } else {
+                    /* NewSegmentReceived */
+                    TSM_List[index].LastSequenceNumber =
+                        service_data->sequence_number;
+                    add_blob_data(
+                        &TSM_List[index], service_request, service_request_len);
+                    /* LastSegmentOfComplexACK_Received */
+                    if (service_data->sequence_number ==
+                        (uint8_t)(TSM_List[index].InitialSequenceNumber +
+                                  TSM_List[index].ActualWindowSize)) {
+                        ack_needed = true;
+                        TSM_List[index].InitialSequenceNumber =
+                            service_data->sequence_number;
+                    }
+                    /* LastSegmentOfComplexACK_Received */
+                    if (!service_data->more_follows) {
+                        /* Resulting segment data */
+                        *pservice_request = get_blob_data(
+                            &TSM_List[index], pservice_request_len);
+                        result =
+                            true; /* Returns true on final segment received */
+                        ack_needed = true;
+                    }
+                    /* LastSegmentOfComplexACK_Received or
+                     * LastSegmentOfGroupReceived */
+                    if (ack_needed) {
+                        /* ACK received segment */
+                        segmentack_pdu_send(
+                            src, false, true, service_data->invoke_id,
+                            TSM_List[index].LastSequenceNumber,
+                            TSM_List[index].ActualWindowSize);
+                    }
+                }
+            }
+            break;
+        default: 
+            break;
+    }
+    return result;
+}
+
+/* calculates how many segments will be used to send data in this TSM slot
+@return 1 : No segmentation needed, >1 segmentation needed (number of segments).
+*/
+uint32_t get_apdu_max_segments(BACNET_TSM_DATA *data)
+{
+    uint32_t header_size;
+    uint32_t packets;
+
+    /* Are we unsegmented ? */
+    header_size = get_apdu_header_typical_size(&data->apdu_fixed_header, false);
+    if (header_size + data->apdu_len <= data->apdu_maximum_length) {
+        return 1;
+    }
+
+    /* We are segmented : calculate how many segments to use */
+    header_size = get_apdu_header_typical_size(&data->apdu_fixed_header, true);
+
+    /* Number of packets to use formula : p = ( ( total_length - 1 ) /
+     * packet_length ) + 1; */
+    packets =
+        ((data->apdu_len - 1) / (data->apdu_maximum_length - header_size)) + 1;
+
+    return packets;
+}
+
+void bacnet_calc_transmittable_length(
+    BACNET_ADDRESS *dest,
+    BACNET_CONFIRMED_SERVICE_DATA *confirmed_service_data,
+    uint32_t *apdu_max,
+    uint32_t *total_max)
+{
+    uint32_t deviceId = 0;
+    unsigned max_apdu;
+    uint8_t segmentation = 0;
+    uint16_t maxsegments = 0;
+    BACNET_ADDRESS src;
+
+    /* either we are replying to a confirmed service, so we use prompted values
+       ; either we are requesting a peer, so we use memorised informations about
+       the peer device.
+     */
+    if (confirmed_service_data) {
+        /* use maximum available APDU */
+        *total_max = *apdu_max =
+            min(confirmed_service_data->max_resp, MAX_APDU);
+        /* segmented : compute maximum number of packets */
+        if (confirmed_service_data->segmented_response_accepted) {
+            maxsegments = confirmed_service_data->max_segs;
+            /* if unspecified, try the maximum available, not just 2 segments */
+            if (!maxsegments || maxsegments > 64) {
+                maxsegments = MAX_SEGMENTS_ACCEPTED;
+            }
+            /* maximum size we are able to transmit */
+            *total_max = min(maxsegments, MAX_SEGMENTS_ACCEPTED) * (*apdu_max);
+        }
+        return;
+    }
+
+    if (address_get_device_id(dest, &deviceId)) {
+        if (address_get_by_device(
+                deviceId, &max_apdu, &src, &segmentation, &maxsegments)) {
+            /* Best possible APDU size */
+            *total_max = *apdu_max = min(max_apdu, MAX_APDU);
+            /* IIf device is able to receive segments */
+            if (segmentation == SEGMENTATION_BOTH ||
+                segmentation == SEGMENTATION_RECEIVE) {
+                /* XXX - TODO: Number of segments accepted by peer device :
+                   If zero segments we should fallback to 2 segments.
+                   Or Maybe we just didn't ask the device about the maximum
+                   segments supported.
+                 */
+                if (!maxsegments) {
+                    maxsegments = MAX_SEGMENTS_ACCEPTED;
+                }
+                /* maximum size we are able to transmit */
+                if (maxsegments) {
+                    *total_max =
+                        min(maxsegments, MAX_SEGMENTS_ACCEPTED) * (*apdu_max);
+                }
+            }
+            return;
+        }
+    }
+    *apdu_max = MAX_APDU;
+    *total_max = *apdu_max * MAX_SEGMENTS_ACCEPTED;
+}
+
+/* room checks to prevent buffer overflows */
+bool check_write_apdu_space(int apdu_len, int max_apdu, int space_needed)
+{
+    return (apdu_len + space_needed) < max_apdu;
+}
+
+/* send a packet to peer */
+int tsm_pdu_send(BACNET_TSM_DATA *tsm_data, uint32_t segment_number)
+{
+    uint8_t Transmit_Buffer[MAX_PDU] = { 0 };
+    BACNET_ADDRESS my_address;
+    int len = 0;
+    int pdu_len = 0;
+    uint8_t *service_data = NULL;
+    uint32_t service_len = 0;
+    uint32_t total_segments = 0;
+
+    /* Rebuild PDU */
+    datalink_get_my_address(&my_address);
+    len = npdu_encode_pdu(
+        &Transmit_Buffer[pdu_len], &tsm_data->dest, &my_address,
+        &tsm_data->npdu_data);
+    if (len < 0) {
+        return -1;
+    }
+    pdu_len += len;
+    /* Header tweaks ! */
+    total_segments = get_apdu_max_segments(tsm_data);
+    /* Index out of bounds */
+    if (segment_number >= total_segments) {
+        return -1;
+    }
+    if (total_segments == 1) {
+        tsm_data->apdu_fixed_header.service_data.common_data.segmented_message =
+            false;
+    } else {
+        /* SEG */
+        tsm_data->apdu_fixed_header.service_data.common_data.segmented_message =
+            true;
+        /* MORE */
+        tsm_data->apdu_fixed_header.service_data.common_data.more_follows =
+            (segment_number < total_segments - 1);
+        /* Window size : do not modify */
+        /* tsm_data->apdu_fixed_header.service_data.common_data.proposed_window_number
+         * = 127; */
+        /* SEQ# */
+        tsm_data->apdu_fixed_header.service_data.common_data.sequence_number =
+            segment_number;
+    }
+    /* Rebuild APDU Header */
+    len = apdu_encode_fixed_header(
+        &Transmit_Buffer[pdu_len], &tsm_data->apdu_fixed_header);
+    if (len < 0) {
+        return -1;
+    }
+    pdu_len += len;
+    /* Rebuild APDU service data */
+    /* gets Nth packet data */
+    service_data =
+        get_apdu_blob_data_segment(tsm_data, segment_number, &service_len);
+    if (!service_data) { /* May be zero-size ! */
+        return -1;
+    }
+    /* enough room ? */
+    if (!check_write_apdu_space(
+            pdu_len, sizeof(Transmit_Buffer), service_len)) {
+        return -1;
+    }
+    memcpy(&Transmit_Buffer[pdu_len], service_data, service_len);
+    pdu_len += service_len;
+    return datalink_send_pdu(
+        &tsm_data->dest, &tsm_data->npdu_data, &Transmit_Buffer[0],
+        pdu_len);
+}
+
+
+/* Process and send segmented/unsegmented complex acknoweldegement based on the
+response data length For unsegemented response, send the whole data For
+segmented response, send the 1st segment of response data*/
+int tsm_set_complexack_transaction(
+    BACNET_ADDRESS *dest,
+    BACNET_NPDU_DATA *npdu_data,
+    BACNET_APDU_FIXED_HEADER *apdu_fixed_header,
+    BACNET_CONFIRMED_SERVICE_DATA *confirmed_service_data,
+    uint8_t *pdu,
+    uint32_t pdu_len)
+{
+    uint8_t index;
+    int bytes_sent;
+    BACNET_TSM_DATA *tsm_data;
+    uint32_t apdu_segments;
+    uint8_t internal_service_id =
+        tsm_get_peer_id(dest, confirmed_service_data->invoke_id);
+
+    if (!internal_service_id) {
+        /* failed : could not allocate enough slot for this transaction */
+        abort_pdu_send(
+            confirmed_service_data->invoke_id, dest,
+            ABORT_REASON_PREEMPTED_BY_HIGHER_PRIORITY_TASK, true);
+        return -1;
+    }
+    index = tsm_find_invokeID_index(internal_service_id);
+    if (index >= MAX_TSM_TRANSACTIONS) { /* shall not fail */
+        abort_pdu_send(
+            confirmed_service_data->invoke_id, dest, ABORT_REASON_OTHER, true);
+        return -1;
+    }
+    tsm_data = &TSM_List[index];
+
+    /* Choice between a segmented or a non-segmented transaction */
+
+    /* fill in maximum fill values */
+    bacnet_calc_transmittable_length(
+        dest, confirmed_service_data, &tsm_data->apdu_maximum_length,
+        &tsm_data->maximum_transmittable_length);
+    /* copy the apdu service data */
+    copy_apdu_blob_data(tsm_data, &pdu[0], pdu_len);
+    /* copy npdu data */
+    npdu_copy_data(&tsm_data->npdu_data, npdu_data);
+    /* copy apdu header data */
+    tsm_data->apdu_fixed_header = *apdu_fixed_header;
+    /* destination address */
+    bacnet_address_copy(&tsm_data->dest, dest);
+    /* absolute "retry" count : won't be reinitialized later */
+    tsm_data->RetryCount = apdu_retries();
+
+    tsm_data->ActualWindowSize = 1;
+    tsm_data->ProposedWindowSize = DEFAULT_WINDOW_SIZE;
+    tsm_data->InitialSequenceNumber = 0;
+    tsm_data->SentAllSegments = false;
+
+    /* Choice between a segmented or a non-segmented transaction */
+    if (1 == (apdu_segments = get_apdu_max_segments(tsm_data))) {
+        /* UNSEGMENTED MODE : Free transaction afterwards */
+        bytes_sent = tsm_pdu_send(tsm_data, 0);
+        if (bytes_sent > 0) {
+            tsm_free_invoke_id_check(internal_service_id, dest, true);
+        }
+    } else {
+        /* SEGMENTED-MODE */
+        /* Take into account the fact that the APDU header is repeated on every
+         * segment */
+        if (pdu_len +
+                apdu_segments *
+                    get_apdu_header_typical_size(apdu_fixed_header, true) >
+            tsm_data->maximum_transmittable_length) {
+            /* Too much data : we cannot send that much, or the API cannot
+             * receive that much ! */
+           free_blob(&TSM_List[index]);
+           /* Abort */
+           abort_pdu_send(
+               confirmed_service_data->invoke_id, dest,ABORT_REASON_BUFFER_OVERFLOW, true);
+           bytes_sent = -2;
+        } else {
+            /* Window size proposal */
+            tsm_data->apdu_fixed_header.service_data.common_data
+                .proposed_window_number = tsm_data->ProposedWindowSize;
+            /* assign the transaction */
+            tsm_data->state = TSM_STATE_SEGMENTED_RESPONSE_SERVER;
+            tsm_data->SegmentRetryCount = apdu_retries();
+            /* start the timer */
+            tsm_data->RequestTimer = 0;
+            tsm_data->SegmentTimer = apdu_segment_timeout();
+            /* Send first packet */
+            bytes_sent = tsm_pdu_send(tsm_data, 0);
+        }
+    }
+    /* If we cannot initiate, free transaction so we don't wait on a timeout to
+       realize it has failed. Caller don't free invoke ID : we must clear it
+       now. */
+    if (bytes_sent <= 0) {
+        tsm_free_invoke_id_check(internal_service_id, dest, true);
+    }
+    return bytes_sent;
+}
+
+/* Sends PDU segments either until the window is full or
+ until the last segment of a message has been sent.*/
+void FillWindow(BACNET_TSM_DATA *tsm_data, uint32_t sequence_number)
+{
+    uint32_t ix;
+    uint32_t total_segments = get_apdu_max_segments(tsm_data);
+    for (ix = 0; (ix < tsm_data->ActualWindowSize) &&
+         (sequence_number + ix < total_segments);
+         ix++) {
+        tsm_pdu_send(tsm_data, sequence_number + ix);
+    }
+    /* sent all segments ? */
+    if (ix + sequence_number >= total_segments) {
+        tsm_data->SentAllSegments = true;
+    }
+}
+
+bool InWindow(BACNET_TSM_DATA *data, uint8_t seqA, uint8_t seqB)
+{
+    uint8_t requiredWindowSize = seqA - seqB;
+    return requiredWindowSize < data->ActualWindowSize;
+}
+
+/*Process the received segment ack and send the next segment accordingly if
+ * available*/
+void tsm_segmentack_received(
+    uint8_t invoke_id,
+    uint8_t sequence_number,
+    uint8_t actual_window_size,
+    bool nak,
+    bool server,
+    BACNET_ADDRESS *src)
+{
+    uint8_t index;
+    uint32_t big_segment_number;
+    uint8_t window;
+    bool some_segment_remains;
+    BACNET_TSM_INDIRECT_DATA *peer_data;
+
+    (void)nak;
+
+    /* bad invoke number from server peer (we never use 0) */
+    if (server && !invoke_id) {
+        return;
+    }
+    /* Peer invoke id number : translate to our internal numbers */
+    if (!server) {
+        peer_data = tsm_get_peer_id_data(src, invoke_id, false);
+        if (!peer_data) {
+            /* failed : unknown message */
+            return;
+        }
+        /* now we use our internal number */
+        invoke_id = peer_data->InternalInvokeID;
+    }
+    /* Find an active TSM slot that matches the Segment-Ack */
+    index = tsm_find_invokeID_index(invoke_id);
+    if (index >= MAX_TSM_TRANSACTIONS) {
+        return;
+    }
+
+    /* Almost the same code for segment handling between segmented requests and
+     * responses */
+    if (!server &&
+        TSM_List[index].state == TSM_STATE_SEGMENTED_RESPONSE_SERVER) {
+        /* DuplicateAck_Received */
+        if (!InWindow(
+                &TSM_List[index], sequence_number,
+                TSM_List[index].InitialSequenceNumber)) {
+            /* Restart timer */
+            TSM_List[index].SegmentTimer = apdu_segment_timeout();
+        } else {
+            /* total segment number (not modulo 256) */
+            window = sequence_number -
+                (uint8_t)TSM_List[index].InitialSequenceNumber;
+            big_segment_number = TSM_List[index].InitialSequenceNumber + window;
+
+            /* 1..N segment number < number of segments ? */
+            some_segment_remains = (big_segment_number + 1) <
+                get_apdu_max_segments(&TSM_List[index]);
+            if (some_segment_remains) {
+                /* NewAck_Received : do we have a segment remaining to send */
+                TSM_List[index].InitialSequenceNumber = big_segment_number + 1;
+                TSM_List[index].ActualWindowSize = actual_window_size;
+                TSM_List[index].SegmentRetryCount = apdu_retries();
+                TSM_List[index].SegmentTimer = apdu_segment_timeout();
+                FillWindow(
+                    &TSM_List[index], TSM_List[index].InitialSequenceNumber);
+                TSM_List[index].SegmentTimer = apdu_segment_timeout();
+            } else {
+                /* FinalAck_Received */
+                TSM_List[index].SegmentTimer = 0;
+                if (TSM_List[index].state ==
+                    TSM_STATE_SEGMENTED_RESPONSE_SERVER) {
+                    /* Response : end communications */
+                    /* Release data */
+                    TSM_List[index].state = TSM_STATE_IDLE;
+                    /* Completely free data */
+                    tsm_free_invoke_id_check(invoke_id, NULL, true);
+                } else {
+                    /* Request : Wait confirmation */
+                    TSM_List[index].RequestTimer = apdu_timeout();
+                    TSM_List[index].state = TSM_STATE_AWAIT_CONFIRMATION;
+                }
+            }
+        }
+    } else {
+        /* UnexpectedPDU_Received */
+        /* Release data */
+        free_blob(&TSM_List[index]);
+        /* Abort */
+        abort_pdu_send(
+            invoke_id, src,
+            ABORT_REASON_INVALID_APDU_IN_THIS_STATE, true);
+        /* We must free invoke_id ! */
+        tsm_free_invoke_id_check(invoke_id, NULL, true);
+    }
+}
+
+/* Check unexpected PDU is received in active TSM state other than idle state for server */
+bool check_unexpected_pdu_received(
+    BACNET_ADDRESS *src, 
+    BACNET_CONFIRMED_SERVICE_DATA *service_data )
+{
+    uint8_t index = 0;
+    bool status = false;
+    uint8_t peer_id = 0;
+    peer_id = tsm_get_peer_id(src, service_data->invoke_id);
+    index = tsm_find_invokeID_index(peer_id);
+    if (index < MAX_TSM_TRANSACTIONS)
+    {
+        BACNET_TSM_DATA *plist = &TSM_List[index];
+        if ((plist->state == TSM_STATE_SEGMENTED_RESPONSE_SERVER) ||
+            (plist->state == TSM_STATE_SEGMENTED_REQUEST_SERVER)) {
+            abort_pdu_send(
+                service_data->invoke_id, src,
+                ABORT_REASON_INVALID_APDU_IN_THIS_STATE, true);
+            tsm_free_invoke_id_check(peer_id, src, true);
+            status = true;
+        }
+    }
+    return status;
+}
+#endif
+
+/** Called once a millisecond or slower.
+ *  This function calls the handler for a
+ *  timeout 'Timeout_Function', if necessary.
+ *  Here, Stack is updated only to support segmentation for Server and implementing only two states
+ *  TSM_STATE_SEGMENTED_RESPONSE_SERVER and TSM_STATE_SEGMENTED_REQUEST_SERVER
+ *  Client segmentation is not updated.
+ *
+ * @param milliseconds - Count of milliseconds passed, since the last call.
+ */
+void tsm_timer_milliseconds(uint16_t milliseconds)
+{
+    unsigned i = 0; /* counter */
+    for (i = 0; i < MAX_TSM_TRANSACTIONS; i++) {
+        BACNET_TSM_DATA *plist = &TSM_List[i];
+        if (plist->state == TSM_STATE_AWAIT_CONFIRMATION) {
+            if (plist->RequestTimer > milliseconds) {
+                plist->RequestTimer -= milliseconds;
+            } else {
+                plist->RequestTimer = 0;
+            }
+            /* AWAIT_CONFIRMATION */
+            if (plist->RequestTimer == 0) {
+                if (plist->RetryCount < apdu_retries()) {
+                    plist->RequestTimer = apdu_timeout();
+                    plist->RetryCount++;
+                    datalink_send_pdu(
+                        &plist->dest, &plist->npdu_data, &plist->apdu[0],
+                        plist->apdu_len);
+                } else {
+                    /* note: the invoke id has not been cleared yet
+                       and this indicates a failed message:
+                       IDLE and a valid invoke id */
+                    plist->state = TSM_STATE_IDLE;
+                    if (plist->InvokeID != 0) {
+                        if (Timeout_Function) {
+                            Timeout_Function(plist->InvokeID);
+                        }
+                    }
+                }
+            }
+        }
+
+#if BACNET_SEGMENTATION_ENABLED
+        if (plist->state == TSM_STATE_SEGMENTED_RESPONSE_SERVER) {
+            /* RequestTimer stopped in this state */
+            if (plist->SegmentTimer > milliseconds) {
+                plist->SegmentTimer -= milliseconds;
+            } else {
+                plist->SegmentTimer = 0;
+            }
+            /* timeout.  retry? */
+            if (plist->SegmentTimer == 0) {
+                plist->SegmentRetryCount--;
+                plist->SegmentTimer = apdu_segment_timeout();
+                if (plist->SegmentRetryCount) {
+                    /* Re-send PDU data */
+                    FillWindow(&TSM_List[i], plist->InitialSequenceNumber);
+                } else {
+                    /* note: the invoke id has not been cleared yet
+                       and this indicates a failed message:
+                       IDLE and a valid invoke id */
+                    plist->state = TSM_STATE_IDLE;
+                }
+            }
+        }
+
+        if (plist->state == TSM_STATE_SEGMENTED_REQUEST_SERVER) {
+            /* RequestTimer stopped in this state */
+            if (plist->SegmentTimer > milliseconds) {
+                plist->SegmentTimer -= milliseconds;
+            } else {
+                plist->SegmentTimer = 0;
+            }
+            /* timeout : free memory */
+            if (plist->SegmentTimer == 0) {
+                /* Clear Peer data, if any. Lookup with our internal ID
+                status. */
+                tsm_clear_peer_id(plist->InvokeID);
+                /* Release segmented data */
+                free_blob(&TSM_List[i]);
+
+                /* flag slot as "unused" */
+                plist->InvokeID = 0;
+                /* free all memory associated */
+                plist->state = TSM_STATE_IDLE;
+            }
+        }
+#endif
+    }
 }
 #endif

--- a/src/bacnet/basic/tsm/tsm.h
+++ b/src/bacnet/basic/tsm/tsm.h
@@ -15,6 +15,9 @@
 #include "bacnet/bacdef.h"
 /* BACnet Stack API */
 #include "bacnet/npdu.h"
+#if BACNET_SEGMENTATION_ENABLED
+#include "bacnet/apdu.h"
+#endif
 
 /* note: TSM functionality is optional - only needed if we are
    doing client requests */
@@ -24,7 +27,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 /* FIXME: modify basic service handlers to use TSM rather than this buffer! */
-BACNET_STACK_EXPORT extern uint8_t Handler_Transmit_Buffer[MAX_PDU];
+BACNET_STACK_EXPORT extern uint8_t *Handler_Transmit_Buffer;
 
 #ifdef __cplusplus
 }
@@ -37,9 +40,25 @@ typedef enum {
     TSM_STATE_IDLE,
     TSM_STATE_AWAIT_CONFIRMATION,
     TSM_STATE_AWAIT_RESPONSE,
-    TSM_STATE_SEGMENTED_REQUEST,
+    TSM_STATE_SEGMENTED_REQUEST_SERVER,
     TSM_STATE_SEGMENTED_CONFIRMATION
+#if BACNET_SEGMENTATION_ENABLED
+    ,TSM_STATE_SEGMENTED_RESPONSE_SERVER
+#endif
 } BACNET_TSM_STATE;
+
+#if BACNET_SEGMENTATION_ENABLED
+/* Indirect data state : */
+typedef struct BACnet_TSM_Indirect_Data {
+    /* the address we received data from */
+    BACNET_ADDRESS PeerAddress;
+    /* the peer unique id */
+    uint8_t PeerInvokeID;
+    /* the unique id to use within our internal states.
+       zero means : "unused slot". */
+    uint8_t InternalInvokeID;
+} BACNET_TSM_INDIRECT_DATA;
+#endif
 
 /* 5.4.1 Variables And Parameters */
 /* The following variables are defined for each instance of  */
@@ -47,21 +66,23 @@ typedef enum {
 typedef struct BACnet_TSM_Data {
     /* used to count APDU retries */
     uint8_t RetryCount;
+#if BACNET_SEGMENTATION_ENABLED
     /* used to count segment retries */
-    /*uint8_t SegmentRetryCount;  */
+    uint8_t SegmentRetryCount;  
     /* used to control APDU retries and the acceptance of server replies */
-    /*bool SentAllSegments;  */
+    bool SentAllSegments;  
     /* stores the sequence number of the last segment received in order */
-    /*uint8_t LastSequenceNumber; */
+    uint8_t LastSequenceNumber; 
     /* stores the sequence number of the first segment of */
     /* a sequence of segments that fill a window */
-    /*uint8_t InitialSequenceNumber; */
+    uint8_t InitialSequenceNumber; 
     /* stores the current window size */
-    /*uint8_t ActualWindowSize; */
+    uint8_t ActualWindowSize; 
     /* stores the window size proposed by the segment sender */
-    /*uint8_t ProposedWindowSize;  */
+    uint8_t ProposedWindowSize;  
     /*  used to perform timeout on PDU segments */
-    /*uint8_t SegmentTimer; */
+    uint16_t SegmentTimer; 
+#endif
     /* used to perform timeout on Confirmed Requests */
     /* in milliseconds */
     uint16_t RequestTimer;
@@ -73,9 +94,25 @@ typedef struct BACnet_TSM_Data {
     BACNET_ADDRESS dest;
     /* the network layer info */
     BACNET_NPDU_DATA npdu_data;
-    /* copy of the APDU, should we need to send it again */
-    uint8_t apdu[MAX_PDU];
     unsigned apdu_len;
+    /* copy of the APDU, should we need to send it again */
+    uint8_t *apdu;
+#if BACNET_SEGMENTATION_ENABLED
+    /* APDU header informations */
+    BACNET_APDU_FIXED_HEADER apdu_fixed_header;
+    /* calculated max APDU length / packet */
+    uint32_t apdu_maximum_length;
+    /* calculated max APDU length / total */
+    uint32_t maximum_transmittable_length;
+    /* Multiple APDU segments blob memorized here */
+    uint8_t *apdu_blob;
+    /* Size of allocated Multiple APDU segments blob */
+    uint32_t apdu_blob_allocated;
+    /* Size of data within the multiple APDU segments blob  */
+    uint32_t apdu_blob_size;
+    /* Count received segments (prevents D.O.S.) */
+    uint32_t ReceivedSegmentsCount;
+#endif
 } BACNET_TSM_DATA;
 
 typedef void (*tsm_timeout_function)(uint8_t invoke_id);
@@ -123,6 +160,64 @@ bool tsm_invoke_id_free(uint8_t invokeID);
 BACNET_STACK_EXPORT
 bool tsm_invoke_id_failed(uint8_t invokeID);
 
+#if BACNET_SEGMENTATION_ENABLED
+/** Clear TSM Peer data */
+BACNET_STACK_EXPORT
+void tsm_clear_peer_id(uint8_t InternalInvokeID);
+
+/* frees the invokeID and sets its state to IDLE */
+BACNET_STACK_EXPORT
+void tsm_free_invoke_id_check(
+    uint8_t invokeID, 
+    BACNET_ADDRESS *peer_address, 
+    bool cleanup);
+
+/* Associates a Peer address and invoke ID with our TSM */
+BACNET_STACK_EXPORT
+uint8_t tsm_get_peer_id(
+    BACNET_ADDRESS *src, 
+    uint8_t invokeID);
+
+BACNET_STACK_EXPORT
+bool tsm_set_segmented_confirmed_service_received(
+    BACNET_ADDRESS *src,
+    BACNET_CONFIRMED_SERVICE_DATA *service_data,
+    uint8_t *internal_invoke_id,
+    uint8_t **pservice_request, /* IN/OUT */
+    uint16_t *pservice_request_len /* IN/OUT */
+);
+
+BACNET_STACK_EXPORT
+int tsm_set_complexack_transaction(
+    BACNET_ADDRESS *dest,
+    BACNET_NPDU_DATA *npdu_data,
+    BACNET_APDU_FIXED_HEADER *apdu_fixed_header,
+    BACNET_CONFIRMED_SERVICE_DATA *confirmed_service_data,
+    uint8_t *pdu,
+    uint32_t pdu_len);
+
+BACNET_STACK_EXPORT
+void tsm_segmentack_received(
+    uint8_t invoke_id,
+    uint8_t sequence_number,
+    uint8_t actual_window_size,
+    bool nak,
+    bool server,
+    BACNET_ADDRESS *src);
+
+BACNET_STACK_EXPORT
+bool check_unexpected_pdu_received(
+    BACNET_ADDRESS *src, 
+    BACNET_CONFIRMED_SERVICE_DATA *service_data);
+
+BACNET_STACK_EXPORT
+void abort_pdu_send(
+    uint8_t invoke_id, 
+    BACNET_ADDRESS *dest, 
+    uint8_t reason, 
+    bool server);
+
+#endif
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/src/bacnet/config.h
+++ b/src/bacnet/config.h
@@ -79,6 +79,11 @@
 #endif
 #endif
 
+#if defined(BACNET_SEGMENTATION_ENABLED)
+#define BACNET_SEGMENTATION_ENABLED 1
+#endif
+
+
 #if defined(BACDL_SOME_DATALINK_ENABLED) && defined(BACDL_NONE)
 #error "BACDL_NONE is not compatible with other BACDL_ defines"
 #elif !defined(BACDL_SOME_DATALINK_ENABLED) && !defined(BACDL_NONE) && \
@@ -189,6 +194,21 @@
 #if !defined(MAX_ADDRESS_CACHE)
 #define MAX_ADDRESS_CACHE 255
 #endif
+
+#if BACNET_SEGMENTATION_ENABLED
+/* for confirmed segmented messages, this is the number of peer
+   segmented requests we can stand at the same time. */
+#if !defined(MAX_TSM_PEERS)
+#define MAX_TSM_PEERS 16
+#endif
+
+/* for segmented messages, this is the number of segments accepted */
+/* (max memory allocated for one message : MAX_APDU * MAX_SEGMENTS) */
+#if !defined(MAX_SEGMENTS_ACCEPTED)
+#define MAX_SEGMENTS_ACCEPTED 25
+#endif
+#endif
+
 
 /* some modules have debugging enabled using PRINT_ENABLED */
 #if !defined(PRINT_ENABLED)

--- a/src/bacnet/segmentack.c
+++ b/src/bacnet/segmentack.c
@@ -1,0 +1,100 @@
+/*####COPYRIGHTBEGIN####
+ -------------------------------------------
+ Copyright (C) 2010 Julien Bennet
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to:
+ The Free Software Foundation, Inc.
+ 59 Temple Place - Suite 330
+ Boston, MA  02111-1307, USA.
+
+ As a special exception, if other files instantiate templates or
+ use macros or inline functions from this file, or you compile
+ this file and link it with other works to produce a work based
+ on this file, this file does not by itself cause the resulting
+ work to be covered by the GNU General Public License. However
+ the source code for this file must still be made available in
+ accordance with section (3) of the GNU General Public License.
+
+ This exception does not invalidate any other reasons why a work
+ based on this file might be covered by the GNU General Public
+ License.
+ -------------------------------------------
+####COPYRIGHTEND####*/
+#include "segmentack.h"
+
+/** Method to encode the segment ack .
+ *
+ * @param apdu[in]  Pointer to the buffer for encoding.
+ * @param negativeack[in]  Acknowedlegment for the segment.
+ * @param server[in]  Set to True if the acknowlegment is from the server, else false.
+ * @param invoke_id[in]  Invoke Id
+ * @param sequence_number[in]  Sequence number of the segment to be acknowledged
+ * @param actual_window_size[in]  Actual window size.
+ *
+ * @return Length of encoded data or zero on error.
+ */
+int segmentack_encode_apdu(
+    uint8_t * apdu,
+    bool negativeack,
+    bool server,
+    uint8_t invoke_id,
+    uint8_t sequence_number,
+    uint8_t actual_window_size)
+{
+    int apdu_len = 0;   /* total length of the apdu, return value */
+    uint8_t server_code = server ? 0x01 : 0x00;
+    uint8_t nak_code = negativeack ? 0x02 : 0x00;
+
+    if (apdu) {
+        apdu[0] = PDU_TYPE_SEGMENT_ACK | server_code | nak_code;
+        apdu[1] = invoke_id;
+        apdu[2] = sequence_number;
+        apdu[3] = actual_window_size;
+        apdu_len = 4;
+    }
+
+    return apdu_len;
+}
+
+/** Method to decode the segment ack service request
+ *
+ * @param apdu[in] The apdu portion of the ACK reply.
+ * @param apdu_len[in] The total length of the apdu.
+ * @param invoke_id[in]  Invoke Id of the request.
+ * @param sequence_number[in]  Sequence number of the segment received.
+ * @param actual_window_size[in]  Actual window size.
+ *
+ * @return Length of decoded data or zero on error.
+ */
+int segmentack_decode_service_request(
+    uint8_t * apdu,
+    unsigned apdu_len,
+    uint8_t * invoke_id,
+    uint8_t * sequence_number,
+    uint8_t * actual_window_size)
+{
+    int len = 0;
+    int apdu_header_size = 3;
+
+    if (apdu_len >= apdu_header_size) {
+        if (invoke_id)
+            *invoke_id = apdu[0];
+        if (sequence_number)
+            *sequence_number = apdu[1];
+        if (actual_window_size)
+            *actual_window_size = apdu[2];
+    }
+
+    return len;
+}

--- a/src/bacnet/segmentack.h
+++ b/src/bacnet/segmentack.h
@@ -1,0 +1,67 @@
+/*####COPYRIGHTBEGIN####
+ -------------------------------------------
+ Copyright (C) 2010 Julien Bennet
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to:
+ The Free Software Foundation, Inc.
+ 59 Temple Place - Suite 330
+ Boston, MA  02111-1307, USA.
+
+ As a special exception, if other files instantiate templates or
+ use macros or inline functions from this file, or you compile
+ this file and link it with other works to produce a work based
+ on this file, this file does not by itself cause the resulting
+ work to be covered by the GNU General Public License. However
+ the source code for this file must still be made available in
+ accordance with section (3) of the GNU General Public License.
+
+ This exception does not invalidate any other reasons why a work
+ based on this file might be covered by the GNU General Public
+ License.
+ -------------------------------------------
+####COPYRIGHTEND####*/
+#ifndef BACNET_SEGMENT_ACK_H
+#define BACNET_SEGMENT_ACK_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "bacenum.h"
+#include "bacdcode.h"
+#include "bacdef.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+BACNET_STACK_EXPORT
+int segmentack_encode_apdu(
+    uint8_t *apdu,
+        bool negativeack,
+        bool server,
+        uint8_t invoke_id,
+        uint8_t sequence_number,
+        uint8_t actual_window_size);
+
+BACNET_STACK_EXPORT
+int segmentack_decode_service_request(uint8_t *apdu,
+        unsigned apdu_len,
+        uint8_t *invoke_id,
+        uint8_t *sequence_number,
+        uint8_t *actual_window_size);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* SEGMENT_ACK_H */


### PR DESCRIPTION
Added segmentation feature for server.

Segmentation can be ON(SEGMENTATION_BOTH)/OFF(SEGMENTATION_NONE) by setting the macro: **BACNET_SEGMENTATION_ENABLED**
Segmentation is ON(SEGMENTATION_BOTH) by default.

Refactored the below services to support segmentation:
1.ReadProperty
2.ReadPropertyMultiple
3.WriteProperty
4.WritePropertyMultiple
5.DCC

Note: Client segmentation is not supported.