### PR TITLE
Fixes for router-ipv6 multicast issues

### DIFF
--- a/ports/bsd/bip6.c
+++ b/ports/bsd/bip6.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * @brief Initializes BACnet/IP interface (Linux).
+ * @brief Initializes BACnet/IPv6 interface (BSD/MAC OS X)
  * @author Steve Karg <skarg@users.sourceforge.net>
  * @date 2016
  * @copyright SPDX-License-Identifier: GPL-2.0-or-later WITH GCC-exception-2.0
@@ -21,6 +21,16 @@
 #include "bacnet/basic/sys/debug.h"
 #endif
 #include "bacport.h"
+
+#if defined(__APPLE__) || defined(__darwin__) || defined(__FreeBSD__)
+/* OSX seems not to define these. */
+#ifndef s6_addr16
+#define s6_addr16 __u6_addr.__u6_addr16
+#endif
+#ifndef s6_addr32
+#define s6_addr32 __u6_addr.__u6_addr32
+#endif
+#endif
 
 /* enable debugging */
 static bool BIP6_Debug = false;
@@ -78,7 +88,7 @@ void bip6_debug_enable(void)
     BIP6_Debug = true;
 }
 
-/** @file linux/bip6.c  Initializes BACnet/IPv6 interface (Linux). */
+/** @file bsd/bip6.c  Initializes BACnet/IPv6 interface (BSD). */
 
 /* unix socket */
 static int BIP6_Socket = -1;
@@ -88,7 +98,7 @@ static BACNET_IP6_ADDRESS BIP6_Addr;
 static BACNET_IP6_ADDRESS BIP6_Broadcast_Addr;
 
 /**
- * Set the interface name. On Linux, ifname is the /dev/ name of the interface.
+ * Set the interface name. On BSD, ifname is the /dev/ name of the interface.
  *
  * @param ifname - C string for name or text address
  */
@@ -103,8 +113,9 @@ void bip6_set_interface(char *ifname)
         exit(1);
     }
     ifa_tmp = ifa;
-    debug_fprintf_bip6(stdout, "BIP6: seeking interface: %s\n", ifname);
-
+    if (BIP6_Debug) {
+        debug_fprintf_bip6(stdout, "BIP6: seeking interface: %s\n", ifname);
+    }
     while (ifa_tmp) {
         if ((ifa_tmp->ifa_addr) && (ifa_tmp->ifa_addr->sa_family == AF_INET6)) {
             debug_fprintf_bip6(
@@ -131,7 +142,7 @@ void bip6_set_interface(char *ifname)
     }
     if (!found) {
         debug_fprintf_bip6(
-            stderr, "BIP6: unable to set interface: %s\n", ifname);
+            stdout, "BIP6: unable to set interface: %s\n", ifname);
         exit(1);
     }
 }
@@ -458,10 +469,10 @@ void bip6_leave_group(void)
  * -# Binds the socket to the local IP address at the specified port for
  *    BACnet/IPv6 (by default, 0xBAC0 = 47808).
  *
- * @note For Linux, ifname is eth0, ath0, arc0, and others.
+ * @note For BSD, ifname is en0, e0, and others.
  *
  * @param ifname [in] The named interface to use for the network layer.
- *        If NULL, the "eth0" interface is assigned.
+ *        If NULL, the "en0" interface is assigned.
  * @return True if the socket is successfully opened for BACnet/IP,
  *         else False if the socket functions fail.
  */
@@ -474,7 +485,7 @@ bool bip6_init(char *ifname)
     if (ifname) {
         bip6_set_interface(ifname);
     } else {
-        bip6_set_interface("eth0");
+        bip6_set_interface("en0");
     }
     if (BIP6_Addr.port == 0) {
         bip6_set_port(0xBAC0U);
@@ -484,24 +495,12 @@ bool bip6_init(char *ifname)
         bvlc6_address_set(
             &BIP6_Broadcast_Addr, BIP6_MULTICAST_SITE_LOCAL, 0, 0, 0, 0, 0, 0,
             BIP6_MULTICAST_GROUP_ID);
-        BIP6_Broadcast_Addr.port = BIP6_Addr.port;
     }
     /* assumes that the driver has already been initialized */
     BIP6_Socket = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
     if (BIP6_Socket < 0) {
         return false;
     }
-
-    if (BIP6_Socket_Scope_Id > 0) {
-        unsigned int idx = BIP6_Socket_Scope_Id;
-        /* Explicitly set the interface for OUTGOING multicast packets */
-        status = setsockopt(
-            BIP6_Socket, IPPROTO_IPV6, IPV6_MULTICAST_IF, &idx, sizeof(idx));
-        if (status < 0) {
-            debug_perror("BIP6: setsockopt(IPV6_MULTICAST_IF)");
-        }
-    }
-
     /* Allow us to use the same socket for sending and receiving */
     /* This makes sure that the src port is correct when sending */
     sockopt = 1;
@@ -523,21 +522,7 @@ bool bip6_init(char *ifname)
     bip6_join_group();
     /* bind the socket to the local port number and IP address */
     server.sin6_family = AF_INET6;
-#if 0
-    uint16_t addr16[8];
-    bvlc6_address_get(&BIP6_Addr, &addr16[0], &addr16[1], &addr16[2],
-        &addr16[3], &addr16[4], &addr16[5], &addr16[6], &addr16[7]);
-    server.sin6_addr.s6_addr16[0] = htons(addr16[0]);
-    server.sin6_addr.s6_addr16[1] = htons(addr16[1]);
-    server.sin6_addr.s6_addr16[2] = htons(addr16[2]);
-    server.sin6_addr.s6_addr16[3] = htons(addr16[3]);
-    server.sin6_addr.s6_addr16[4] = htons(addr16[4]);
-    server.sin6_addr.s6_addr16[5] = htons(addr16[5]);
-    server.sin6_addr.s6_addr16[6] = htons(addr16[6]);
-    server.sin6_addr.s6_addr16[7] = htons(addr16[7]);
-#else
     server.sin6_addr = in6addr_any;
-#endif
     server.sin6_port = htons(BIP6_Addr.port);
     debug_print_ipv6("Binding->", &server.sin6_addr);
     status = bind(BIP6_Socket, (const void *)&server, sizeof(server));


### PR DESCRIPTION
[Hi, Thanks for all your work on this project.]

When using the router-ipv6 application there seem to be a couple of issues which prevent broadcasts from the router functioning correctly on ipv6 in my setup:

1. When `BACNET_BIP6_PORT` is specified (even if specified as default 47808) the ipv6 multicast packets are sent with a seemingly random destination port e.g. 1088 and thus do not reach devices listening on BAC0. (Without specifying `BACNET_BIP6_PORT` the destination port is default 47808 as expected)
2. With more than one interface on the device the ipv6 multicast packets (e.g. to `ff05::bac0`) can be sent to another interface rather than the interface specified in `BACNET_BIP6_IFACE`

The changes in this PR seems to fix both these issues for me. I have tested on linux only, `bip6.c` for other ports may well show the same issues.

(AI was used to debug the issue and write the code.)