### PR TITLE
Fixed MS/TP state WAIT_FOR_REPLY to allow reception of any frames that are not known to be not reply frames.

### DIFF
--- a/ports/at91sam7s/dlmstp.c
+++ b/ports/at91sam7s/dlmstp.c
@@ -795,20 +795,25 @@ static bool MSTP_Master_Node_FSM(void)
                                 Master_State =
                                     MSTP_MASTER_STATE_DONE_WITH_TOKEN;
                                 break;
-                            case FRAME_TYPE_BACNET_DATA_NOT_EXPECTING_REPLY:
+                            case FRAME_TYPE_TOKEN:
+                            case FRAME_TYPE_POLL_FOR_MASTER:
+                            case FRAME_TYPE_REPLY_TO_POLL_FOR_MASTER:
+                            case FRAME_TYPE_TEST_REQUEST:
+                                /* ReceivedUnexpectedFrame */
+                                /* FrameType has a value other than a FrameType
+                                   known to this node that indicates a reply */
+                                Master_State =
+                                    MSTP_MASTER_STATE_IDLE;
+                                break;
+                            default:
                                 /* ReceivedReply */
-                                /* or a proprietary type that indicates
-                                   a reply */
-                                /* indicate successful reception to
-                                   the higher layers */
+                                /* FrameType known to this node that
+                                   indicates a reply */
+                                /* indicate successful reception
+                                   to the higher layers */
                                 MSTP_Flag.ReceivePacketPending = true;
                                 Master_State =
                                     MSTP_MASTER_STATE_DONE_WITH_TOKEN;
-                                break;
-                            default:
-                                /* if proprietary frame was expected, you might
-                                   need to transition to DONE WITH TOKEN */
-                                Master_State = MSTP_MASTER_STATE_IDLE;
                                 break;
                         }
                     } else {

--- a/ports/atmega328/dlmstp.c
+++ b/ports/atmega328/dlmstp.c
@@ -680,20 +680,24 @@ static bool MSTP_Master_Node_FSM(void)
                                 Master_State =
                                     MSTP_MASTER_STATE_DONE_WITH_TOKEN;
                                 break;
-                            case FRAME_TYPE_BACNET_DATA_NOT_EXPECTING_REPLY:
+                            case FRAME_TYPE_TOKEN:
+                            case FRAME_TYPE_POLL_FOR_MASTER:
+                            case FRAME_TYPE_REPLY_TO_POLL_FOR_MASTER:
+                            case FRAME_TYPE_TEST_REQUEST:
+                                /* ReceivedUnexpectedFrame */
+                                /* FrameType has a value other than a FrameType
+                                   known to this node that indicates a reply */
+                                Master_State = MSTP_MASTER_STATE_IDLE;
+                                break;
+                            default:
                                 /* ReceivedReply */
-                                /* or a proprietary type that indicates a reply
-                                 */
-                                /* indicate successful reception to the higher
-                                 * layers */
+                                /* FrameType known to this node that
+                                   indicates a reply */
+                                /* indicate successful reception
+                                   to the higher layers */
                                 MSTP_Flag.ReceivePacketPending = true;
                                 Master_State =
                                     MSTP_MASTER_STATE_DONE_WITH_TOKEN;
-                                break;
-                            default:
-                                /* if proprietary frame was expected, you might
-                                   need to transition to DONE WITH TOKEN */
-                                Master_State = MSTP_MASTER_STATE_IDLE;
                                 break;
                         }
                     } else {

--- a/ports/bdk-atxx4-mstp/dlmstp.c
+++ b/ports/bdk-atxx4-mstp/dlmstp.c
@@ -817,20 +817,25 @@ static bool MSTP_Master_Node_FSM(void)
                                 Master_State =
                                     MSTP_MASTER_STATE_DONE_WITH_TOKEN;
                                 break;
-                            case FRAME_TYPE_BACNET_DATA_NOT_EXPECTING_REPLY:
+                            case FRAME_TYPE_TOKEN:
+                            case FRAME_TYPE_POLL_FOR_MASTER:
+                            case FRAME_TYPE_REPLY_TO_POLL_FOR_MASTER:
+                            case FRAME_TYPE_TEST_REQUEST:
+                                /* ReceivedUnexpectedFrame */
+                                /* FrameType has a value other than a FrameType
+                                   known to this node that indicates a reply */
+                                Master_State =
+                                    MSTP_MASTER_STATE_IDLE;
+                                break;
+                            default:
                                 /* ReceivedReply */
-                                /* or a proprietary type that indicates
-                                   a reply */
-                                /* indicate successful reception to
-                                   the higher layers */
+                                /* FrameType known to this node that
+                                   indicates a reply */
+                                /* indicate successful reception
+                                   to the higher layers */
                                 MSTP_Flag.ReceivePacketPending = true;
                                 Master_State =
                                     MSTP_MASTER_STATE_DONE_WITH_TOKEN;
-                                break;
-                            default:
-                                /* if proprietary frame was expected, you might
-                                   need to transition to DONE WITH TOKEN */
-                                Master_State = MSTP_MASTER_STATE_IDLE;
                                 break;
                         }
                     } else {

--- a/ports/pic18f6720/mstp.c
+++ b/ports/pic18f6720/mstp.c
@@ -850,12 +850,22 @@ bool MSTP_Master_Node_FSM(volatile struct mstp_port_struct_t *mstp_port)
                                 mstp_port->master_state =
                                     MSTP_MASTER_STATE_IDLE;
                                 break;
-                            case FRAME_TYPE_BACNET_DATA_NOT_EXPECTING_REPLY:
+                            case FRAME_TYPE_TOKEN:
+                            case FRAME_TYPE_POLL_FOR_MASTER:
+                            case FRAME_TYPE_REPLY_TO_POLL_FOR_MASTER:
+                            case FRAME_TYPE_TEST_REQUEST:
+                                /* ReceivedUnexpectedFrame */
+                                /* FrameType has a value other than a FrameType
+                                   known to this node that indicates a reply */
+                                mstp_port->master_state =
+                                    MSTP_MASTER_STATE_IDLE;
+                                break;
+                            default:
                                 /* ReceivedReply */
-                                /* or a proprietary type that indicates a reply
-                                 */
-                                /* indicate successful reception to the higher
-                                 * layers */
+                                /* FrameType known to this node that
+                                   indicates a reply */
+                                /* indicate successful reception
+                                   to the higher layers */
                                 dlmstp_put_receive(
                                     mstp_port->SourceAddress, /* source MS/TP
                                                                  address */
@@ -863,12 +873,6 @@ bool MSTP_Master_Node_FSM(volatile struct mstp_port_struct_t *mstp_port)
                                     mstp_port->DataLength);
                                 mstp_port->master_state =
                                     MSTP_MASTER_STATE_DONE_WITH_TOKEN;
-                                break;
-                            default:
-                                /* if proprietary frame was expected, you might
-                                   need to transition to DONE WITH TOKEN */
-                                mstp_port->master_state =
-                                    MSTP_MASTER_STATE_IDLE;
                                 break;
                         }
                     } else {

--- a/ports/pic18f97j60/mstp.c
+++ b/ports/pic18f97j60/mstp.c
@@ -858,12 +858,22 @@ bool MSTP_Master_Node_FSM(volatile struct mstp_port_struct_t *mstp_port)
                                 mstp_port->master_state =
                                     MSTP_MASTER_STATE_IDLE;
                                 break;
-                            case FRAME_TYPE_BACNET_DATA_NOT_EXPECTING_REPLY:
+                            case FRAME_TYPE_TOKEN:
+                            case FRAME_TYPE_POLL_FOR_MASTER:
+                            case FRAME_TYPE_REPLY_TO_POLL_FOR_MASTER:
+                            case FRAME_TYPE_TEST_REQUEST:
+                                /* ReceivedUnexpectedFrame */
+                                /* FrameType has a value other than a FrameType
+                                   known to this node that indicates a reply */
+                                mstp_port->master_state =
+                                    MSTP_MASTER_STATE_IDLE;
+                                break;
+                            default:
                                 /* ReceivedReply */
-                                /* or a proprietary type that indicates a reply
-                                 */
-                                /* indicate successful reception to the higher
-                                 * layers */
+                                /* FrameType known to this node that
+                                   indicates a reply */
+                                /* indicate successful reception
+                                   to the higher layers */
                                 dlmstp_put_receive(
                                     mstp_port->SourceAddress, /* source MS/TP
                                                                  address */
@@ -871,12 +881,6 @@ bool MSTP_Master_Node_FSM(volatile struct mstp_port_struct_t *mstp_port)
                                     mstp_port->DataLength);
                                 mstp_port->master_state =
                                     MSTP_MASTER_STATE_DONE_WITH_TOKEN;
-                                break;
-                            default:
-                                /* if proprietary frame was expected, you might
-                                   need to transition to DONE WITH TOKEN */
-                                mstp_port->master_state =
-                                    MSTP_MASTER_STATE_IDLE;
                                 break;
                         }
                     } else {

--- a/src/bacnet/datalink/mstp.c
+++ b/src/bacnet/datalink/mstp.c
@@ -836,8 +836,6 @@ bool MSTP_Master_Node_FSM(struct mstp_port_struct_t *mstp_port)
                         mstp_port->master_state =
                             MSTP_MASTER_STATE_WAIT_FOR_REPLY;
                         break;
-                    case FRAME_TYPE_TEST_RESPONSE:
-                    case FRAME_TYPE_BACNET_DATA_NOT_EXPECTING_REPLY:
                     default:
                         /* SendNoWait */
                         mstp_port->master_state =
@@ -883,21 +881,25 @@ bool MSTP_Master_Node_FSM(struct mstp_port_struct_t *mstp_port)
                                 mstp_port->master_state =
                                     MSTP_MASTER_STATE_DONE_WITH_TOKEN;
                                 break;
-                            case FRAME_TYPE_BACNET_DATA_NOT_EXPECTING_REPLY:
+                            case FRAME_TYPE_TOKEN:
+                            case FRAME_TYPE_POLL_FOR_MASTER:
+                            case FRAME_TYPE_REPLY_TO_POLL_FOR_MASTER:
+                            case FRAME_TYPE_TEST_REQUEST:
+                                /* ReceivedUnexpectedFrame */
+                                /* FrameType has a value other than a FrameType
+                                   known to this node that indicates a reply */
+                                mstp_port->master_state =
+                                    MSTP_MASTER_STATE_IDLE;
+                                break;
+                            default:
                                 /* ReceivedReply */
-                                /* or a proprietary type that indicates a reply
-                                 */
-                                /* indicate successful reception to the higher
-                                 * layers */
+                                /* FrameType known to this node that
+                                   indicates a reply */
+                                /* indicate successful reception
+                                   to the higher layers */
                                 (void)MSTP_Put_Receive(mstp_port);
                                 mstp_port->master_state =
                                     MSTP_MASTER_STATE_DONE_WITH_TOKEN;
-                                break;
-                            default:
-                                /* if proprietary frame was expected, you might
-                                   need to transition to DONE WITH TOKEN */
-                                mstp_port->master_state =
-                                    MSTP_MASTER_STATE_IDLE;
                                 break;
                         }
                     } else {


### PR DESCRIPTION
This fixes segmented Complex-ACK frames which were dropped. This enables all proprietary frames and any new frames to be recieved to the higher layers.