### PR TITLE
increase size of `MAX_HEADER` in `BACDL_MULTIPLE`

### DIFF
--- a/src/bacnet/datalink/datalink.h
+++ b/src/bacnet/datalink/datalink.h
@@ -132,7 +132,7 @@ void routed_get_my_address(BACNET_ADDRESS *my_address);
 #elif !defined(BACDL_TEST) /* Multiple, none or custom datalink */
 #include "bacnet/npdu.h"
 
-#define MAX_HEADER (8)
+#define MAX_HEADER (17) /* ETHERNET_HEADER_MAX */
 #define MAX_MPDU (MAX_HEADER + MAX_PDU)
 
 #ifdef __cplusplus


### PR DESCRIPTION
increase size of `MAX_HEADER` in `BACDL_MULTIPLE` because 8 is not big enough for some datalinks (e.g. mstp)