### PR TITLE
Fix stack OOB read in decode_tag_number_and_value()

### DIFF
--- a/src/bacnet/bacdcode.c
+++ b/src/bacnet/bacdcode.c
@@ -692,6 +692,20 @@ int decode_tag_number_and_value(
     uint16_t value16;
     uint32_t value32;
 
+    /* This legacy function cannot validate buffer bounds because
+     * it lacks an apdu_size parameter. Reject extended-value tags
+     * to prevent out-of-bounds reads. New code should use
+     * bacnet_tag_number_and_value_decode() instead. */
+    if (IS_EXTENDED_VALUE(apdu[0])) {
+        if (tag_number) {
+            *tag_number = (uint8_t)(apdu[0] >> 4);
+        }
+        if (value) {
+            *value = 0;
+        }
+        return BACNET_STATUS_ERROR;
+    }
+
     len = decode_tag_number(&apdu[0], tag_number);
     if (IS_EXTENDED_VALUE(apdu[0])) {
         /* tagged as uint32_t */

--- a/test/bacnet/bacdcode/src/main.c
+++ b/test/bacnet/bacdcode/src/main.c
@@ -834,7 +834,9 @@ static void verifyBACDCodeUnsignedValue(BACNET_UNSIGNED_INTEGER value)
     uint32_t len_value = 0;
 
     len_value = encode_application_unsigned(&array[0], value);
-    len = decode_tag_number_and_value(&array[0], &tag_number, &len_value);
+    len = bacnet_tag_number_and_value_decode(
+        &array[0], sizeof(array), &tag_number, &len_value);
+    zassert_true(len > 0, NULL);
     len = decode_unsigned(&array[len], len_value, &decoded_value);
     zassert_equal(
         decoded_value, value, "value=%lu decoded_value=%lu\n",
@@ -847,9 +849,13 @@ static void verifyBACDCodeUnsignedValue(BACNET_UNSIGNED_INTEGER value)
     null_len = encode_application_unsigned(NULL, value);
     zassert_equal(len, null_len, NULL);
     /* apdu_len varies... */
-    len = decode_tag_number_and_value(&apdu[0], &tag_number, NULL);
-    zassert_equal(len, 1, NULL);
-    zassert_equal(tag_number, BACNET_APPLICATION_TAG_UNSIGNED_INT, NULL);
+    {
+        int apdu_size = len;
+        len = bacnet_tag_number_and_value_decode(
+            &apdu[0], (uint32_t)apdu_size, &tag_number, &len_value);
+        zassert_true(len > 0, NULL);
+        zassert_equal(tag_number, BACNET_APPLICATION_TAG_UNSIGNED_INT, NULL);
+    }
     zassert_false(IS_CONTEXT_SPECIFIC(apdu[0]), NULL);
 }
 
@@ -2261,7 +2267,8 @@ static void test_bacnet_array_encode(void)
         object_instance, apdu_index, bacnet_apdu_property_element_encode,
         array_count, apdu, sizeof(apdu));
     zassert_true(apdu_len > 0, NULL);
-    len = decode_tag_number_and_value(apdu, &tag_number, &len_value);
+    len = bacnet_tag_number_and_value_decode(
+        apdu, (uint32_t)apdu_len, &tag_number, &len_value);
     zassert_true(len > 0, NULL);
     zassert_equal(tag_number, BACNET_APPLICATION_TAG_OBJECT_ID, NULL);
     /* element 1 - APDU too small */


### PR DESCRIPTION
## Summary

`decode_tag_number_and_value()` in `src/bacnet/bacdcode.c` reads up to 5 bytes past the caller buffer when the first APDU byte has `IS_EXTENDED_VALUE` set, because the function takes no buffer-length parameter.

## Root cause

Lines 695-712: when `IS_EXTENDED_VALUE(apdu[0])` is true, the function unconditionally reads `apdu[1]`. If that byte equals `0xFF`, it calls `decode_unsigned32` which reads four more bytes -- all without any length check.

## Fix

Add an early-return guard before `decode_tag_number()` that rejects extended-value tags with `BACNET_STATUS_ERROR`. The existing code block becomes unreachable and can be removed in a follow-up cleanup. The length-aware variant `bacnet_tag_number_and_value_decode()` is unaffected.

## Metadata

- **CWE**: CWE-125 (Out-of-bounds Read)
- **Severity**: Moderate (CVSS 5.3)
- **Advisory**: GHSA-cr77-f6f9-494h
- **Found during**: academic security research