### PR TITLE
Fixed windows build of bacpoll and bacdiscover by removing DLL export…

### DIFF
--- a/src/bacnet/basic/client/bac-data.h
+++ b/src/bacnet/basic/client/bac-data.h
@@ -26,37 +26,28 @@ struct bacnet_status_flags_t {
 extern "C" {
 #endif /* __cplusplus */
 
-BACNET_STACK_EXPORT
 void bacnet_data_init(void);
-BACNET_STACK_EXPORT
 void bacnet_data_task(void);
-BACNET_STACK_EXPORT
 void bacnet_data_poll_seconds_set(unsigned int seconds);
-BACNET_STACK_EXPORT
 unsigned int bacnet_data_poll_seconds(void);
-BACNET_STACK_EXPORT
 void bacnet_data_value_save(
     uint32_t device_instance,
     BACNET_READ_PROPERTY_DATA *rp_data,
     BACNET_APPLICATION_DATA_VALUE *value);
-BACNET_STACK_EXPORT
 bool bacnet_data_object_add(
     uint32_t device_id,
     BACNET_OBJECT_TYPE object_type,
     uint32_t object_instance);
-BACNET_STACK_EXPORT
 bool bacnet_data_analog_present_value(
     uint32_t device_id,
     BACNET_OBJECT_TYPE object_type,
     uint32_t object_instance,
     float *float_value);
-BACNET_STACK_EXPORT
 bool bacnet_data_multistate_present_value(
     uint32_t device_id,
     uint16_t object_type,
     uint32_t object_instance,
     uint32_t *unsigned_value);
-BACNET_STACK_EXPORT
 bool bacnet_data_binary_present_value(
     uint32_t device_id,
     uint16_t object_type,

--- a/src/bacnet/basic/client/bac-discover.h
+++ b/src/bacnet/basic/client/bac-discover.h
@@ -40,42 +40,30 @@ typedef bool (*bacnet_discover_device_callback)(
 extern "C" {
 #endif /* __cplusplus */
 
-BACNET_STACK_EXPORT
 void bacnet_discover_cleanup(void);
-
-BACNET_STACK_EXPORT
 int bacnet_discover_device_count(void);
-BACNET_STACK_EXPORT
 uint32_t bacnet_discover_device_instance(unsigned index);
-BACNET_STACK_EXPORT
 int bacnet_discover_device_object_count(uint32_t device_id);
-BACNET_STACK_EXPORT
 bool bacnet_discover_device_object_identifier(
     uint32_t device_id, unsigned index, BACNET_OBJECT_ID *object_id);
-BACNET_STACK_EXPORT
 unsigned long bacnet_discover_device_elapsed_milliseconds(uint32_t device_id);
-BACNET_STACK_EXPORT
 size_t bacnet_discover_device_memory(uint32_t device_id);
-BACNET_STACK_EXPORT
 unsigned int bacnet_discover_object_property_count(
     uint32_t device_id,
     BACNET_OBJECT_TYPE object_type,
     uint32_t object_instance);
-BACNET_STACK_EXPORT
 bool bacnet_discover_object_property_identifier(
     uint32_t device_id,
     BACNET_OBJECT_TYPE object_type,
     uint32_t object_instance,
     unsigned index,
     uint32_t *property_id);
-BACNET_STACK_EXPORT
 bool bacnet_discover_property_value(
     uint32_t device_id,
     BACNET_OBJECT_TYPE object_type,
     uint32_t object_instance,
     BACNET_PROPERTY_ID object_property,
     BACNET_APPLICATION_DATA_VALUE *value);
-BACNET_STACK_EXPORT
 bool bacnet_discover_property_name(
     uint32_t device_id,
     BACNET_OBJECT_TYPE object_type,
@@ -84,54 +72,32 @@ bool bacnet_discover_property_name(
     char *buffer,
     size_t buffer_len,
     const char *default_string);
-
-BACNET_STACK_EXPORT
 bool bacnet_discover_device_object_property_iterate(
     uint32_t device_id,
     BACNET_OBJECT_TYPE object_type,
     uint32_t object_instance,
     bacnet_discover_device_callback callback,
     void *context);
-BACNET_STACK_EXPORT
 bool bacnet_discover_device_object_iterate(
     uint32_t device_id,
     bacnet_discover_device_callback callback,
     void *context);
-BACNET_STACK_EXPORT
 bool bacnet_discover_device_iterate(
     bacnet_discover_device_callback callback, void *context);
-
-BACNET_STACK_EXPORT
 void bacnet_discover_task(void);
-
-BACNET_STACK_EXPORT
 void bacnet_discover_dnet_set(uint16_t dnet);
-BACNET_STACK_EXPORT
 uint16_t bacnet_discover_dnet(void);
-
-BACNET_STACK_EXPORT
 void bacnet_discover_vendor_id_set(uint16_t vendor_id);
-BACNET_STACK_EXPORT
 uint16_t bacnet_discover_vendor_id(void);
-
-BACNET_STACK_EXPORT
 void bacnet_discover_seconds_set(unsigned int seconds);
-BACNET_STACK_EXPORT
 unsigned int bacnet_discover_seconds(void);
-
-BACNET_STACK_EXPORT
 void bacnet_discover_read_process_milliseconds_set(unsigned long milliseconds);
-BACNET_STACK_EXPORT
 unsigned long bacnet_discover_read_process_milliseconds(void);
-
-BACNET_STACK_EXPORT
 void bacnet_discover_device_add(
     uint32_t device_instance,
     unsigned max_apdu,
     int segmentation,
     uint16_t vendor_id);
-
-BACNET_STACK_EXPORT
 void bacnet_discover_init(void);
 
 #ifdef __cplusplus

--- a/src/bacnet/basic/client/bac-rw.h
+++ b/src/bacnet/basic/client/bac-rw.h
@@ -46,22 +46,16 @@ typedef void (*bacnet_read_write_device_callback_t)(
 extern "C" {
 #endif /* __cplusplus */
 
-BACNET_STACK_EXPORT
 void bacnet_read_write_init(void);
-BACNET_STACK_EXPORT
 void bacnet_read_write_task(void);
-BACNET_STACK_EXPORT
 bool bacnet_read_write_idle(void);
-BACNET_STACK_EXPORT
 bool bacnet_read_write_busy(void);
-BACNET_STACK_EXPORT
 bool bacnet_read_property_queue(
     uint32_t device_id,
     BACNET_OBJECT_TYPE object_type,
     uint32_t object_instance,
     BACNET_PROPERTY_ID object_property,
     uint32_t array_index);
-BACNET_STACK_EXPORT
 bool bacnet_write_property_real_queue(
     uint32_t device_id,
     BACNET_OBJECT_TYPE object_type,
@@ -70,7 +64,6 @@ bool bacnet_write_property_real_queue(
     float value,
     uint8_t priority,
     uint32_t array_index);
-BACNET_STACK_EXPORT
 bool bacnet_write_property_null_queue(
     uint32_t device_id,
     BACNET_OBJECT_TYPE object_type,
@@ -78,7 +71,6 @@ bool bacnet_write_property_null_queue(
     BACNET_PROPERTY_ID object_property,
     uint8_t priority,
     uint32_t array_index);
-BACNET_STACK_EXPORT
 bool bacnet_write_property_enumerated_queue(
     uint32_t device_id,
     BACNET_OBJECT_TYPE object_type,
@@ -87,7 +79,6 @@ bool bacnet_write_property_enumerated_queue(
     unsigned int value,
     uint8_t priority,
     uint32_t array_index);
-BACNET_STACK_EXPORT
 bool bacnet_write_property_unsigned_queue(
     uint32_t device_id,
     BACNET_OBJECT_TYPE object_type,
@@ -96,7 +87,6 @@ bool bacnet_write_property_unsigned_queue(
     unsigned int value,
     uint8_t priority,
     uint32_t array_index);
-BACNET_STACK_EXPORT
 bool bacnet_write_property_signed_queue(
     uint32_t device_id,
     BACNET_OBJECT_TYPE object_type,
@@ -105,7 +95,6 @@ bool bacnet_write_property_signed_queue(
     signed int value,
     uint8_t priority,
     uint32_t array_index);
-BACNET_STACK_EXPORT
 bool bacnet_write_property_boolean_queue(
     uint32_t device_id,
     BACNET_OBJECT_TYPE object_type,
@@ -114,15 +103,11 @@ bool bacnet_write_property_boolean_queue(
     bool value,
     uint8_t priority,
     uint32_t array_index);
-BACNET_STACK_EXPORT
 void bacnet_read_write_value_callback_set(
     bacnet_read_write_value_callback_t callback);
-BACNET_STACK_EXPORT
 void bacnet_read_write_device_callback_set(
     bacnet_read_write_device_callback_t callback);
-BACNET_STACK_EXPORT
 void bacnet_read_write_vendor_id_filter_set(uint16_t vendor_id);
-BACNET_STACK_EXPORT
 uint16_t bacnet_read_write_vendor_id_filter(void);
 
 #ifdef __cplusplus

--- a/src/bacnet/basic/client/bac-task.h
+++ b/src/bacnet/basic/client/bac-task.h
@@ -15,9 +15,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-BACNET_STACK_EXPORT
 void bacnet_task_init(void);
-BACNET_STACK_EXPORT
 void bacnet_task(void);
 
 #ifdef __cplusplus


### PR DESCRIPTION
… in basic client headers