### PR TITLE
`host_n_port_to_minimal`: support ipv4 address

### DIFF
--- a/ports/bsd/bip-init.c
+++ b/ports/bsd/bip-init.c
@@ -460,13 +460,13 @@ static void *get_addr_ptr(struct sockaddr *sockaddr_ptr)
 /**
  * @brief Get the default interface name using routing info
  * @return interface name, or NULL if not found or none
-*/
+ */
 static char *ifname_default(void)
 {
     if (BIP_Interface_Name[0] != 0) {
         return BIP_Interface_Name;
     }
-    snprintf(BIP_Interface_Name,  sizeof(BIP_Interface_Name), "%s", "en0");
+    snprintf(BIP_Interface_Name, sizeof(BIP_Interface_Name), "%s", "en0");
 
     return BIP_Interface_Name;
 }
@@ -606,7 +606,8 @@ void bip_set_interface(const char *ifname)
     }
     BIP_Broadcast_Addr.s_addr = htonl(broadcast_address);
 #else
-    rv = bip_get_local_address_ioctl(ifname, &broadcast_address, SIOCGIFBRDADDR);
+    rv =
+        bip_get_local_address_ioctl(ifname, &broadcast_address, SIOCGIFBRDADDR);
     if (rv < 0) {
         BIP_Broadcast_Addr.s_addr = ~0;
     } else {
@@ -723,7 +724,8 @@ bool bip_init(char *ifname)
 
     broadcast_sin_config.sin_family = AF_INET;
     broadcast_sin_config.sin_port = BIP_Port;
-    memset(&(broadcast_sin_config.sin_zero), '\0',
+    memset(
+        &(broadcast_sin_config.sin_zero), '\0',
         sizeof(broadcast_sin_config.sin_zero));
     if (BIP_Broadcast_Binding_Address_Override) {
         broadcast_sin_config.sin_addr.s_addr =

--- a/src/bacnet/hostnport.c
+++ b/src/bacnet/hostnport.c
@@ -506,7 +506,9 @@ bool host_n_port_to_minimal(
             dst->tag = BACNET_HOST_ADDRESS_TAG_IP_ADDRESS;
             dst->host.ip_address.length = octetstring_copy_value(
                 dst->host.ip_address.address,
-                sizeof(dst->host.ip_address.address), &src->host.ip_address);
+                min(sizeof(dst->host.ip_address.address),
+                    src->host.ip_address.length),
+                &src->host.ip_address);
             if (dst->host.ip_address.length > 0) {
                 status = true;
             }


### PR DESCRIPTION
If the `ip_address` in the `BACNET_HOST_N_PORT` `src` is a 4-byte IP4 address, then `host_n_port_to_minimal` refuses to copy it, by passing `sizeof(dst->host.ip_address.address)` (which is 16) to `octetstring_copy_value` as the number of bytes to copy.

`min(sizeof(dst->host.ip_address.address), src->host.ip_address.length)` causes the copy to safely succeed, but maybe there's a better solution?