### PR TITLE
Errors related to stringent compiler rules. 12 improperly formatted snprintf datatypes.

### DIFF
--- a/src/bacnet/basic/object/bitstring_value.c
+++ b/src/bacnet/basic/object/bitstring_value.c
@@ -495,7 +495,7 @@ bool BitString_Value_Object_Name(
                 characterstring_init_ansi(object_name, pObject->Object_Name);
         } else {
             snprintf(
-                name_text, sizeof(name_text), "BITSTRING_VALUE-%u",
+                name_text, sizeof(name_text), "BITSTRING_VALUE-%lu",
                 object_instance);
             status = characterstring_init_ansi(object_name, name_text);
         }

--- a/src/bacnet/basic/object/blo.c
+++ b/src/bacnet/basic/object/blo.c
@@ -782,7 +782,7 @@ bool Binary_Lighting_Output_Object_Name(
                 characterstring_init_ansi(object_name, pObject->Object_Name);
         } else {
             snprintf(
-                name_text, sizeof(name_text), "BINARY-LIGHTING-OUTPUT-%u",
+                name_text, sizeof(name_text), "BINARY-LIGHTING-OUTPUT-%lu",
                 object_instance);
             status = characterstring_init_ansi(object_name, name_text);
         }

--- a/src/bacnet/basic/object/calendar.c
+++ b/src/bacnet/basic/object/calendar.c
@@ -384,7 +384,7 @@ bool Calendar_Object_Name(
                 characterstring_init_ansi(object_name, pObject->Object_Name);
         } else {
             snprintf(
-                name_text, sizeof(name_text), "CALENDAR-%u", object_instance);
+                name_text, sizeof(name_text), "CALENDAR-%lu", object_instance);
             status = characterstring_init_ansi(object_name, name_text);
         }
     }

--- a/src/bacnet/basic/object/color_object.c
+++ b/src/bacnet/basic/object/color_object.c
@@ -704,7 +704,7 @@ bool Color_Object_Name(
             status =
                 characterstring_init_ansi(object_name, pObject->Object_Name);
         } else {
-            snprintf(name_text, sizeof(name_text), "COLOR-%u", object_instance);
+            snprintf(name_text, sizeof(name_text), "COLOR-%lu", object_instance);
             status = characterstring_init_ansi(object_name, name_text);
         }
     }

--- a/src/bacnet/basic/object/color_temperature.c
+++ b/src/bacnet/basic/object/color_temperature.c
@@ -944,7 +944,7 @@ bool Color_Temperature_Object_Name(
                 characterstring_init_ansi(object_name, pObject->Object_Name);
         } else {
             snprintf(
-                name_text, sizeof(name_text), "COLOR-TEMPERATURE-%u",
+                name_text, sizeof(name_text), "COLOR-TEMPERATURE-%lu",
                 object_instance);
             status = characterstring_init_ansi(object_name, name_text);
         }

--- a/src/bacnet/basic/object/lc.c
+++ b/src/bacnet/basic/object/lc.c
@@ -244,7 +244,7 @@ bool Load_Control_Object_Name(
                 characterstring_init_ansi(object_name, pObject->Object_Name);
         } else {
             snprintf(
-                name_text, sizeof(name_text), "LOAD_CONTROL-%u",
+                name_text, sizeof(name_text), "LOAD_CONTROL-%lu",
                 object_instance);
             status = characterstring_init_ansi(object_name, name_text);
         }

--- a/src/bacnet/basic/object/lo.c
+++ b/src/bacnet/basic/object/lo.c
@@ -983,7 +983,7 @@ bool Lighting_Output_Object_Name(
                 characterstring_init_ansi(object_name, pObject->Object_Name);
         } else {
             snprintf(
-                name_text, sizeof(name_text), "LIGHTING-OUTPUT-%u",
+                name_text, sizeof(name_text), "LIGHTING-OUTPUT-%lu",
                 object_instance);
             status = characterstring_init_ansi(object_name, name_text);
         }

--- a/src/bacnet/basic/object/lsp.c
+++ b/src/bacnet/basic/object/lsp.c
@@ -198,7 +198,7 @@ bool Life_Safety_Point_Object_Name(
                 characterstring_init_ansi(object_name, pObject->Object_Name);
         } else {
             snprintf(
-                name_text, sizeof(name_text), "LIFE-SAFETY-POINT-%u",
+                name_text, sizeof(name_text), "LIFE-SAFETY-POINT-%lu",
                 object_instance);
             status = characterstring_init_ansi(object_name, name_text);
         }

--- a/src/bacnet/basic/object/lsz.c
+++ b/src/bacnet/basic/object/lsz.c
@@ -209,7 +209,7 @@ bool Life_Safety_Zone_Object_Name(
                 characterstring_init_ansi(object_name, pObject->Object_Name);
         } else {
             snprintf(
-                name_text, sizeof(name_text), "LIFE-SAFETY-ZONE-%u",
+                name_text, sizeof(name_text), "LIFE-SAFETY-ZONE-%lu",
                 object_instance);
             status = characterstring_init_ansi(object_name, name_text);
         }

--- a/src/bacnet/basic/object/structured_view.c
+++ b/src/bacnet/basic/object/structured_view.c
@@ -177,7 +177,7 @@ bool Structured_View_Object_Name(
                 characterstring_init_ansi(object_name, pObject->Object_Name);
         } else {
             snprintf(
-                name_text, sizeof(name_text), "Structured-View-%u",
+                name_text, sizeof(name_text), "Structured-View-%lu",
                 object_instance);
             status = characterstring_init_ansi(object_name, name_text);
         }

--- a/src/bacnet/basic/object/time_value.c
+++ b/src/bacnet/basic/object/time_value.c
@@ -367,7 +367,7 @@ bool Time_Value_Object_Name(
             status =
                 characterstring_init_ansi(object_name, pObject->Object_Name);
         } else {
-            snprintf(name_text, sizeof(name_text), "Time-%u", object_instance);
+            snprintf(name_text, sizeof(name_text), "Time-%lu", object_instance);
             status = characterstring_init_ansi(object_name, name_text);
         }
     }

--- a/src/bacnet/basic/service/h_getevent.c
+++ b/src/bacnet/basic/service/h_getevent.c
@@ -44,7 +44,7 @@ void ge_ack_print_data(
     printf("--------------- ------- --------------- ---------------\n");
     while (act_data) {
         printf(
-            "%u\t\t%u\t%u\t\t%s\n", device_id, act_data->objectIdentifier.type,
+            "%lu\t\t%u\t%lu\t\t%s\n", device_id, act_data->objectIdentifier.type,
             act_data->objectIdentifier.instance, state_strs[data->eventState]);
         act_data = act_data->next;
         count++;


### PR DESCRIPTION
"format '%u' expects argument of type 'unsigned int', but argument 4 has type 'uint32_t' {aka 'long unsigned int'} [-Werror=format=]",

Fixed rather than loosensing the compiler restrictions.