### PR TITLE
Increase unit test coverage for device object

### DIFF
--- a/test/bacnet/basic/object/device/src/main.c
+++ b/test/bacnet/basic/object/device/src/main.c
@@ -126,7 +126,15 @@ static void testDevice(void)
     bool status = false;
     const char *name = "Patricia";
     BACNET_REINITIALIZE_DEVICE_DATA rd_data;
+    unsigned i, count, writable;
+    BACNET_OBJECT_TYPE object_type;
+    uint32_t object_instance;
+    const int32_t *properties;
+    struct special_property_list_t property_list;
 
+    Device_Init(NULL);
+    count = Device_Count();
+    zassert_true(count > 0, NULL);
     status = Device_Set_Object_Instance_Number(0);
     zassert_equal(Device_Object_Instance_Number(), 0, NULL);
     zassert_true(status, NULL);
@@ -214,6 +222,27 @@ static void testDevice(void)
     zassert_equal(
         rd_data.error_code, ERROR_CODE_PARAMETER_OUT_OF_RANGE, "error-code=%s",
         bactext_error_code_name(rd_data.error_code));
+
+    count = Device_Object_List_Count();
+    for (i = 1; i <= count; i++) {
+        bool valid = false;
+
+        valid =
+            Device_Object_List_Identifier(i, &object_type, &object_instance);
+        zassert_true(valid, "object-list[%u] is not valid", i);
+        valid = Device_Valid_Object_Id(object_type, object_instance);
+        zassert_true(valid, NULL);
+        Device_Objects_Writable_Property_List(
+            object_type, object_instance, &properties);
+        zassert_not_null(properties, NULL);
+        writable = property_list_count(properties);
+        zassert_true(
+            writable > 0, "%s-%u has no writable properties",
+            bactext_object_type_name(object_type), object_instance);
+        Device_Objects_Property_List(
+            object_type, object_instance, &property_list);
+        zassert_true(property_list.Required.count > 0, NULL);
+    }
 
     return;
 }

--- a/test/bacnet/basic/server/bacnet_device/src/main.c
+++ b/test/bacnet/basic/server/bacnet_device/src/main.c
@@ -15,6 +15,14 @@
  * @{
  */
 
+static BACNET_WRITE_PROPERTY_DATA Test_Write_Property_Store_Data;
+bool Test_Write_Property_Return_Value;
+static bool Test_Write_Property_Store(BACNET_WRITE_PROPERTY_DATA *wp_data)
+{
+    Test_Write_Property_Store_Data = *wp_data;
+    return Test_Write_Property_Return_Value;
+}
+
 /**
  * @brief Test ReadProperty API
  */
@@ -27,6 +35,7 @@ static void test_Device_Data_Sharing(void)
     const int32_t skip_fail_property_list[] = { -1 };
 
     Device_Init(NULL);
+    Device_Write_Property_Store_Callback_Set(Test_Write_Property_Store);
     status = Device_Set_Object_Instance_Number(instance);
     zassert_true(status, NULL);
     test_instance = Device_Object_Instance_Number();
@@ -69,6 +78,9 @@ static void testDevice(void)
     const char *name_string = NULL;
     unsigned count = 0, test_count = 0;
     int len = 0, time_diff = 0;
+    unsigned i, writable;
+    const int32_t *properties;
+    struct special_property_list_t property_list;
 
     Device_Init(NULL);
     status = Device_Set_Object_Instance_Number(0);
@@ -331,6 +343,12 @@ static void testDevice(void)
     zassert_equal(time_diff, -60, NULL);
     status = Device_Daylight_Savings_Status();
     zassert_false(status, NULL);
+    name_string = Device_Application_Software_Version();
+    zassert_not_null(name_string, NULL);
+    zassert_true(strlen(name_string) > 0, NULL);
+    status = Device_Set_Application_Software_Version(
+        name_string, strlen(name_string));
+    zassert_true(status, NULL);
 
     /* Add/Remove List Elements */
     list_data.object_type = OBJECT_DEVICE;
@@ -424,6 +442,27 @@ static void testDevice(void)
     zassert_false(status, NULL);
     /* object timers */
     Device_Timer(1000);
+    /* property lists */
+    count = Device_Object_List_Count();
+    for (i = 1; i <= count; i++) {
+        bool valid = false;
+
+        valid =
+            Device_Object_List_Identifier(i, &object_type, &object_instance);
+        zassert_true(valid, "object-list[%u] is not valid", i);
+        valid = Device_Valid_Object_Id(object_type, object_instance);
+        zassert_true(valid, NULL);
+        Device_Objects_Writable_Property_List(
+            object_type, object_instance, &properties);
+        zassert_not_null(properties, NULL);
+        writable = property_list_count(properties);
+        zassert_true(
+            writable > 0, "%s-%u has no writable properties",
+            bactext_object_type_name(object_type), object_instance);
+        Device_Objects_Property_List(
+            object_type, object_instance, &property_list);
+        zassert_true(property_list.Required.count > 0, NULL);
+    }
 }
 /**
  * @}


### PR DESCRIPTION
Enhance unit tests for the device object to improve coverage and validate writable properties and their lists. This ensures better reliability and correctness of the device functionalities.