### PR TITLE
specify a target for discovery

### DIFF
--- a/apps/server-discover/main.c
+++ b/apps/server-discover/main.c
@@ -266,6 +266,7 @@ int main(int argc, char *argv[])
                 if ((long_value >= 0) &&
                     (long_value <= BACNET_BROADCAST_NETWORK)) {
                     dnet = (uint16_t)long_value;
+                    specific_address = true;
                 }
             }
         } else if (strcmp(argv[argi], "--mac") == 0) {

--- a/apps/server-discover/main.c
+++ b/apps/server-discover/main.c
@@ -301,34 +301,6 @@ int main(int argc, char *argv[])
     }
     if (specific_address) {
         bacnet_address_init(&dest, &mac, dnet, &adr);
-        if (adr.len && mac.len) {
-            memcpy(&dest.mac[0], &mac.adr[0], mac.len);
-            dest.mac_len = mac.len;
-            memcpy(&dest.adr[0], &adr.adr[0], adr.len);
-            dest.len = adr.len;
-            if ((dnet >= 0) && (dnet <= BACNET_BROADCAST_NETWORK)) {
-                dest.net = dnet;
-            } else {
-                dest.net = BACNET_BROADCAST_NETWORK;
-            }
-        } else if (mac.len) {
-            memcpy(&dest.mac[0], &mac.adr[0], mac.len);
-            dest.mac_len = mac.len;
-            dest.len = 0;
-            if ((dnet >= 0) && (dnet <= BACNET_BROADCAST_NETWORK)) {
-                dest.net = dnet;
-            } else {
-                dest.net = 0;
-            }
-        } else {
-            if ((dnet >= 0) && (dnet <= BACNET_BROADCAST_NETWORK)) {
-                dest.net = dnet;
-            } else {
-                dest.net = BACNET_BROADCAST_NETWORK;
-            }
-            dest.mac_len = 0;
-            dest.len = 0;
-        }
     }
     Device_Set_Object_Instance_Number(device_id);
     debug_printf_stdout(

--- a/apps/server-discover/main.c
+++ b/apps/server-discover/main.c
@@ -228,7 +228,7 @@ int main(int argc, char *argv[])
     /* data from the command line */
     unsigned long print_seconds = 60;
     unsigned long discover_seconds = 60;
-    long dnet = -1;
+    uint16_t dnet = BACNET_BROADCAST_NETWORK;
     BACNET_MAC_ADDRESS mac = { 0 };
     BACNET_MAC_ADDRESS adr = { 0 };
     BACNET_ADDRESS dest = { 0 };
@@ -263,20 +263,14 @@ int main(int argc, char *argv[])
         } else if (strcmp(argv[argi], "--dnet") == 0) {
             if (++argi < argc) {
                 long_value = strtol(argv[argi], NULL, 0);
-                if ((long_value >= 0) && (long_value <= UINT16_MAX)) {
+                if ((long_value >= 0) &&
+                    (long_value <= BACNET_BROADCAST_NETWORK)) {
                     dnet = (uint16_t)long_value;
                 }
             }
         } else if (strcmp(argv[argi], "--mac") == 0) {
             if (++argi < argc) {
                 if (bacnet_address_mac_from_ascii(&mac, argv[argi])) {
-                    specific_address = true;
-                }
-            }
-        } else if (strcmp(argv[argi], "--dnet") == 0) {
-            if (++argi < argc) {
-                dnet = strtol(argv[argi], NULL, 0);
-                if ((dnet >= 0) && (dnet <= BACNET_BROADCAST_NETWORK)) {
                     specific_address = true;
                 }
             }

--- a/apps/server-discover/main.c
+++ b/apps/server-discover/main.c
@@ -174,7 +174,7 @@ static void bacnet_server_init(void)
  */
 static void print_usage(const char *filename)
 {
-    printf("Usage: %s [--dnet]\n", filename);
+    printf("Usage: %s [--dnet][--dadr][--mac]\n", filename);
     printf("       [--discover-seconds][--print-seconds][--print-summary]\n");
     printf("       [--version][--help]\n");
 }
@@ -191,10 +191,24 @@ static void print_help(const char *filename)
            "Number of seconds to wait before printing list of devices.\n");
     printf("--print-summary:\n"
            "Print only the list of devices.\n");
+    printf("\n");
     printf("--dnet N\n"
            "Optional BACnet network number N for directed requests.\n"
            "Valid range is from 0 to 65535 where 0 is the local connection\n"
            "and 65535 is network broadcast.\n");
+    printf("\n");
+    printf("--mac A\n"
+           "Optional BACnet mac address."
+           "Valid ranges are from 00 to FF (hex) for MS/TP or ARCNET,\n"
+           "or an IP string with optional port number like 10.1.2.3:47808\n"
+           "or an Ethernet MAC in hex like 00:21:70:7e:32:bb\n");
+    printf("\n");
+    printf("--dadr A\n"
+           "Optional BACnet mac address on the destination BACnet network "
+           "number.\n"
+           "Valid ranges are from 00 to FF (hex) for MS/TP or ARCNET,\n"
+           "or an IP string with optional port number like 10.1.2.3:47808\n"
+           "or an Ethernet MAC in hex like 00:21:70:7e:32:bb\n");
     (void)filename;
 }
 
@@ -214,7 +228,11 @@ int main(int argc, char *argv[])
     /* data from the command line */
     unsigned long print_seconds = 60;
     unsigned long discover_seconds = 60;
-    uint16_t dnet = 0;
+    long dnet = -1;
+    BACNET_MAC_ADDRESS mac = { 0 };
+    BACNET_MAC_ADDRESS adr = { 0 };
+    BACNET_ADDRESS dest = { 0 };
+    bool specific_address = false;
 
     filename = filename_remove_path(argv[0]);
     for (argi = 1; argi < argc; argi++) {
@@ -249,6 +267,25 @@ int main(int argc, char *argv[])
                     dnet = (uint16_t)long_value;
                 }
             }
+        } else if (strcmp(argv[argi], "--mac") == 0) {
+            if (++argi < argc) {
+                if (bacnet_address_mac_from_ascii(&mac, argv[argi])) {
+                    specific_address = true;
+                }
+            }
+        } else if (strcmp(argv[argi], "--dnet") == 0) {
+            if (++argi < argc) {
+                dnet = strtol(argv[argi], NULL, 0);
+                if ((dnet >= 0) && (dnet <= BACNET_BROADCAST_NETWORK)) {
+                    specific_address = true;
+                }
+            }
+        } else if (strcmp(argv[argi], "--dadr") == 0) {
+            if (++argi < argc) {
+                if (bacnet_address_mac_from_ascii(&adr, argv[argi])) {
+                    specific_address = true;
+                }
+            }
         } else {
             if (target_args == 0) {
                 device_id = strtol(argv[argi], NULL, 0);
@@ -262,6 +299,37 @@ int main(int argc, char *argv[])
             BACNET_MAX_INSTANCE);
         return 1;
     }
+    if (specific_address) {
+        bacnet_address_init(&dest, &mac, dnet, &adr);
+        if (adr.len && mac.len) {
+            memcpy(&dest.mac[0], &mac.adr[0], mac.len);
+            dest.mac_len = mac.len;
+            memcpy(&dest.adr[0], &adr.adr[0], adr.len);
+            dest.len = adr.len;
+            if ((dnet >= 0) && (dnet <= BACNET_BROADCAST_NETWORK)) {
+                dest.net = dnet;
+            } else {
+                dest.net = BACNET_BROADCAST_NETWORK;
+            }
+        } else if (mac.len) {
+            memcpy(&dest.mac[0], &mac.adr[0], mac.len);
+            dest.mac_len = mac.len;
+            dest.len = 0;
+            if ((dnet >= 0) && (dnet <= BACNET_BROADCAST_NETWORK)) {
+                dest.net = dnet;
+            } else {
+                dest.net = 0;
+            }
+        } else {
+            if ((dnet >= 0) && (dnet <= BACNET_BROADCAST_NETWORK)) {
+                dest.net = dnet;
+            } else {
+                dest.net = BACNET_BROADCAST_NETWORK;
+            }
+            dest.mac_len = 0;
+            dest.len = 0;
+        }
+    }
     Device_Set_Object_Instance_Number(device_id);
     debug_printf_stdout(
         "BACnet Server-Discovery Demo\n"
@@ -270,13 +338,13 @@ int main(int argc, char *argv[])
         "DNET: %u every %lu seconds\n"
         "Print Devices: every %lu seconds (0=none)\n"
         "Max APDU: %d\n",
-        BACnet_Version, Device_Object_Instance_Number(), dnet, discover_seconds,
-        print_seconds, MAX_APDU);
+        BACnet_Version, Device_Object_Instance_Number(), dest.net,
+        discover_seconds, print_seconds, MAX_APDU);
     dlenv_init();
     atexit(datalink_cleanup);
     bacnet_server_init();
     /* configure the discovery module */
-    bacnet_discover_dnet_set(dnet);
+    bacnet_discover_dest_set(&dest);
     bacnet_discover_seconds_set(discover_seconds);
     bacnet_discover_init();
     atexit(bacnet_discover_cleanup);

--- a/src/bacnet/basic/client/bac-discover.c
+++ b/src/bacnet/basic/client/bac-discover.c
@@ -31,8 +31,8 @@ static struct mstimer WhoIs_Timer;
 static struct mstimer Read_Write_Timer;
 /* list of devices */
 static OS_Keylist Device_List = NULL;
-/* discovery destination network */
-static uint16_t Target_DNET = 0;
+/* discovery destination */
+static BACNET_ADDRESS Target_DEST = { 0 };
 /* re-discovery time */
 static unsigned long Discovery_Milliseconds;
 /* states of discovery */
@@ -1074,16 +1074,12 @@ bool bacnet_discover_device_iterate(
 
 /**
  * @brief Non-blocking task for running BACnet client tasks
- * @param dest - BACnet address of the destination discovery
  */
 void bacnet_discover_task(void)
 {
-    BACNET_ADDRESS dest = { 0 };
-
     if (mstimer_expired(&WhoIs_Timer)) {
         mstimer_restart(&WhoIs_Timer);
-        dest.net = Target_DNET;
-        Send_WhoIs_To_Network(&dest, -1, -1);
+        Send_WhoIs_To_Network(&Target_DEST, -1, -1);
     }
     if (mstimer_expired(&Read_Write_Timer)) {
         mstimer_restart(&Read_Write_Timer);
@@ -1095,21 +1091,39 @@ void bacnet_discover_task(void)
 }
 
 /**
- * @brief Set the BACnet time between discovery in seconds
- * @param seconds - number of seconds between discovery intervals
+ * @brief Set the BACnet network number for directed requests
+ * @param dnet - BACnet network number
  */
 void bacnet_discover_dnet_set(uint16_t dnet)
 {
-    Target_DNET = dnet;
+    Target_DEST.net = dnet;
 }
 
 /**
- * @brief Get the BACnet time between discovery in seconds
- * @return number of seconds between discovery intervals
+ * @brief Get the BACnet network number
+ * @return BACnet network number
  */
 uint16_t bacnet_discover_dnet(void)
 {
-    return Target_DNET;
+    return Target_DEST.net;
+}
+
+/**
+ * @brief Set the BACnet address of target for directed requests
+ * @param dest - BACnet address
+ */
+void bacnet_discover_dest_set(const BACNET_ADDRESS *dest)
+{
+    bacnet_address_copy(&Target_DEST, dest);
+}
+
+/**
+ * @brief Get the the BACnet address of target
+ * @return BACnet address
+ */
+const BACNET_ADDRESS *bacnet_discover_dest(void)
+{
+    return &Target_DEST;
 }
 
 /**

--- a/src/bacnet/basic/client/bac-discover.h
+++ b/src/bacnet/basic/client/bac-discover.h
@@ -87,6 +87,8 @@ bool bacnet_discover_device_iterate(
 void bacnet_discover_task(void);
 void bacnet_discover_dnet_set(uint16_t dnet);
 uint16_t bacnet_discover_dnet(void);
+void bacnet_discover_dest_set(const BACNET_ADDRESS *dest);
+const BACNET_ADDRESS *bacnet_discover_dest(void);
 void bacnet_discover_vendor_id_set(uint16_t vendor_id);
 uint16_t bacnet_discover_vendor_id(void);
 void bacnet_discover_seconds_set(unsigned int seconds);


### PR DESCRIPTION
This allows folks to use something like `bacdiscover --mac "192.168.1.79:47808"` to discover a BACnet server running on a different port on the same host (as long as the server is using `handler_who_is_unicast`), which is at least useful for developing a BACnet server, but probably has other uses.

- added `bacnet_discover_dest_set` to `bac-discover`
- copied `--dadr` and `--mac` support from `readprop` to `server-discover`