### PR TITLE
Fixed off-by-one bug in gateway main() causing duplicate I-Am broadcast

### DIFF
--- a/apps/gateway/main.c
+++ b/apps/gateway/main.c
@@ -61,7 +61,7 @@ int DNET_list[2] = {
 static const char *BACnet_Version = BACNET_VERSION_TEXT;
 
 /* routed devices - I-Am on startup */
-static unsigned Routed_Device_Index;
+static unsigned Routed_Device_Index = 1;
 
 /** Initialize the Device Objects and each of the child Object instances.
  * @param first_object_instance Set the first (gateway) Device to this
@@ -278,10 +278,10 @@ int main(int argc, char *argv[])
         }
         handler_cov_task();
         if (Routed_Device_Index < MAX_NUM_DEVICES) {
-            Routed_Device_Index++;
             Get_Routed_Device_Object(Routed_Device_Index);
             /* broadcast an I-Am for each routed Device now */
             Send_I_Am(&Handler_Transmit_Buffer[0]);
+            Routed_Device_Index++;
         }
     }
     /* Dummy return */


### PR DESCRIPTION
# Description
When Routed_Device_Index reached MAX_NUM_DEVICES, Get_Routed_Device_Object() returned NULL without updating iCurrent_Device_Idx, causing Send_I_Am() to broadcast the previous device's I-Am again.

* Initialize Routed_Device_Index to 1 (first routed device index)
* Move increment after Send_I_Am() to prevent out-of-bounds access

# Related Issue
close #1286 