### PR TITLE
Bsc fix debug printf warnings

### DIFF
--- a/ports/bsd/bsc-event.c
+++ b/ports/bsd/bsc-event.c
@@ -16,6 +16,7 @@
 
 #define DEBUG_BSC_EVENT 0
 
+#undef DEBUG_PRINTF
 #if DEBUG_BSC_EVENT == 1
 #define DEBUG_PRINTF printf
 #else

--- a/ports/bsd/websocket-cli.c
+++ b/ports/bsd/websocket-cli.c
@@ -16,6 +16,7 @@
 
 #define DEBUG_WEBSOCKET_CLIENT 0
 
+#undef DEBUG_PRINTF
 #if DEBUG_WEBSOCKET_CLIENT == 1
 #define DEBUG_PRINTF debug_printf
 #else

--- a/ports/bsd/websocket-srv.c
+++ b/ports/bsd/websocket-srv.c
@@ -17,6 +17,7 @@
 
 #define DEBUG_WEBSOCKET_SERVER 0
 
+#undef DEBUG_PRINTF
 #if DEBUG_WEBSOCKET_SERVER == 1
 #define DEBUG_PRINTF debug_printf
 #else

--- a/ports/linux/bsc-event.c
+++ b/ports/linux/bsc-event.c
@@ -16,6 +16,7 @@
 
 #define DEBUG_BSC_EVENT 0
 
+#undef DEBUG_PRINTF
 #if DEBUG_BSC_EVENT == 1
 #define DEBUG_PRINTF printf
 #else

--- a/ports/linux/websocket-cli.c
+++ b/ports/linux/websocket-cli.c
@@ -17,6 +17,7 @@
 
 #define DEBUG_WEBSOCKET_CLIENT 0
 
+#undef DEBUG_PRINTF
 #if DEBUG_WEBSOCKET_CLIENT == 1
 #define DEBUG_PRINTF debug_printf
 #else

--- a/ports/linux/websocket-srv.c
+++ b/ports/linux/websocket-srv.c
@@ -18,6 +18,7 @@
 
 #define DEBUG_WEBSOCKET_SERVER 0
 
+#undef DEBUG_PRINTF
 #if DEBUG_WEBSOCKET_SERVER == 1
 #define DEBUG_PRINTF debug_printf
 #else

--- a/ports/win32/bsc-event.c
+++ b/ports/win32/bsc-event.c
@@ -15,6 +15,7 @@
 
 #define DEBUG_BSC_EVENT 0
 
+#undef DEBUG_PRINTF
 #if DEBUG_BSC_EVENT == 1
 #define DEBUG_PRINTF printf
 #else

--- a/ports/win32/websocket-cli.c
+++ b/ports/win32/websocket-cli.c
@@ -15,6 +15,7 @@
 
 #define DEBUG_WEBSOCKET_CLIENT 0
 
+#undef DEBUG_PRINTF
 #if DEBUG_WEBSOCKET_CLIENT == 1
 #define DEBUG_PRINTF debug_printf
 #else

--- a/ports/win32/websocket-srv.c
+++ b/ports/win32/websocket-srv.c
@@ -15,10 +15,11 @@
 
 #define DEBUG_WEBSOCKET_SERVER 0
 
+#undef DEBUG_PRINTF
 #if DEBUG_WEBSOCKET_SERVER == 1
 #define DEBUG_PRINTF debug_printf
 #else
-#undef DEBUG_ENABLED
+#undef DEBUG_PRINTF
 #define DEBUG_PRINTF debug_printf_disabled
 #endif
 

--- a/ports/win32/websocket-srv.c
+++ b/ports/win32/websocket-srv.c
@@ -19,7 +19,7 @@
 #if DEBUG_WEBSOCKET_SERVER == 1
 #define DEBUG_PRINTF debug_printf
 #else
-#undef DEBUG_PRINTF
+#undef DEBUG_ENABLED
 #define DEBUG_PRINTF debug_printf_disabled
 #endif
 

--- a/src/bacnet/datalink/bsc/bsc-datalink.c
+++ b/src/bacnet/datalink/bsc/bsc-datalink.c
@@ -24,6 +24,7 @@
 
 #define PRINTF debug_printf_stderr
 #define DEBUG_BSC_DATALINK 0
+#undef DEBUG_PRINTF
 #if DEBUG_BSC_DATALINK == 1
 #define DEBUG_PRINTF debug_printf
 #else

--- a/src/bacnet/datalink/bsc/bsc-hub-connector.c
+++ b/src/bacnet/datalink/bsc/bsc-hub-connector.c
@@ -18,10 +18,11 @@
 
 #define DEBUG_BSC_HUB_CONNECTOR 0
 
+#undef DEBUG_PRINTF
 #if DEBUG_BSC_HUB_CONNECTOR == 1
 #define DEBUG_PRINTF debug_printf
 #else
-#undef DEBUG_ENABLED
+#undef DEBUG_PRINTF
 #define DEBUG_PRINTF debug_printf_disabled
 #endif
 

--- a/src/bacnet/datalink/bsc/bsc-hub-connector.c
+++ b/src/bacnet/datalink/bsc/bsc-hub-connector.c
@@ -22,7 +22,7 @@
 #if DEBUG_BSC_HUB_CONNECTOR == 1
 #define DEBUG_PRINTF debug_printf
 #else
-#undef DEBUG_PRINTF
+#undef DEBUG_ENABLED
 #define DEBUG_PRINTF debug_printf_disabled
 #endif
 

--- a/src/bacnet/datalink/bsc/bsc-hub-function.c
+++ b/src/bacnet/datalink/bsc/bsc-hub-function.c
@@ -17,6 +17,7 @@
 
 #define DEBUG_BSC_HUB_FUNCTION 0
 
+#undef DEBUG_PRINTF
 #if DEBUG_BSC_HUB_FUNCTION == 1
 #define DEBUG_PRINTF debug_printf
 #else

--- a/src/bacnet/datalink/bsc/bsc-node-switch.c
+++ b/src/bacnet/datalink/bsc/bsc-node-switch.c
@@ -18,6 +18,7 @@
 
 #define DEBUG_BSC_NODE_SWITCH 0
 
+#undef DEBUG_PRINTF
 #if DEBUG_BSC_NODE_SWITCH == 1
 #define DEBUG_PRINTF debug_printf
 #else

--- a/src/bacnet/datalink/bsc/bsc-node.c
+++ b/src/bacnet/datalink/bsc/bsc-node.c
@@ -21,6 +21,7 @@
 
 #define DEBUG_BSC_NODE 0
 
+#undef DEBUG_PRINTF
 #if DEBUG_BSC_NODE == 1
 #define DEBUG_PRINTF debug_printf
 #else

--- a/src/bacnet/datalink/bsc/bsc-socket.c
+++ b/src/bacnet/datalink/bsc/bsc-socket.c
@@ -17,6 +17,7 @@
 
 #define DEBUG_BSC_SOCKET 0
 
+#undef DEBUG_PRINTF
 #if DEBUG_BSC_SOCKET == 1
 #define DEBUG_PRINTF debug_printf
 #else


### PR DESCRIPTION
cleans up all the warnings like these in debug builds with `BACDL_BSC` on:
```
[build] src/bacnet/datalink/bsc/bsc-node-switch.c:25:9: warning: "DEBUG_PRINTF" redefined
[build]    25 | #define DEBUG_PRINTF debug_printf_disabled
[build]       |         ^~~~~~~~~~~~
[build] In file included from src/bacnet/datalink/bsc/bsc-node-switch.c:8:
[build] src/bacnet/basic/sys/debug.h:73:9: note: this is the location of the previous definition
[build]    73 | #define DEBUG_PRINTF debug_printf
[build]       |         ^~~~~~~~~~~~
```