### PR TITLE
Added enum text sprintf for Network Port object

### DIFF
--- a/src/bacnet/bacapp.c
+++ b/src/bacnet/bacapp.c
@@ -2454,6 +2454,18 @@ static int bacapp_snprintf_enumerated(
             ret_val = bacapp_snprintf(
                 str, str_len, "%s", bactext_program_error_name(value));
             break;
+        case PROP_NETWORK_NUMBER_QUALITY:
+            ret_val = bacapp_snprintf(
+                str, str_len, "%s", bactext_network_number_quality_name(value));
+            break;
+        case PROP_NETWORK_TYPE:
+            ret_val = bacapp_snprintf(
+                str, str_len, "%s", bactext_network_port_type_name(value));
+            break;
+        case PROP_PROTOCOL_LEVEL:
+            ret_val = bacapp_snprintf(
+                str, str_len, "%s", bactext_protocol_level_name(value));
+            break;
         default:
             ret_val =
                 bacapp_snprintf(str, str_len, "%lu", (unsigned long)value);

--- a/src/bacnet/bactext.c
+++ b/src/bacnet/bactext.c
@@ -2402,6 +2402,20 @@ const char *bactext_network_number_quality_name(unsigned index)
         bactext_network_number_quality_names, index, ASHRAE_Reserved_String);
 }
 
+INDTEXT_DATA bactext_protocol_level_names[] = {
+    { BACNET_PROTOCOL_LEVEL_PHYSICAL, "physical" },
+    { BACNET_PROTOCOL_LEVEL_PROTOCOL, "protocol" },
+    { BACNET_PROTOCOL_LEVEL_BACNET_APPLICATION, "bacnet-application" },
+    { BACNET_PROTOCOL_LEVEL_NON_BACNET_APPLICATION, "non-bacnet-application" },
+    { 0, NULL }
+};
+
+const char *bactext_protocol_level_name(unsigned index)
+{
+    return indtext_by_index_default(
+        bactext_protocol_level_names, index, ASHRAE_Reserved_String);
+}
+
 INDTEXT_DATA bactext_network_port_command_names[] = {
     { PORT_COMMAND_IDLE, "idle" },
     { PORT_COMMAND_DISCARD_CHANGES, "discard-changes" },

--- a/src/bacnet/bactext.h
+++ b/src/bacnet/bactext.h
@@ -172,6 +172,8 @@ const char *bactext_network_port_type_name(unsigned index);
 BACNET_STACK_EXPORT
 const char *bactext_network_number_quality_name(unsigned index);
 BACNET_STACK_EXPORT
+const char *bactext_protocol_level_name(unsigned index);
+BACNET_STACK_EXPORT
 const char *bactext_network_port_command_name(unsigned index);
 
 BACNET_STACK_EXPORT


### PR DESCRIPTION
Added text sprintf for Network Port object BACnetNetworkType, BACnetNetworkNumberQuality, and BACnetProtocolLevel enumerations.