### PR TITLE
Feature/lighting output and command loose coupling

### DIFF
--- a/src/bacnet/basic/object/lo.c
+++ b/src/bacnet/basic/object/lo.c
@@ -508,29 +508,6 @@ unsigned Lighting_Output_Present_Value_Priority(uint32_t object_instance)
 }
 
 /**
- * @brief Determine if fade, ramp, or warn command is currently executing
- * @param pObject [in] object to apply the trim values to
- * @param priority [in] priority of the command
- */
-static bool Lighting_Command_In_Progress(struct object_data *pObject)
-{
-    bool in_progress = false;
-
-    if (!pObject) {
-        return in_progress;
-    }
-    if ((pObject->Lighting_Command.In_Progress ==
-         BACNET_LIGHTING_FADE_ACTIVE) ||
-        (pObject->Lighting_Command.In_Progress ==
-         BACNET_LIGHTING_RAMP_ACTIVE) ||
-        (pObject->Lighting_Command.Blink.Duration > 0)) {
-        in_progress = true;
-    }
-
-    return in_progress;
-}
-
-/**
  * @brief Configure the lighting command to apply low or high trim
  * to the tracking value based on the priority of the command
  * @param pObject [in] object to apply the trim values to
@@ -547,14 +524,12 @@ Lighting_Command_Trim_Apply(struct object_data *pObject, unsigned priority)
         the Tracking_Value shall not be clamped. */
     if ((priority == 1) || (priority == 2)) {
         /* remove any high or low trim */
-        pObject->Lighting_Command.High_Trim_Value = 100.0f;
-        pObject->Lighting_Command.Low_Trim_Value = 1.0f;
-        pObject->Lighting_Command.Trim_Fade_Time = 0;
+        lighting_command_trim_set(&pObject->Lighting_Command, 100.0f, 1.0f, 0);
     } else {
         /* apply high and low trim */
-        pObject->Lighting_Command.High_Trim_Value = pObject->High_End_Trim;
-        pObject->Lighting_Command.Low_Trim_Value = pObject->Low_End_Trim;
-        pObject->Lighting_Command.Trim_Fade_Time = pObject->Trim_Fade_Time;
+        lighting_command_trim_set(
+            &pObject->Lighting_Command, pObject->High_End_Trim,
+            pObject->Low_End_Trim, pObject->Trim_Fade_Time);
     }
 }
 
@@ -653,6 +628,7 @@ static void
 Lighting_Command_Warn(struct object_data *pObject, unsigned priority)
 {
     unsigned current_priority;
+    BACNET_LIGHTING_COMMAND_WARN_DATA blink = { 0 };
 
     if (!pObject) {
         return;
@@ -669,9 +645,9 @@ Lighting_Command_Warn(struct object_data *pObject, unsigned priority)
                 active priority, or
             (b) The value at the specified priority is 0.0%, or
             (c) Blink_Warn_Enable is FALSE. */
+        lighting_command_blink_copy(&pObject->Lighting_Command, &blink);
         lighting_command_blink_warn(
-            &pObject->Lighting_Command, BACNET_LIGHTS_WARN,
-            &pObject->Lighting_Command.Blink);
+            &pObject->Lighting_Command, BACNET_LIGHTS_WARN, &blink);
     }
 }
 
@@ -720,7 +696,7 @@ static void
 Lighting_Command_Warn_Off(struct object_data *pObject, unsigned priority)
 {
     unsigned current_priority;
-    BACNET_LIGHTING_COMMAND_WARN_DATA blink;
+    BACNET_LIGHTING_COMMAND_WARN_DATA blink = { 0 };
 
     if (!pObject) {
         return;
@@ -740,9 +716,7 @@ Lighting_Command_Warn_Off(struct object_data *pObject, unsigned priority)
                     active priority, or
                 (b) The Present_Value is 0.0%, or
                 (c) Blink_Warn_Enable is FALSE. */
-            memmove(
-                &blink, &pObject->Lighting_Command.Blink,
-                sizeof(BACNET_LIGHTING_COMMAND_WARN_DATA));
+            lighting_command_blink_copy(&pObject->Lighting_Command, &blink);
             blink.Duration = pObject->Egress_Time_Seconds * 1000UL;
             blink.Priority = priority;
             blink.Callback = Lighting_Command_Blink_Stop;
@@ -813,9 +787,7 @@ Lighting_Command_Warn_Relinquish(struct object_data *pObject, unsigned priority)
                 (b) The Present_Value is 0.0%, or
                 (c) The Present_Value would not evaluate to 0.0% after
                     the priority slot is relinquished. */
-            memmove(
-                &blink, &pObject->Lighting_Command.Blink,
-                sizeof(BACNET_LIGHTING_COMMAND_WARN_DATA));
+            lighting_command_blink_copy(&pObject->Lighting_Command, &blink);
             blink.Duration = pObject->Egress_Time_Seconds * 1000UL;
             blink.Priority = priority;
             blink.Callback = Lighting_Command_Blink_Stop;
@@ -860,7 +832,7 @@ static void Lighting_Command_Step_Up_On(
     if (!pObject) {
         return;
     }
-    value = pObject->Lighting_Command.Tracking_Value;
+    value = lighting_command_tracking_value_get(&pObject->Lighting_Command);
     if (operation == BACNET_LIGHTS_STEP_UP) {
         if (is_float_equal(value, 0.0)) {
             /* If the starting level of Tracking_Value is 0.0%,
@@ -914,7 +886,7 @@ static void Lighting_Command_Step_Down_Off(
     if (!pObject) {
         return;
     }
-    value = pObject->Lighting_Command.Tracking_Value;
+    value = lighting_command_tracking_value_get(&pObject->Lighting_Command);
     if (is_float_equal(value, 0.0)) {
         /* If the starting level of Tracking_Value is 0.0%,
         then this operation is ignored. */
@@ -959,7 +931,7 @@ Lighting_Command_Restore_On(struct object_data *pObject, unsigned priority)
     if (!pObject) {
         return;
     }
-    value = pObject->Lighting_Command.Last_On_Value;
+    value = lighting_command_last_on_value_get(&pObject->Lighting_Command);
     Lighting_Command_Transition_Default(pObject, priority, value);
 }
 
@@ -978,7 +950,7 @@ Lighting_Command_Default_On(struct object_data *pObject, unsigned priority)
     if (!pObject) {
         return;
     }
-    value = pObject->Lighting_Command.Default_On_Value;
+    value = lighting_command_default_on_value_get(&pObject->Lighting_Command);
     Lighting_Command_Transition_Default(pObject, priority, value);
 }
 
@@ -1001,7 +973,8 @@ Lighting_Command_Toggle_Restore(struct object_data *pObject, unsigned priority)
         /* Prior to the execution of this command, if Present_Value is 0.0%,
            write the Last_On_Value to the specified slot in the priority
            array. */
-        toggle_value = pObject->Lighting_Command.Last_On_Value;
+        toggle_value =
+            lighting_command_last_on_value_get(&pObject->Lighting_Command);
     } else {
         /* Prior to the execution of this command, if Present_Value is not 0.0%,
            write 0.0% to the specified slot in the priority array. */
@@ -1029,7 +1002,8 @@ Lighting_Command_Toggle_Default(struct object_data *pObject, unsigned priority)
         /* Prior to the execution of this command, if Present_Value is 0.0%,
            write the Default_On_Value to the specified slot in the priority
            array. */
-        toggle_value = pObject->Lighting_Command.Default_On_Value;
+        toggle_value =
+            lighting_command_default_on_value_get(&pObject->Lighting_Command);
     } else {
         /* Prior to the execution of this command, if Present_Value is not 0.0%,
            write 0.0% to the specified slot in the priority array. */
@@ -1467,10 +1441,11 @@ Lighting_Command_Stop(struct object_data *pObject, unsigned priority)
     }
     current_priority = Present_Value_Priority(pObject);
     if (priority == current_priority) {
-        if (Lighting_Command_In_Progress(pObject)) {
+        if (lighting_command_active(&pObject->Lighting_Command)) {
             /* fade, ramp, or warn command is currently
                executing at the specified priority */
-            value = pObject->Lighting_Command.Tracking_Value;
+            value =
+                lighting_command_tracking_value_get(&pObject->Lighting_Command);
             Present_Value_Set(pObject, value, priority);
             /* configure the Lighting Command */
             lighting_command_stop(&pObject->Lighting_Command);
@@ -1762,7 +1737,7 @@ Lighting_Output_In_Progress(uint32_t object_instance)
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
-        value = pObject->Lighting_Command.In_Progress;
+        value = lighting_command_in_progress_get(&pObject->Lighting_Command);
     }
 
     return value;
@@ -1785,7 +1760,8 @@ bool Lighting_Output_In_Progress_Set(
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
-        pObject->Lighting_Command.In_Progress = in_progress;
+        lighting_command_in_progress_set(
+            &pObject->Lighting_Command, in_progress);
     }
 
     return status;
@@ -1805,7 +1781,7 @@ float Lighting_Output_Tracking_Value(uint32_t object_instance)
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
-        value = pObject->Lighting_Command.Tracking_Value;
+        value = lighting_command_tracking_value_get(&pObject->Lighting_Command);
     }
 
     return value;
@@ -1827,7 +1803,7 @@ bool Lighting_Output_Tracking_Value_Set(uint32_t object_instance, float value)
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
-        pObject->Lighting_Command.Tracking_Value = value;
+        lighting_command_tracking_value_set(&pObject->Lighting_Command, value);
         status = true;
     }
 
@@ -1916,9 +1892,8 @@ bool Lighting_Output_Blink_Warn_Feature_Set(
         } else if (isgreater(off_value, 100.0)) {
             off_value = 100.0f;
         }
-        pObject->Lighting_Command.Blink.Off_Value = off_value;
-        pObject->Lighting_Command.Blink.Interval = interval;
-        pObject->Lighting_Command.Blink.Count = count;
+        lighting_command_blink_warn_feature_set(
+            &pObject->Lighting_Command, off_value, interval, count);
         status = true;
     }
 
@@ -2023,9 +1998,8 @@ bool Lighting_Output_Egress_Active(uint32_t object_instance)
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
-        if (pObject->Lighting_Command.Blink.Duration > 0) {
-            value = true;
-        }
+        value =
+            lighting_command_blink_egress_active(&pObject->Lighting_Command);
     }
 
     return value;
@@ -2357,7 +2331,7 @@ bool Lighting_Output_Out_Of_Service(uint32_t object_instance)
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
-        value = pObject->Lighting_Command.Out_Of_Service;
+        value = lighting_command_out_of_service_get(&pObject->Lighting_Command);
     }
 
     return value;
@@ -2377,7 +2351,7 @@ void Lighting_Output_Out_Of_Service_Set(uint32_t object_instance, bool value)
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
-        pObject->Lighting_Command.Out_Of_Service = value;
+        lighting_command_out_of_service_set(&pObject->Lighting_Command, value);
     }
 }
 
@@ -2477,7 +2451,7 @@ float Lighting_Output_Last_On_Value(uint32_t object_instance)
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
-        value = pObject->Lighting_Command.Last_On_Value;
+        value = lighting_command_last_on_value_get(&pObject->Lighting_Command);
     }
 
     return value;
@@ -2498,7 +2472,8 @@ bool Lighting_Output_Last_On_Value_Set(uint32_t object_instance, float value)
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if (isgreaterequal(value, 1.0) && islessequal(value, 100.0)) {
-            pObject->Lighting_Command.Last_On_Value = value;
+            lighting_command_last_on_value_set(
+                &pObject->Lighting_Command, value);
             status = true;
         }
     }
@@ -2547,7 +2522,8 @@ float Lighting_Output_Default_On_Value(uint32_t object_instance)
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
-        value = pObject->Lighting_Command.Default_On_Value;
+        value =
+            lighting_command_default_on_value_get(&pObject->Lighting_Command);
     }
 
     return value;
@@ -2568,7 +2544,8 @@ bool Lighting_Output_Default_On_Value_Set(uint32_t object_instance, float value)
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if (isgreaterequal(value, 1.0) && islessequal(value, 100.0)) {
-            pObject->Lighting_Command.Default_On_Value = value;
+            lighting_command_default_on_value_set(
+                &pObject->Lighting_Command, value);
             status = true;
         }
     }
@@ -2643,7 +2620,7 @@ bool Lighting_Output_High_End_Trim_Set(uint32_t object_instance, float value)
             pObject->High_End_Trim = value;
             Lighting_Command_Trim_Apply(
                 pObject, Present_Value_Priority(pObject));
-            if (!Lighting_Command_In_Progress(pObject)) {
+            if (!lighting_command_active(&pObject->Lighting_Command)) {
                 lighting_command_refresh(&pObject->Lighting_Command);
             }
             status = true;
@@ -2720,7 +2697,7 @@ bool Lighting_Output_Low_End_Trim_Set(uint32_t object_instance, float value)
             pObject->Low_End_Trim = value;
             Lighting_Command_Trim_Apply(
                 pObject, Present_Value_Priority(pObject));
-            if (!Lighting_Command_In_Progress(pObject)) {
+            if (!lighting_command_active(&pObject->Lighting_Command)) {
                 lighting_command_refresh(&pObject->Lighting_Command);
             }
             status = true;
@@ -2798,7 +2775,7 @@ bool Lighting_Output_Trim_Fade_Time_Set(
             pObject->Trim_Fade_Time = value;
             Lighting_Command_Trim_Apply(
                 pObject, Present_Value_Priority(pObject));
-            if (!Lighting_Command_In_Progress(pObject)) {
+            if (!lighting_command_active(&pObject->Lighting_Command)) {
                 lighting_command_refresh(&pObject->Lighting_Command);
             }
             status = true;
@@ -2927,8 +2904,7 @@ bool Lighting_Output_Overridden_Status(uint32_t object_instance)
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
-        status = pObject->Lighting_Command.Overridden ||
-            pObject->Lighting_Command.Overridden_Momentary;
+        status = lighting_command_overridden_status(&pObject->Lighting_Command);
     }
 
     return status;
@@ -3876,9 +3852,10 @@ uint32_t Lighting_Output_Create(uint32_t object_instance)
         pObject->Description = NULL;
         pObject->Present_Value = 0.0f;
         lighting_command_init(&pObject->Lighting_Command);
-        pObject->Lighting_Command.Key = object_instance;
-        pObject->Lighting_Command.Notification_Head.callback =
-            Lighting_Output_Tracking_Value_Callback;
+        lighting_command_key_set(&pObject->Lighting_Command, object_instance);
+        lighting_command_tracking_value_callback_set(
+            &pObject->Lighting_Command,
+            Lighting_Output_Tracking_Value_Callback);
         pObject->Last_Lighting_Command.operation = BACNET_LIGHTS_NONE;
         pObject->Last_Lighting_Command.use_target_level = false;
         pObject->Last_Lighting_Command.use_ramp_rate = false;
@@ -3887,9 +3864,10 @@ uint32_t Lighting_Output_Create(uint32_t object_instance)
         pObject->Last_Lighting_Command.use_priority = false;
         pObject->Blink_Warn_Enable = false;
         pObject->High_End_Trim = 100.0f;
-        pObject->Lighting_Command.High_Trim_Value = pObject->High_End_Trim;
         pObject->Low_End_Trim = 1.0f;
-        pObject->Lighting_Command.Low_Trim_Value = pObject->Low_End_Trim;
+        lighting_command_trim_set(
+            &pObject->Lighting_Command, pObject->High_End_Trim,
+            pObject->Low_End_Trim, pObject->Trim_Fade_Time);
         pObject->Trim_Fade_Time = 0;
         pObject->Egress_Time_Seconds = 0;
         pObject->Default_Fade_Time = 100;

--- a/src/bacnet/basic/object/lo.c
+++ b/src/bacnet/basic/object/lo.c
@@ -3836,7 +3836,7 @@ Lighting_Output_Lighting_Command_Data(uint32_t object_instance)
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
-        data = pObject->Lighting_Command;
+        data = &pObject->Lighting_Command;
     }
 
     return data;

--- a/src/bacnet/basic/object/lo.c
+++ b/src/bacnet/basic/object/lo.c
@@ -33,7 +33,7 @@
 
 struct object_data {
     float Present_Value;
-    BACNET_LIGHTING_COMMAND_DATA Lighting_Command;
+    BACNET_LIGHTING_COMMAND_DATA *Lighting_Command;
     BACNET_LIGHTING_COMMAND Last_Lighting_Command;
     uint32_t Egress_Time_Seconds;
     uint32_t Default_Fade_Time;
@@ -516,14 +516,14 @@ static bool Lighting_Command_In_Progress(struct object_data *pObject)
 {
     bool in_progress = false;
 
-    if (!pObject) {
+    if (!pObject || !pObject->Lighting_Command) {
         return in_progress;
     }
-    if ((pObject->Lighting_Command.In_Progress ==
+    if ((pObject->Lighting_Command->In_Progress ==
          BACNET_LIGHTING_FADE_ACTIVE) ||
-        (pObject->Lighting_Command.In_Progress ==
+        (pObject->Lighting_Command->In_Progress ==
          BACNET_LIGHTING_RAMP_ACTIVE) ||
-        (pObject->Lighting_Command.Blink.Duration > 0)) {
+        (pObject->Lighting_Command->Blink.Duration > 0)) {
         in_progress = true;
     }
 
@@ -539,7 +539,7 @@ static bool Lighting_Command_In_Progress(struct object_data *pObject)
 static void
 Lighting_Command_Trim_Apply(struct object_data *pObject, unsigned priority)
 {
-    if (!pObject) {
+    if (!pObject || !pObject->Lighting_Command) {
         return;
     }
     /* If Present_Value is commanded at priority 1 or 2,
@@ -547,14 +547,14 @@ Lighting_Command_Trim_Apply(struct object_data *pObject, unsigned priority)
         the Tracking_Value shall not be clamped. */
     if ((priority == 1) || (priority == 2)) {
         /* remove any high or low trim */
-        pObject->Lighting_Command.High_Trim_Value = 100.0f;
-        pObject->Lighting_Command.Low_Trim_Value = 1.0f;
-        pObject->Lighting_Command.Trim_Fade_Time = 0;
+        pObject->Lighting_Command->High_Trim_Value = 100.0f;
+        pObject->Lighting_Command->Low_Trim_Value = 1.0f;
+        pObject->Lighting_Command->Trim_Fade_Time = 0;
     } else {
         /* apply high and low trim */
-        pObject->Lighting_Command.High_Trim_Value = pObject->High_End_Trim;
-        pObject->Lighting_Command.Low_Trim_Value = pObject->Low_End_Trim;
-        pObject->Lighting_Command.Trim_Fade_Time = pObject->Trim_Fade_Time;
+        pObject->Lighting_Command->High_Trim_Value = pObject->High_End_Trim;
+        pObject->Lighting_Command->Low_Trim_Value = pObject->Low_End_Trim;
+        pObject->Lighting_Command->Trim_Fade_Time = pObject->Trim_Fade_Time;
     }
 }
 
@@ -580,9 +580,12 @@ static void Lighting_Command_Fade_To(
     current_priority = Present_Value_Priority(pObject);
     if (priority <= current_priority) {
         /* we have priority */
+        if (!pObject->Lighting_Command) {
+            return;
+        }
         Lighting_Command_Trim_Apply(pObject, priority);
         /* configure the Lighting Command */
-        lighting_command_fade_to(&pObject->Lighting_Command, value, fade_time);
+        lighting_command_fade_to(pObject->Lighting_Command, value, fade_time);
     }
 }
 
@@ -608,9 +611,12 @@ static void Lighting_Command_Ramp_To(
     current_priority = Present_Value_Priority(pObject);
     if (priority <= current_priority) {
         /* we have priority */
+        if (!pObject->Lighting_Command) {
+            return;
+        }
         Lighting_Command_Trim_Apply(pObject, priority);
         /* configure the Lighting Command */
-        lighting_command_ramp_to(&pObject->Lighting_Command, value, ramp_rate);
+        lighting_command_ramp_to(pObject->Lighting_Command, value, ramp_rate);
     }
 }
 
@@ -654,14 +660,14 @@ Lighting_Command_Warn(struct object_data *pObject, unsigned priority)
 {
     unsigned current_priority;
 
-    if (!pObject) {
+    if (!pObject || !pObject->Lighting_Command) {
         return;
     }
     current_priority = Present_Value_Priority(pObject);
-    if ((priority <= current_priority) &&
-        (Priority_Array_Active(pObject, priority - 1)) &&
-        (!is_float_equal(Priority_Array_Value(pObject, priority - 1), 0.0)) &&
-        pObject->Blink_Warn_Enable) {
+    if (priority <= current_priority) {
+        if (!pObject->Lighting_Command) {
+            return;
+        }
         Lighting_Command_Trim_Apply(pObject, priority);
         /* The blink-warn notification shall not occur
             if any of the following conditions occur:
@@ -670,8 +676,8 @@ Lighting_Command_Warn(struct object_data *pObject, unsigned priority)
             (b) The value at the specified priority is 0.0%, or
             (c) Blink_Warn_Enable is FALSE. */
         lighting_command_blink_warn(
-            &pObject->Lighting_Command, BACNET_LIGHTS_WARN,
-            &pObject->Lighting_Command.Blink);
+            pObject->Lighting_Command, BACNET_LIGHTS_WARN,
+            &pObject->Lighting_Command->Blink);
     }
 }
 
@@ -722,11 +728,15 @@ Lighting_Command_Warn_Off(struct object_data *pObject, unsigned priority)
     unsigned current_priority;
     BACNET_LIGHTING_COMMAND_WARN_DATA blink;
 
-    if (!pObject) {
+    if (!pObject || !pObject->Lighting_Command) {
         return;
     }
     current_priority = Present_Value_Priority(pObject);
     if (priority <= current_priority) {
+        if (!pObject->Lighting_Command) {
+            Present_Value_Set(pObject, 0.0, priority);
+            return;
+        }
         Lighting_Command_Trim_Apply(pObject, priority);
         if ((Priority_Array_Active(pObject, priority - 1)) &&
             (!is_float_equal(
@@ -741,13 +751,13 @@ Lighting_Command_Warn_Off(struct object_data *pObject, unsigned priority)
                 (b) The Present_Value is 0.0%, or
                 (c) Blink_Warn_Enable is FALSE. */
             memmove(
-                &blink, &pObject->Lighting_Command.Blink,
+                &blink, &pObject->Lighting_Command->Blink,
                 sizeof(BACNET_LIGHTING_COMMAND_WARN_DATA));
             blink.Duration = pObject->Egress_Time_Seconds * 1000UL;
             blink.Priority = priority;
             blink.Callback = Lighting_Command_Blink_Stop;
             lighting_command_blink_warn(
-                &pObject->Lighting_Command, BACNET_LIGHTS_WARN_OFF, &blink);
+                pObject->Lighting_Command, BACNET_LIGHTS_WARN_OFF, &blink);
         } else {
             /* the value 0.0% written at the specified priority immediately */
             Present_Value_Set(pObject, 0.0, priority);
@@ -793,11 +803,15 @@ Lighting_Command_Warn_Relinquish(struct object_data *pObject, unsigned priority)
     uint8_t current_priority;
     BACNET_LIGHTING_COMMAND_WARN_DATA blink;
 
-    if (!pObject) {
+    if (!pObject || !pObject->Lighting_Command) {
         return;
     }
     current_priority = Present_Value_Priority(pObject);
     if (priority <= current_priority) {
+        if (!pObject->Lighting_Command) {
+            Present_Value_Relinquish(pObject, priority);
+            return;
+        }
         Lighting_Command_Trim_Apply(pObject, priority);
         if ((Priority_Array_Active(pObject, priority - 1)) &&
             (!is_float_equal(
@@ -814,13 +828,13 @@ Lighting_Command_Warn_Relinquish(struct object_data *pObject, unsigned priority)
                 (c) The Present_Value would not evaluate to 0.0% after
                     the priority slot is relinquished. */
             memmove(
-                &blink, &pObject->Lighting_Command.Blink,
+                &blink, &pObject->Lighting_Command->Blink,
                 sizeof(BACNET_LIGHTING_COMMAND_WARN_DATA));
             blink.Duration = pObject->Egress_Time_Seconds * 1000UL;
             blink.Priority = priority;
             blink.Callback = Lighting_Command_Blink_Stop;
             lighting_command_blink_warn(
-                &pObject->Lighting_Command, BACNET_LIGHTS_WARN_RELINQUISH,
+                pObject->Lighting_Command, BACNET_LIGHTS_WARN_RELINQUISH,
                 &blink);
         } else {
             /* the value at the specified priority shall be
@@ -857,10 +871,10 @@ static void Lighting_Command_Step_Up_On(
     unsigned current_priority;
     float value;
 
-    if (!pObject) {
+    if (!pObject || !pObject->Lighting_Command) {
         return;
     }
-    value = pObject->Lighting_Command.Tracking_Value;
+    value = pObject->Lighting_Command->Tracking_Value;
     if (operation == BACNET_LIGHTS_STEP_UP) {
         if (is_float_equal(value, 0.0)) {
             /* If the starting level of Tracking_Value is 0.0%,
@@ -880,9 +894,12 @@ static void Lighting_Command_Step_Up_On(
     current_priority = Present_Value_Priority(pObject);
     if (priority <= current_priority) {
         /* we have priority - configure the Lighting Command */
+        if (!pObject->Lighting_Command) {
+            return;
+        }
         Lighting_Command_Trim_Apply(pObject, priority);
         lighting_command_step(
-            &pObject->Lighting_Command, operation, step_increment);
+            pObject->Lighting_Command, operation, step_increment);
     }
 }
 
@@ -911,10 +928,10 @@ static void Lighting_Command_Step_Down_Off(
     unsigned current_priority;
     float value;
 
-    if (!pObject) {
+    if (!pObject || !pObject->Lighting_Command) {
         return;
     }
-    value = pObject->Lighting_Command.Tracking_Value;
+    value = pObject->Lighting_Command->Tracking_Value;
     if (is_float_equal(value, 0.0)) {
         /* If the starting level of Tracking_Value is 0.0%,
         then this operation is ignored. */
@@ -938,9 +955,12 @@ static void Lighting_Command_Step_Down_Off(
     current_priority = Present_Value_Priority(pObject);
     if (priority <= current_priority) {
         /* we have priority - configure the Lighting Command */
+        if (!pObject->Lighting_Command) {
+            return;
+        }
         Lighting_Command_Trim_Apply(pObject, priority);
         lighting_command_step(
-            &pObject->Lighting_Command, operation, step_increment);
+            pObject->Lighting_Command, operation, step_increment);
     }
 }
 
@@ -956,10 +976,10 @@ Lighting_Command_Restore_On(struct object_data *pObject, unsigned priority)
 {
     float value;
 
-    if (!pObject) {
+    if (!pObject || !pObject->Lighting_Command) {
         return;
     }
-    value = pObject->Lighting_Command.Last_On_Value;
+    value = pObject->Lighting_Command->Last_On_Value;
     Lighting_Command_Transition_Default(pObject, priority, value);
 }
 
@@ -975,10 +995,10 @@ Lighting_Command_Default_On(struct object_data *pObject, unsigned priority)
 {
     float value;
 
-    if (!pObject) {
+    if (!pObject || !pObject->Lighting_Command) {
         return;
     }
-    value = pObject->Lighting_Command.Default_On_Value;
+    value = pObject->Lighting_Command->Default_On_Value;
     Lighting_Command_Transition_Default(pObject, priority, value);
 }
 
@@ -993,7 +1013,7 @@ Lighting_Command_Toggle_Restore(struct object_data *pObject, unsigned priority)
 {
     float present_value, toggle_value;
 
-    if (!pObject) {
+    if (!pObject || !pObject->Lighting_Command) {
         return;
     }
     present_value = Priority_Array_Next_Value(pObject, 0);
@@ -1001,7 +1021,7 @@ Lighting_Command_Toggle_Restore(struct object_data *pObject, unsigned priority)
         /* Prior to the execution of this command, if Present_Value is 0.0%,
            write the Last_On_Value to the specified slot in the priority
            array. */
-        toggle_value = pObject->Lighting_Command.Last_On_Value;
+        toggle_value = pObject->Lighting_Command->Last_On_Value;
     } else {
         /* Prior to the execution of this command, if Present_Value is not 0.0%,
            write 0.0% to the specified slot in the priority array. */
@@ -1021,7 +1041,7 @@ Lighting_Command_Toggle_Default(struct object_data *pObject, unsigned priority)
 {
     float present_value, toggle_value;
 
-    if (!pObject) {
+    if (!pObject || !pObject->Lighting_Command) {
         return;
     }
     present_value = Priority_Array_Next_Value(pObject, 0);
@@ -1029,7 +1049,7 @@ Lighting_Command_Toggle_Default(struct object_data *pObject, unsigned priority)
         /* Prior to the execution of this command, if Present_Value is 0.0%,
            write the Default_On_Value to the specified slot in the priority
            array. */
-        toggle_value = pObject->Lighting_Command.Default_On_Value;
+        toggle_value = pObject->Lighting_Command->Default_On_Value;
     } else {
         /* Prior to the execution of this command, if Present_Value is not 0.0%,
            write 0.0% to the specified slot in the priority array. */
@@ -1470,10 +1490,12 @@ Lighting_Command_Stop(struct object_data *pObject, unsigned priority)
         if (Lighting_Command_In_Progress(pObject)) {
             /* fade, ramp, or warn command is currently
                executing at the specified priority */
-            value = pObject->Lighting_Command.Tracking_Value;
+            if (pObject->Lighting_Command) {
+                value = pObject->Lighting_Command->Tracking_Value;
+            }
             Present_Value_Set(pObject, value, priority);
             /* configure the Lighting Command */
-            lighting_command_stop(&pObject->Lighting_Command);
+            lighting_command_stop(pObject->Lighting_Command);
         }
     }
 }
@@ -1739,8 +1761,8 @@ bool Lighting_Output_Lighting_Command_Refresh(uint32_t object_instance)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject) {
-        lighting_command_refresh(&pObject->Lighting_Command);
+    if (pObject && pObject->Lighting_Command) {
+        lighting_command_refresh(pObject->Lighting_Command);
         status = true;
     }
 
@@ -1761,8 +1783,8 @@ Lighting_Output_In_Progress(uint32_t object_instance)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject) {
-        value = pObject->Lighting_Command.In_Progress;
+    if (pObject && pObject->Lighting_Command) {
+        value = pObject->Lighting_Command->In_Progress;
     }
 
     return value;
@@ -1784,8 +1806,9 @@ bool Lighting_Output_In_Progress_Set(
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject) {
-        pObject->Lighting_Command.In_Progress = in_progress;
+    if (pObject && pObject->Lighting_Command) {
+        pObject->Lighting_Command->In_Progress = in_progress;
+        status = true;
     }
 
     return status;
@@ -1804,8 +1827,8 @@ float Lighting_Output_Tracking_Value(uint32_t object_instance)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject) {
-        value = pObject->Lighting_Command.Tracking_Value;
+    if (pObject && pObject->Lighting_Command) {
+        value = pObject->Lighting_Command->Tracking_Value;
     }
 
     return value;
@@ -1826,8 +1849,8 @@ bool Lighting_Output_Tracking_Value_Set(uint32_t object_instance, float value)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject) {
-        pObject->Lighting_Command.Tracking_Value = value;
+    if (pObject && pObject->Lighting_Command) {
+        pObject->Lighting_Command->Tracking_Value = value;
         status = true;
     }
 
@@ -1909,16 +1932,16 @@ bool Lighting_Output_Blink_Warn_Feature_Set(
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject) {
+    if (pObject && pObject->Lighting_Command) {
         /* clamp the value */
         if (isless(off_value, 0.0)) {
             off_value = 0.0f;
         } else if (isgreater(off_value, 100.0)) {
             off_value = 100.0f;
         }
-        pObject->Lighting_Command.Blink.Off_Value = off_value;
-        pObject->Lighting_Command.Blink.Interval = interval;
-        pObject->Lighting_Command.Blink.Count = count;
+        pObject->Lighting_Command->Blink.Off_Value = off_value;
+        pObject->Lighting_Command->Blink.Interval = interval;
+        pObject->Lighting_Command->Blink.Count = count;
         status = true;
     }
 
@@ -2022,8 +2045,8 @@ bool Lighting_Output_Egress_Active(uint32_t object_instance)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject) {
-        if (pObject->Lighting_Command.Blink.Duration > 0) {
+    if (pObject && pObject->Lighting_Command) {
+        if (pObject->Lighting_Command->Blink.Duration > 0) {
             value = true;
         }
     }
@@ -2356,8 +2379,8 @@ bool Lighting_Output_Out_Of_Service(uint32_t object_instance)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject) {
-        value = pObject->Lighting_Command.Out_Of_Service;
+    if (pObject && pObject->Lighting_Command) {
+        value = pObject->Lighting_Command->Out_Of_Service;
     }
 
     return value;
@@ -2376,8 +2399,8 @@ void Lighting_Output_Out_Of_Service_Set(uint32_t object_instance, bool value)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject) {
-        pObject->Lighting_Command.Out_Of_Service = value;
+    if (pObject && pObject->Lighting_Command) {
+        pObject->Lighting_Command->Out_Of_Service = value;
     }
 }
 
@@ -2476,8 +2499,8 @@ float Lighting_Output_Last_On_Value(uint32_t object_instance)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject) {
-        value = pObject->Lighting_Command.Last_On_Value;
+    if (pObject && pObject->Lighting_Command) {
+        value = pObject->Lighting_Command->Last_On_Value;
     }
 
     return value;
@@ -2496,9 +2519,9 @@ bool Lighting_Output_Last_On_Value_Set(uint32_t object_instance, float value)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject) {
+    if (pObject && pObject->Lighting_Command) {
         if (isgreaterequal(value, 1.0) && islessequal(value, 100.0)) {
-            pObject->Lighting_Command.Last_On_Value = value;
+            pObject->Lighting_Command->Last_On_Value = value;
             status = true;
         }
     }
@@ -2546,8 +2569,8 @@ float Lighting_Output_Default_On_Value(uint32_t object_instance)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject) {
-        value = pObject->Lighting_Command.Default_On_Value;
+    if (pObject && pObject->Lighting_Command) {
+        value = pObject->Lighting_Command->Default_On_Value;
     }
 
     return value;
@@ -2566,9 +2589,9 @@ bool Lighting_Output_Default_On_Value_Set(uint32_t object_instance, float value)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject) {
+    if (pObject && pObject->Lighting_Command) {
         if (isgreaterequal(value, 1.0) && islessequal(value, 100.0)) {
-            pObject->Lighting_Command.Default_On_Value = value;
+            pObject->Lighting_Command->Default_On_Value = value;
             status = true;
         }
     }
@@ -2644,7 +2667,7 @@ bool Lighting_Output_High_End_Trim_Set(uint32_t object_instance, float value)
             Lighting_Command_Trim_Apply(
                 pObject, Present_Value_Priority(pObject));
             if (!Lighting_Command_In_Progress(pObject)) {
-                lighting_command_refresh(&pObject->Lighting_Command);
+                lighting_command_refresh(pObject->Lighting_Command);
             }
             status = true;
         }
@@ -2721,7 +2744,7 @@ bool Lighting_Output_Low_End_Trim_Set(uint32_t object_instance, float value)
             Lighting_Command_Trim_Apply(
                 pObject, Present_Value_Priority(pObject));
             if (!Lighting_Command_In_Progress(pObject)) {
-                lighting_command_refresh(&pObject->Lighting_Command);
+                lighting_command_refresh(pObject->Lighting_Command);
             }
             status = true;
         }
@@ -2799,7 +2822,7 @@ bool Lighting_Output_Trim_Fade_Time_Set(
             Lighting_Command_Trim_Apply(
                 pObject, Present_Value_Priority(pObject));
             if (!Lighting_Command_In_Progress(pObject)) {
-                lighting_command_refresh(&pObject->Lighting_Command);
+                lighting_command_refresh(pObject->Lighting_Command);
             }
             status = true;
         }
@@ -2851,8 +2874,8 @@ bool Lighting_Output_Overridden_Set(uint32_t object_instance, float value)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject) {
-        lighting_command_override_set(&pObject->Lighting_Command, value);
+    if (pObject && pObject->Lighting_Command) {
+        lighting_command_override_set(pObject->Lighting_Command, value);
         status = true;
     }
 
@@ -2874,9 +2897,9 @@ bool Lighting_Output_Overridden_Clear(uint32_t object_instance)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject) {
+    if (pObject && pObject->Lighting_Command) {
         value = Priority_Array_Next_Value(pObject, 0);
-        lighting_command_override_clear(&pObject->Lighting_Command, value);
+        lighting_command_override_clear(pObject->Lighting_Command, value);
         status = true;
     }
 
@@ -2898,9 +2921,9 @@ bool Lighting_Output_Overridden_Momentary(uint32_t object_instance, float value)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject) {
+    if (pObject && pObject->Lighting_Command) {
         /* set the override */
-        lighting_command_override_momentary(&pObject->Lighting_Command, value);
+        lighting_command_override_momentary(pObject->Lighting_Command, value);
         status = true;
     }
 
@@ -2926,9 +2949,9 @@ bool Lighting_Output_Overridden_Status(uint32_t object_instance)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject) {
-        status = pObject->Lighting_Command.Overridden ||
-            pObject->Lighting_Command.Overridden_Momentary;
+    if (pObject && pObject->Lighting_Command) {
+        status = pObject->Lighting_Command->Overridden ||
+            pObject->Lighting_Command->Overridden_Momentary;
     }
 
     return status;
@@ -3762,8 +3785,8 @@ void Lighting_Output_Timer(uint32_t object_instance, uint16_t milliseconds)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject) {
-        lighting_command_timer(&pObject->Lighting_Command, milliseconds);
+    if (pObject && pObject->Lighting_Command) {
+        lighting_command_timer(pObject->Lighting_Command, milliseconds);
     }
 }
 
@@ -3824,6 +3847,41 @@ void Lighting_Output_Context_Set(uint32_t object_instance, void *context)
 }
 
 /**
+ * @brief Get the lighting command data for a specific object instance
+ * @param object_instance [in] BACnet object instance number
+ * @return pointer to the lighting command data, or NULL if not found
+ */
+BACNET_LIGHTING_COMMAND_DATA *
+Lighting_Output_Lighting_Command_Data(uint32_t object_instance)
+{
+    BACNET_LIGHTING_COMMAND_DATA *data = NULL;
+    struct object_data *pObject;
+
+    pObject = Keylist_Data(Object_List, object_instance);
+    if (pObject) {
+        data = pObject->Lighting_Command;
+    }
+
+    return data;
+}
+
+/**
+ * @brief Set the lighting command data for a specific object instance
+ * @param object_instance [in] BACnet object instance number
+ * @param data [in] pointer to the lighting command data
+ */
+void Lighting_Output_Lighting_Command_Data_Set(
+    uint32_t object_instance, BACNET_LIGHTING_COMMAND_DATA *data)
+{
+    struct object_data *pObject;
+
+    pObject = Keylist_Data(Object_List, object_instance);
+    if (pObject) {
+        pObject->Lighting_Command = data;
+    }
+}
+
+/**
  * @brief Creates a Color object
  * @param object_instance - object-instance number of the object
  * @return the object-instance that was created, or BACNET_MAX_INSTANCE
@@ -3856,10 +3914,10 @@ uint32_t Lighting_Output_Create(uint32_t object_instance)
         pObject->Object_Name = NULL;
         pObject->Description = NULL;
         pObject->Present_Value = 0.0f;
-        lighting_command_init(&pObject->Lighting_Command);
-        pObject->Lighting_Command.Key = object_instance;
-        pObject->Lighting_Command.Notification_Head.callback =
-            Lighting_Output_Tracking_Value_Callback;
+#ifndef CONFIG_BACNET_LIGHTING_OUTPUT_LIGHTING_COMMAND_EXTERNAL
+        pObject->Lighting_Command =
+            calloc(1, sizeof(BACNET_LIGHTING_COMMAND_DATA));
+#endif
         pObject->Last_Lighting_Command.operation = BACNET_LIGHTS_NONE;
         pObject->Last_Lighting_Command.use_target_level = false;
         pObject->Last_Lighting_Command.use_ramp_rate = false;
@@ -3868,9 +3926,7 @@ uint32_t Lighting_Output_Create(uint32_t object_instance)
         pObject->Last_Lighting_Command.use_priority = false;
         pObject->Blink_Warn_Enable = false;
         pObject->High_End_Trim = 100.0f;
-        pObject->Lighting_Command.High_Trim_Value = pObject->High_End_Trim;
         pObject->Low_End_Trim = 1.0f;
-        pObject->Lighting_Command.Low_Trim_Value = pObject->Low_End_Trim;
         pObject->Trim_Fade_Time = 0;
         pObject->Egress_Time_Seconds = 0;
         pObject->Default_Fade_Time = 100;
@@ -3891,6 +3947,15 @@ uint32_t Lighting_Output_Create(uint32_t object_instance)
         pObject->Color_Reference.instance = BACNET_MAX_INSTANCE;
         pObject->Override_Color_Reference.type = OBJECT_COLOR;
         pObject->Override_Color_Reference.instance = BACNET_MAX_INSTANCE;
+        /* defaults for lighting command */
+        if (pObject->Lighting_Command) {
+            lighting_command_init(pObject->Lighting_Command);
+            pObject->Lighting_Command->Key = object_instance;
+            pObject->Lighting_Command->Notification_Head.callback =
+                Lighting_Output_Tracking_Value_Callback;
+            pObject->Lighting_Command->High_Trim_Value = pObject->High_End_Trim;
+            pObject->Lighting_Command->Low_Trim_Value = pObject->Low_End_Trim;
+        }
         /* add to list */
         index = Keylist_Data_Add(Object_List, object_instance, pObject);
         if (index < 0) {

--- a/src/bacnet/basic/object/lo.c
+++ b/src/bacnet/basic/object/lo.c
@@ -33,7 +33,7 @@
 
 struct object_data {
     float Present_Value;
-    BACNET_LIGHTING_COMMAND_DATA *Lighting_Command;
+    BACNET_LIGHTING_COMMAND_DATA Lighting_Command;
     BACNET_LIGHTING_COMMAND Last_Lighting_Command;
     uint32_t Egress_Time_Seconds;
     uint32_t Default_Fade_Time;
@@ -516,14 +516,14 @@ static bool Lighting_Command_In_Progress(struct object_data *pObject)
 {
     bool in_progress = false;
 
-    if (!pObject || !pObject->Lighting_Command) {
+    if (!pObject) {
         return in_progress;
     }
-    if ((pObject->Lighting_Command->In_Progress ==
+    if ((pObject->Lighting_Command.In_Progress ==
          BACNET_LIGHTING_FADE_ACTIVE) ||
-        (pObject->Lighting_Command->In_Progress ==
+        (pObject->Lighting_Command.In_Progress ==
          BACNET_LIGHTING_RAMP_ACTIVE) ||
-        (pObject->Lighting_Command->Blink.Duration > 0)) {
+        (pObject->Lighting_Command.Blink.Duration > 0)) {
         in_progress = true;
     }
 
@@ -539,7 +539,7 @@ static bool Lighting_Command_In_Progress(struct object_data *pObject)
 static void
 Lighting_Command_Trim_Apply(struct object_data *pObject, unsigned priority)
 {
-    if (!pObject || !pObject->Lighting_Command) {
+    if (!pObject) {
         return;
     }
     /* If Present_Value is commanded at priority 1 or 2,
@@ -547,14 +547,14 @@ Lighting_Command_Trim_Apply(struct object_data *pObject, unsigned priority)
         the Tracking_Value shall not be clamped. */
     if ((priority == 1) || (priority == 2)) {
         /* remove any high or low trim */
-        pObject->Lighting_Command->High_Trim_Value = 100.0f;
-        pObject->Lighting_Command->Low_Trim_Value = 1.0f;
-        pObject->Lighting_Command->Trim_Fade_Time = 0;
+        pObject->Lighting_Command.High_Trim_Value = 100.0f;
+        pObject->Lighting_Command.Low_Trim_Value = 1.0f;
+        pObject->Lighting_Command.Trim_Fade_Time = 0;
     } else {
         /* apply high and low trim */
-        pObject->Lighting_Command->High_Trim_Value = pObject->High_End_Trim;
-        pObject->Lighting_Command->Low_Trim_Value = pObject->Low_End_Trim;
-        pObject->Lighting_Command->Trim_Fade_Time = pObject->Trim_Fade_Time;
+        pObject->Lighting_Command.High_Trim_Value = pObject->High_End_Trim;
+        pObject->Lighting_Command.Low_Trim_Value = pObject->Low_End_Trim;
+        pObject->Lighting_Command.Trim_Fade_Time = pObject->Trim_Fade_Time;
     }
 }
 
@@ -580,12 +580,9 @@ static void Lighting_Command_Fade_To(
     current_priority = Present_Value_Priority(pObject);
     if (priority <= current_priority) {
         /* we have priority */
-        if (!pObject->Lighting_Command) {
-            return;
-        }
         Lighting_Command_Trim_Apply(pObject, priority);
         /* configure the Lighting Command */
-        lighting_command_fade_to(pObject->Lighting_Command, value, fade_time);
+        lighting_command_fade_to(&pObject->Lighting_Command, value, fade_time);
     }
 }
 
@@ -611,12 +608,9 @@ static void Lighting_Command_Ramp_To(
     current_priority = Present_Value_Priority(pObject);
     if (priority <= current_priority) {
         /* we have priority */
-        if (!pObject->Lighting_Command) {
-            return;
-        }
         Lighting_Command_Trim_Apply(pObject, priority);
         /* configure the Lighting Command */
-        lighting_command_ramp_to(pObject->Lighting_Command, value, ramp_rate);
+        lighting_command_ramp_to(&pObject->Lighting_Command, value, ramp_rate);
     }
 }
 
@@ -660,14 +654,14 @@ Lighting_Command_Warn(struct object_data *pObject, unsigned priority)
 {
     unsigned current_priority;
 
-    if (!pObject || !pObject->Lighting_Command) {
+    if (!pObject) {
         return;
     }
     current_priority = Present_Value_Priority(pObject);
-    if (priority <= current_priority) {
-        if (!pObject->Lighting_Command) {
-            return;
-        }
+    if ((priority <= current_priority) &&
+        (Priority_Array_Active(pObject, priority - 1)) &&
+        (!is_float_equal(Priority_Array_Value(pObject, priority - 1), 0.0)) &&
+        pObject->Blink_Warn_Enable) {
         Lighting_Command_Trim_Apply(pObject, priority);
         /* The blink-warn notification shall not occur
             if any of the following conditions occur:
@@ -676,8 +670,8 @@ Lighting_Command_Warn(struct object_data *pObject, unsigned priority)
             (b) The value at the specified priority is 0.0%, or
             (c) Blink_Warn_Enable is FALSE. */
         lighting_command_blink_warn(
-            pObject->Lighting_Command, BACNET_LIGHTS_WARN,
-            &pObject->Lighting_Command->Blink);
+            &pObject->Lighting_Command, BACNET_LIGHTS_WARN,
+            &pObject->Lighting_Command.Blink);
     }
 }
 
@@ -728,15 +722,11 @@ Lighting_Command_Warn_Off(struct object_data *pObject, unsigned priority)
     unsigned current_priority;
     BACNET_LIGHTING_COMMAND_WARN_DATA blink;
 
-    if (!pObject || !pObject->Lighting_Command) {
+    if (!pObject) {
         return;
     }
     current_priority = Present_Value_Priority(pObject);
     if (priority <= current_priority) {
-        if (!pObject->Lighting_Command) {
-            Present_Value_Set(pObject, 0.0, priority);
-            return;
-        }
         Lighting_Command_Trim_Apply(pObject, priority);
         if ((Priority_Array_Active(pObject, priority - 1)) &&
             (!is_float_equal(
@@ -751,13 +741,13 @@ Lighting_Command_Warn_Off(struct object_data *pObject, unsigned priority)
                 (b) The Present_Value is 0.0%, or
                 (c) Blink_Warn_Enable is FALSE. */
             memmove(
-                &blink, &pObject->Lighting_Command->Blink,
+                &blink, &pObject->Lighting_Command.Blink,
                 sizeof(BACNET_LIGHTING_COMMAND_WARN_DATA));
             blink.Duration = pObject->Egress_Time_Seconds * 1000UL;
             blink.Priority = priority;
             blink.Callback = Lighting_Command_Blink_Stop;
             lighting_command_blink_warn(
-                pObject->Lighting_Command, BACNET_LIGHTS_WARN_OFF, &blink);
+                &pObject->Lighting_Command, BACNET_LIGHTS_WARN_OFF, &blink);
         } else {
             /* the value 0.0% written at the specified priority immediately */
             Present_Value_Set(pObject, 0.0, priority);
@@ -803,15 +793,11 @@ Lighting_Command_Warn_Relinquish(struct object_data *pObject, unsigned priority)
     uint8_t current_priority;
     BACNET_LIGHTING_COMMAND_WARN_DATA blink;
 
-    if (!pObject || !pObject->Lighting_Command) {
+    if (!pObject) {
         return;
     }
     current_priority = Present_Value_Priority(pObject);
     if (priority <= current_priority) {
-        if (!pObject->Lighting_Command) {
-            Present_Value_Relinquish(pObject, priority);
-            return;
-        }
         Lighting_Command_Trim_Apply(pObject, priority);
         if ((Priority_Array_Active(pObject, priority - 1)) &&
             (!is_float_equal(
@@ -828,13 +814,13 @@ Lighting_Command_Warn_Relinquish(struct object_data *pObject, unsigned priority)
                 (c) The Present_Value would not evaluate to 0.0% after
                     the priority slot is relinquished. */
             memmove(
-                &blink, &pObject->Lighting_Command->Blink,
+                &blink, &pObject->Lighting_Command.Blink,
                 sizeof(BACNET_LIGHTING_COMMAND_WARN_DATA));
             blink.Duration = pObject->Egress_Time_Seconds * 1000UL;
             blink.Priority = priority;
             blink.Callback = Lighting_Command_Blink_Stop;
             lighting_command_blink_warn(
-                pObject->Lighting_Command, BACNET_LIGHTS_WARN_RELINQUISH,
+                &pObject->Lighting_Command, BACNET_LIGHTS_WARN_RELINQUISH,
                 &blink);
         } else {
             /* the value at the specified priority shall be
@@ -871,10 +857,10 @@ static void Lighting_Command_Step_Up_On(
     unsigned current_priority;
     float value;
 
-    if (!pObject || !pObject->Lighting_Command) {
+    if (!pObject) {
         return;
     }
-    value = pObject->Lighting_Command->Tracking_Value;
+    value = pObject->Lighting_Command.Tracking_Value;
     if (operation == BACNET_LIGHTS_STEP_UP) {
         if (is_float_equal(value, 0.0)) {
             /* If the starting level of Tracking_Value is 0.0%,
@@ -894,12 +880,9 @@ static void Lighting_Command_Step_Up_On(
     current_priority = Present_Value_Priority(pObject);
     if (priority <= current_priority) {
         /* we have priority - configure the Lighting Command */
-        if (!pObject->Lighting_Command) {
-            return;
-        }
         Lighting_Command_Trim_Apply(pObject, priority);
         lighting_command_step(
-            pObject->Lighting_Command, operation, step_increment);
+            &pObject->Lighting_Command, operation, step_increment);
     }
 }
 
@@ -928,10 +911,10 @@ static void Lighting_Command_Step_Down_Off(
     unsigned current_priority;
     float value;
 
-    if (!pObject || !pObject->Lighting_Command) {
+    if (!pObject) {
         return;
     }
-    value = pObject->Lighting_Command->Tracking_Value;
+    value = pObject->Lighting_Command.Tracking_Value;
     if (is_float_equal(value, 0.0)) {
         /* If the starting level of Tracking_Value is 0.0%,
         then this operation is ignored. */
@@ -955,12 +938,9 @@ static void Lighting_Command_Step_Down_Off(
     current_priority = Present_Value_Priority(pObject);
     if (priority <= current_priority) {
         /* we have priority - configure the Lighting Command */
-        if (!pObject->Lighting_Command) {
-            return;
-        }
         Lighting_Command_Trim_Apply(pObject, priority);
         lighting_command_step(
-            pObject->Lighting_Command, operation, step_increment);
+            &pObject->Lighting_Command, operation, step_increment);
     }
 }
 
@@ -976,10 +956,10 @@ Lighting_Command_Restore_On(struct object_data *pObject, unsigned priority)
 {
     float value;
 
-    if (!pObject || !pObject->Lighting_Command) {
+    if (!pObject) {
         return;
     }
-    value = pObject->Lighting_Command->Last_On_Value;
+    value = pObject->Lighting_Command.Last_On_Value;
     Lighting_Command_Transition_Default(pObject, priority, value);
 }
 
@@ -995,10 +975,10 @@ Lighting_Command_Default_On(struct object_data *pObject, unsigned priority)
 {
     float value;
 
-    if (!pObject || !pObject->Lighting_Command) {
+    if (!pObject) {
         return;
     }
-    value = pObject->Lighting_Command->Default_On_Value;
+    value = pObject->Lighting_Command.Default_On_Value;
     Lighting_Command_Transition_Default(pObject, priority, value);
 }
 
@@ -1013,7 +993,7 @@ Lighting_Command_Toggle_Restore(struct object_data *pObject, unsigned priority)
 {
     float present_value, toggle_value;
 
-    if (!pObject || !pObject->Lighting_Command) {
+    if (!pObject) {
         return;
     }
     present_value = Priority_Array_Next_Value(pObject, 0);
@@ -1021,7 +1001,7 @@ Lighting_Command_Toggle_Restore(struct object_data *pObject, unsigned priority)
         /* Prior to the execution of this command, if Present_Value is 0.0%,
            write the Last_On_Value to the specified slot in the priority
            array. */
-        toggle_value = pObject->Lighting_Command->Last_On_Value;
+        toggle_value = pObject->Lighting_Command.Last_On_Value;
     } else {
         /* Prior to the execution of this command, if Present_Value is not 0.0%,
            write 0.0% to the specified slot in the priority array. */
@@ -1041,7 +1021,7 @@ Lighting_Command_Toggle_Default(struct object_data *pObject, unsigned priority)
 {
     float present_value, toggle_value;
 
-    if (!pObject || !pObject->Lighting_Command) {
+    if (!pObject) {
         return;
     }
     present_value = Priority_Array_Next_Value(pObject, 0);
@@ -1049,7 +1029,7 @@ Lighting_Command_Toggle_Default(struct object_data *pObject, unsigned priority)
         /* Prior to the execution of this command, if Present_Value is 0.0%,
            write the Default_On_Value to the specified slot in the priority
            array. */
-        toggle_value = pObject->Lighting_Command->Default_On_Value;
+        toggle_value = pObject->Lighting_Command.Default_On_Value;
     } else {
         /* Prior to the execution of this command, if Present_Value is not 0.0%,
            write 0.0% to the specified slot in the priority array. */
@@ -1490,12 +1470,10 @@ Lighting_Command_Stop(struct object_data *pObject, unsigned priority)
         if (Lighting_Command_In_Progress(pObject)) {
             /* fade, ramp, or warn command is currently
                executing at the specified priority */
-            if (pObject->Lighting_Command) {
-                value = pObject->Lighting_Command->Tracking_Value;
-            }
+            value = pObject->Lighting_Command.Tracking_Value;
             Present_Value_Set(pObject, value, priority);
             /* configure the Lighting Command */
-            lighting_command_stop(pObject->Lighting_Command);
+            lighting_command_stop(&pObject->Lighting_Command);
         }
     }
 }
@@ -1761,8 +1739,8 @@ bool Lighting_Output_Lighting_Command_Refresh(uint32_t object_instance)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject && pObject->Lighting_Command) {
-        lighting_command_refresh(pObject->Lighting_Command);
+    if (pObject) {
+        lighting_command_refresh(&pObject->Lighting_Command);
         status = true;
     }
 
@@ -1783,8 +1761,8 @@ Lighting_Output_In_Progress(uint32_t object_instance)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject && pObject->Lighting_Command) {
-        value = pObject->Lighting_Command->In_Progress;
+    if (pObject) {
+        value = pObject->Lighting_Command.In_Progress;
     }
 
     return value;
@@ -1806,9 +1784,8 @@ bool Lighting_Output_In_Progress_Set(
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject && pObject->Lighting_Command) {
-        pObject->Lighting_Command->In_Progress = in_progress;
-        status = true;
+    if (pObject) {
+        pObject->Lighting_Command.In_Progress = in_progress;
     }
 
     return status;
@@ -1827,8 +1804,8 @@ float Lighting_Output_Tracking_Value(uint32_t object_instance)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject && pObject->Lighting_Command) {
-        value = pObject->Lighting_Command->Tracking_Value;
+    if (pObject) {
+        value = pObject->Lighting_Command.Tracking_Value;
     }
 
     return value;
@@ -1849,8 +1826,8 @@ bool Lighting_Output_Tracking_Value_Set(uint32_t object_instance, float value)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject && pObject->Lighting_Command) {
-        pObject->Lighting_Command->Tracking_Value = value;
+    if (pObject) {
+        pObject->Lighting_Command.Tracking_Value = value;
         status = true;
     }
 
@@ -1932,16 +1909,16 @@ bool Lighting_Output_Blink_Warn_Feature_Set(
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject && pObject->Lighting_Command) {
+    if (pObject) {
         /* clamp the value */
         if (isless(off_value, 0.0)) {
             off_value = 0.0f;
         } else if (isgreater(off_value, 100.0)) {
             off_value = 100.0f;
         }
-        pObject->Lighting_Command->Blink.Off_Value = off_value;
-        pObject->Lighting_Command->Blink.Interval = interval;
-        pObject->Lighting_Command->Blink.Count = count;
+        pObject->Lighting_Command.Blink.Off_Value = off_value;
+        pObject->Lighting_Command.Blink.Interval = interval;
+        pObject->Lighting_Command.Blink.Count = count;
         status = true;
     }
 
@@ -2045,8 +2022,8 @@ bool Lighting_Output_Egress_Active(uint32_t object_instance)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject && pObject->Lighting_Command) {
-        if (pObject->Lighting_Command->Blink.Duration > 0) {
+    if (pObject) {
+        if (pObject->Lighting_Command.Blink.Duration > 0) {
             value = true;
         }
     }
@@ -2379,8 +2356,8 @@ bool Lighting_Output_Out_Of_Service(uint32_t object_instance)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject && pObject->Lighting_Command) {
-        value = pObject->Lighting_Command->Out_Of_Service;
+    if (pObject) {
+        value = pObject->Lighting_Command.Out_Of_Service;
     }
 
     return value;
@@ -2399,8 +2376,8 @@ void Lighting_Output_Out_Of_Service_Set(uint32_t object_instance, bool value)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject && pObject->Lighting_Command) {
-        pObject->Lighting_Command->Out_Of_Service = value;
+    if (pObject) {
+        pObject->Lighting_Command.Out_Of_Service = value;
     }
 }
 
@@ -2499,8 +2476,8 @@ float Lighting_Output_Last_On_Value(uint32_t object_instance)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject && pObject->Lighting_Command) {
-        value = pObject->Lighting_Command->Last_On_Value;
+    if (pObject) {
+        value = pObject->Lighting_Command.Last_On_Value;
     }
 
     return value;
@@ -2519,9 +2496,9 @@ bool Lighting_Output_Last_On_Value_Set(uint32_t object_instance, float value)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject && pObject->Lighting_Command) {
+    if (pObject) {
         if (isgreaterequal(value, 1.0) && islessequal(value, 100.0)) {
-            pObject->Lighting_Command->Last_On_Value = value;
+            pObject->Lighting_Command.Last_On_Value = value;
             status = true;
         }
     }
@@ -2569,8 +2546,8 @@ float Lighting_Output_Default_On_Value(uint32_t object_instance)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject && pObject->Lighting_Command) {
-        value = pObject->Lighting_Command->Default_On_Value;
+    if (pObject) {
+        value = pObject->Lighting_Command.Default_On_Value;
     }
 
     return value;
@@ -2589,9 +2566,9 @@ bool Lighting_Output_Default_On_Value_Set(uint32_t object_instance, float value)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject && pObject->Lighting_Command) {
+    if (pObject) {
         if (isgreaterequal(value, 1.0) && islessequal(value, 100.0)) {
-            pObject->Lighting_Command->Default_On_Value = value;
+            pObject->Lighting_Command.Default_On_Value = value;
             status = true;
         }
     }
@@ -2667,7 +2644,7 @@ bool Lighting_Output_High_End_Trim_Set(uint32_t object_instance, float value)
             Lighting_Command_Trim_Apply(
                 pObject, Present_Value_Priority(pObject));
             if (!Lighting_Command_In_Progress(pObject)) {
-                lighting_command_refresh(pObject->Lighting_Command);
+                lighting_command_refresh(&pObject->Lighting_Command);
             }
             status = true;
         }
@@ -2744,7 +2721,7 @@ bool Lighting_Output_Low_End_Trim_Set(uint32_t object_instance, float value)
             Lighting_Command_Trim_Apply(
                 pObject, Present_Value_Priority(pObject));
             if (!Lighting_Command_In_Progress(pObject)) {
-                lighting_command_refresh(pObject->Lighting_Command);
+                lighting_command_refresh(&pObject->Lighting_Command);
             }
             status = true;
         }
@@ -2822,7 +2799,7 @@ bool Lighting_Output_Trim_Fade_Time_Set(
             Lighting_Command_Trim_Apply(
                 pObject, Present_Value_Priority(pObject));
             if (!Lighting_Command_In_Progress(pObject)) {
-                lighting_command_refresh(pObject->Lighting_Command);
+                lighting_command_refresh(&pObject->Lighting_Command);
             }
             status = true;
         }
@@ -2874,8 +2851,8 @@ bool Lighting_Output_Overridden_Set(uint32_t object_instance, float value)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject && pObject->Lighting_Command) {
-        lighting_command_override_set(pObject->Lighting_Command, value);
+    if (pObject) {
+        lighting_command_override_set(&pObject->Lighting_Command, value);
         status = true;
     }
 
@@ -2897,9 +2874,9 @@ bool Lighting_Output_Overridden_Clear(uint32_t object_instance)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject && pObject->Lighting_Command) {
+    if (pObject) {
         value = Priority_Array_Next_Value(pObject, 0);
-        lighting_command_override_clear(pObject->Lighting_Command, value);
+        lighting_command_override_clear(&pObject->Lighting_Command, value);
         status = true;
     }
 
@@ -2921,9 +2898,9 @@ bool Lighting_Output_Overridden_Momentary(uint32_t object_instance, float value)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject && pObject->Lighting_Command) {
+    if (pObject) {
         /* set the override */
-        lighting_command_override_momentary(pObject->Lighting_Command, value);
+        lighting_command_override_momentary(&pObject->Lighting_Command, value);
         status = true;
     }
 
@@ -2949,9 +2926,9 @@ bool Lighting_Output_Overridden_Status(uint32_t object_instance)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject && pObject->Lighting_Command) {
-        status = pObject->Lighting_Command->Overridden ||
-            pObject->Lighting_Command->Overridden_Momentary;
+    if (pObject) {
+        status = pObject->Lighting_Command.Overridden ||
+            pObject->Lighting_Command.Overridden_Momentary;
     }
 
     return status;
@@ -3785,8 +3762,8 @@ void Lighting_Output_Timer(uint32_t object_instance, uint16_t milliseconds)
     struct object_data *pObject;
 
     pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject && pObject->Lighting_Command) {
-        lighting_command_timer(pObject->Lighting_Command, milliseconds);
+    if (pObject) {
+        lighting_command_timer(&pObject->Lighting_Command, milliseconds);
     }
 }
 
@@ -3866,22 +3843,6 @@ Lighting_Output_Lighting_Command_Data(uint32_t object_instance)
 }
 
 /**
- * @brief Set the lighting command data for a specific object instance
- * @param object_instance [in] BACnet object instance number
- * @param data [in] pointer to the lighting command data
- */
-void Lighting_Output_Lighting_Command_Data_Set(
-    uint32_t object_instance, BACNET_LIGHTING_COMMAND_DATA *data)
-{
-    struct object_data *pObject;
-
-    pObject = Keylist_Data(Object_List, object_instance);
-    if (pObject) {
-        pObject->Lighting_Command = data;
-    }
-}
-
-/**
  * @brief Creates a Color object
  * @param object_instance - object-instance number of the object
  * @return the object-instance that was created, or BACNET_MAX_INSTANCE
@@ -3914,10 +3875,10 @@ uint32_t Lighting_Output_Create(uint32_t object_instance)
         pObject->Object_Name = NULL;
         pObject->Description = NULL;
         pObject->Present_Value = 0.0f;
-#ifndef CONFIG_BACNET_LIGHTING_OUTPUT_LIGHTING_COMMAND_EXTERNAL
-        pObject->Lighting_Command =
-            calloc(1, sizeof(BACNET_LIGHTING_COMMAND_DATA));
-#endif
+        lighting_command_init(&pObject->Lighting_Command);
+        pObject->Lighting_Command.Key = object_instance;
+        pObject->Lighting_Command.Notification_Head.callback =
+            Lighting_Output_Tracking_Value_Callback;
         pObject->Last_Lighting_Command.operation = BACNET_LIGHTS_NONE;
         pObject->Last_Lighting_Command.use_target_level = false;
         pObject->Last_Lighting_Command.use_ramp_rate = false;
@@ -3926,7 +3887,9 @@ uint32_t Lighting_Output_Create(uint32_t object_instance)
         pObject->Last_Lighting_Command.use_priority = false;
         pObject->Blink_Warn_Enable = false;
         pObject->High_End_Trim = 100.0f;
+        pObject->Lighting_Command.High_Trim_Value = pObject->High_End_Trim;
         pObject->Low_End_Trim = 1.0f;
+        pObject->Lighting_Command.Low_Trim_Value = pObject->Low_End_Trim;
         pObject->Trim_Fade_Time = 0;
         pObject->Egress_Time_Seconds = 0;
         pObject->Default_Fade_Time = 100;
@@ -3947,15 +3910,6 @@ uint32_t Lighting_Output_Create(uint32_t object_instance)
         pObject->Color_Reference.instance = BACNET_MAX_INSTANCE;
         pObject->Override_Color_Reference.type = OBJECT_COLOR;
         pObject->Override_Color_Reference.instance = BACNET_MAX_INSTANCE;
-        /* defaults for lighting command */
-        if (pObject->Lighting_Command) {
-            lighting_command_init(pObject->Lighting_Command);
-            pObject->Lighting_Command->Key = object_instance;
-            pObject->Lighting_Command->Notification_Head.callback =
-                Lighting_Output_Tracking_Value_Callback;
-            pObject->Lighting_Command->High_Trim_Value = pObject->High_End_Trim;
-            pObject->Lighting_Command->Low_Trim_Value = pObject->Low_End_Trim;
-        }
         /* add to list */
         index = Keylist_Data_Add(Object_List, object_instance, pObject);
         if (index < 0) {

--- a/src/bacnet/basic/object/lo.h
+++ b/src/bacnet/basic/object/lo.h
@@ -249,6 +249,13 @@ BACNET_STACK_EXPORT
 void Lighting_Output_Context_Set(uint32_t object_instance, void *context);
 
 BACNET_STACK_EXPORT
+BACNET_LIGHTING_COMMAND_DATA *
+Lighting_Output_Lighting_Command_Data(uint32_t object_instance);
+BACNET_STACK_EXPORT
+void Lighting_Output_Lighting_Command_Data_Set(
+    uint32_t object_instance, BACNET_LIGHTING_COMMAND_DATA *data);
+
+BACNET_STACK_EXPORT
 uint32_t Lighting_Output_Create(uint32_t object_instance);
 BACNET_STACK_EXPORT
 bool Lighting_Output_Delete(uint32_t object_instance);

--- a/src/bacnet/basic/object/lo.h
+++ b/src/bacnet/basic/object/lo.h
@@ -251,9 +251,6 @@ void Lighting_Output_Context_Set(uint32_t object_instance, void *context);
 BACNET_STACK_EXPORT
 BACNET_LIGHTING_COMMAND_DATA *
 Lighting_Output_Lighting_Command_Data(uint32_t object_instance);
-BACNET_STACK_EXPORT
-void Lighting_Output_Lighting_Command_Data_Set(
-    uint32_t object_instance, BACNET_LIGHTING_COMMAND_DATA *data);
 
 BACNET_STACK_EXPORT
 uint32_t Lighting_Output_Create(uint32_t object_instance);

--- a/src/bacnet/basic/sys/lighting_command.c
+++ b/src/bacnet/basic/sys/lighting_command.c
@@ -1215,6 +1215,32 @@ void lighting_command_blink_warn(
 }
 
 /**
+ * @brief Copy the current blink data from the lighting command
+ * @param data [in] dimmer object instance
+ * @param blink [out] BACnet blink data to copy into
+ */
+void lighting_command_blink_copy(
+    struct bacnet_lighting_command_data *data,
+    struct bacnet_lighting_command_warn_data *blink)
+{
+    if (!data || !blink) {
+        return;
+    }
+    lighting_command_lock(data);
+    blink->On_Value = data->Blink.On_Value;
+    blink->Off_Value = data->Blink.Off_Value;
+    blink->End_Value = data->Blink.End_Value;
+    blink->Priority = data->Blink.Priority;
+    blink->Callback = data->Blink.Callback;
+    blink->Target_Interval = data->Blink.Target_Interval;
+    blink->Interval = data->Blink.Interval;
+    blink->Duration = data->Blink.Duration;
+    blink->Count = data->Blink.Count;
+    blink->State = data->Blink.State;
+    lighting_command_unlock(data);
+}
+
+/**
  * @brief Set the lighting command to perform a stop operation
  * @param object [in] BACnet object instance
  * @param priority [in] BACnet priority array value 1..16
@@ -1348,6 +1374,250 @@ void lighting_command_toggle_default(
         data->Target_Level = 0.0f;
     }
     lighting_command_unlock(data);
+}
+
+/**
+ * @brief Configure the lighting command to apply low or high trim
+ * @param data [in] dimmer data
+ */
+void lighting_command_trim_set(
+    struct bacnet_lighting_command_data *data,
+    float High_End_Trim,
+    float Low_End_Trim,
+    uint32_t Trim_Fade_Time)
+{
+    if (!data) {
+        return;
+    }
+    lighting_command_lock(data);
+    /* apply high and low trim */
+    data->High_Trim_Value = High_End_Trim;
+    data->Low_Trim_Value = Low_End_Trim;
+    data->Trim_Fade_Time = Trim_Fade_Time;
+    lighting_command_unlock(data);
+}
+
+void lighting_command_key_set(
+    struct bacnet_lighting_command_data *data, uint32_t key)
+{
+    if (!data) {
+        return;
+    }
+    lighting_command_lock(data);
+    data->Key = key;
+    lighting_command_unlock(data);
+}
+
+void lighting_command_tracking_value_callback_set(
+    struct bacnet_lighting_command_data *data,
+    lighting_command_tracking_value_callback cb)
+{
+    if (!data) {
+        return;
+    }
+    lighting_command_lock(data);
+    data->Notification_Head.callback = cb;
+    lighting_command_unlock(data);
+}
+
+BACNET_LIGHTING_IN_PROGRESS
+lighting_command_in_progress_get(struct bacnet_lighting_command_data *data)
+{
+    BACNET_LIGHTING_IN_PROGRESS in_progress = BACNET_LIGHTING_IDLE;
+
+    if (!data) {
+        return in_progress;
+    }
+    lighting_command_lock(data);
+    in_progress = data->In_Progress;
+    lighting_command_unlock(data);
+
+    return in_progress;
+}
+
+void lighting_command_in_progress_set(
+    struct bacnet_lighting_command_data *data,
+    BACNET_LIGHTING_IN_PROGRESS in_progress)
+{
+    if (!data) {
+        return;
+    }
+    lighting_command_lock(data);
+    data->In_Progress = in_progress;
+    lighting_command_unlock(data);
+}
+
+float lighting_command_tracking_value_get(
+    struct bacnet_lighting_command_data *data)
+{
+    float value = 0.0f;
+
+    if (!data) {
+        return value;
+    }
+    lighting_command_lock(data);
+    value = data->Tracking_Value;
+    lighting_command_unlock(data);
+
+    return value;
+}
+
+void lighting_command_tracking_value_set(
+    struct bacnet_lighting_command_data *data, float value)
+{
+    if (!data) {
+        return;
+    }
+    lighting_command_lock(data);
+    data->Tracking_Value = value;
+    lighting_command_unlock(data);
+}
+
+void lighting_command_blink_warn_feature_set(
+    struct bacnet_lighting_command_data *data,
+    float off_value,
+    uint16_t interval,
+    uint16_t count)
+{
+    if (!data) {
+        return;
+    }
+    lighting_command_lock(data);
+    data->Blink.Off_Value = off_value;
+    data->Blink.Interval = interval;
+    data->Blink.Count = count;
+    lighting_command_unlock(data);
+}
+
+bool lighting_command_blink_egress_active(
+    struct bacnet_lighting_command_data *data)
+{
+    bool active = false;
+
+    if (!data) {
+        return active;
+    }
+    lighting_command_lock(data);
+    active = data->Blink.Duration > 0;
+    lighting_command_unlock(data);
+
+    return active;
+}
+
+bool lighting_command_out_of_service_get(
+    struct bacnet_lighting_command_data *data)
+{
+    bool value = false;
+
+    if (!data) {
+        return value;
+    }
+    lighting_command_lock(data);
+    value = data->Out_Of_Service;
+    lighting_command_unlock(data);
+
+    return value;
+}
+
+void lighting_command_out_of_service_set(
+    struct bacnet_lighting_command_data *data, bool value)
+{
+    if (!data) {
+        return;
+    }
+    lighting_command_lock(data);
+    data->Out_Of_Service = value;
+    lighting_command_unlock(data);
+}
+
+float lighting_command_last_on_value_get(
+    struct bacnet_lighting_command_data *data)
+{
+    float value = 0.0f;
+
+    if (!data) {
+        return value;
+    }
+    lighting_command_lock(data);
+    value = data->Last_On_Value;
+    lighting_command_unlock(data);
+
+    return value;
+}
+
+void lighting_command_last_on_value_set(
+    struct bacnet_lighting_command_data *data, float value)
+{
+    if (!data) {
+        return;
+    }
+    lighting_command_lock(data);
+    data->Last_On_Value = value;
+    lighting_command_unlock(data);
+}
+
+float lighting_command_default_on_value_get(
+    struct bacnet_lighting_command_data *data)
+{
+    float value = 0.0f;
+
+    if (!data) {
+        return value;
+    }
+    lighting_command_lock(data);
+    value = data->Default_On_Value;
+    lighting_command_unlock(data);
+
+    return value;
+}
+
+void lighting_command_default_on_value_set(
+    struct bacnet_lighting_command_data *data, float value)
+{
+    if (!data) {
+        return;
+    }
+    lighting_command_lock(data);
+    data->Default_On_Value = value;
+    lighting_command_unlock(data);
+}
+
+bool lighting_command_overridden_status(
+    struct bacnet_lighting_command_data *data)
+{
+    bool status = false;
+
+    if (!data) {
+        return status;
+    }
+    lighting_command_lock(data);
+    status = data->Overridden || data->Overridden_Momentary;
+    lighting_command_unlock(data);
+
+    return status;
+}
+
+/**
+ * @brief Determine if fade, ramp, or warn command is currently executing
+ * @param pObject [in] object to apply the trim values to
+ * @param priority [in] priority of the command
+ */
+bool lighting_command_active(struct bacnet_lighting_command_data *data)
+{
+    bool in_progress = false;
+
+    if (!data) {
+        return in_progress;
+    }
+    lighting_command_lock(data);
+    if ((data->In_Progress == BACNET_LIGHTING_FADE_ACTIVE) ||
+        (data->In_Progress == BACNET_LIGHTING_RAMP_ACTIVE) ||
+        (data->Blink.Duration > 0)) {
+        in_progress = true;
+    }
+    lighting_command_unlock(data);
+
+    return in_progress;
 }
 
 /**

--- a/src/bacnet/basic/sys/lighting_command.c
+++ b/src/bacnet/basic/sys/lighting_command.c
@@ -918,6 +918,9 @@ void lighting_command_timer(
     if (!data) {
         return;
     }
+    if (data->Lock) {
+        data->Lock(data);
+    }
     if (data->Overridden) {
         data->Lighting_Operation = BACNET_LIGHTS_NONE;
     }
@@ -961,6 +964,9 @@ void lighting_command_timer(
             break;
     }
     lighting_command_timer_notify(data, milliseconds);
+    if (data->Unlock) {
+        data->Unlock(data);
+    }
 }
 
 /**

--- a/src/bacnet/basic/sys/lighting_command.c
+++ b/src/bacnet/basic/sys/lighting_command.c
@@ -49,9 +49,7 @@ void lighting_command_notification_add(
     if (!data || !notification) {
         return;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
 
     head = &data->Notification_Head;
     do {
@@ -65,9 +63,7 @@ void lighting_command_notification_add(
         }
         head = head->next;
     } while (head);
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 }
 
 /**
@@ -103,9 +99,7 @@ void lighting_command_timer_notfication_add(
     if (!data || !notification) {
         return;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
 
     head = &data->Timer_Notification_Head;
     do {
@@ -119,9 +113,7 @@ void lighting_command_timer_notfication_add(
         }
         head = head->next;
     } while (head);
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 }
 
 /**
@@ -358,14 +350,10 @@ float lighting_command_operating_range_clamp_fade(
     if (!data) {
         return value;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     clamped_value = lighting_command_operating_range_clamp_fade_nolock(
         data, value, milliseconds);
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 
     return clamped_value;
 }
@@ -398,13 +386,9 @@ float lighting_command_operating_range_clamp(
     if (!data) {
         return value;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     clamped_value = lighting_command_operating_range_clamp_nolock(data, value);
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 
     return clamped_value;
 }
@@ -458,14 +442,10 @@ float lighting_command_normalized_on_range_clamp(
     if (!data) {
         return value;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     clamped_value =
         lighting_command_normalized_on_range_clamp_nolock(data, value);
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 
     return clamped_value;
 }
@@ -525,13 +505,9 @@ float lighting_command_normalized_range_clamp(
     if (!data) {
         return value;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     clamped_value = lighting_command_normalized_range_clamp_nolock(data, value);
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 
     return clamped_value;
 }
@@ -946,13 +922,9 @@ void lighting_command_override(
     if (!data) {
         return;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     lighting_command_override_nolock(data, value);
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 }
 
 /**
@@ -965,15 +937,11 @@ void lighting_command_override_set(
     if (!data) {
         return;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     data->Overridden = true;
     data->Overridden_Momentary = false;
     lighting_command_override_nolock(data, value);
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 }
 
 /**
@@ -988,9 +956,7 @@ void lighting_command_override_clear(
     if (!data) {
         return;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     data->Overridden = false;
     data->Overridden_Momentary = false;
     old_value = data->Tracking_Value;
@@ -1002,9 +968,7 @@ void lighting_command_override_clear(
         lighting_command_operating_range_clamp_nolock(data, normalized_value);
     data->Tracking_Value = operating_value;
     lighting_command_tracking_value_event(data, old_value, operating_value);
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 }
 
 /**
@@ -1017,15 +981,11 @@ void lighting_command_override_momentary(
     if (!data) {
         return;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     data->Overridden = true;
     data->Overridden_Momentary = true;
     lighting_command_override_nolock(data, value);
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 }
 
 /**
@@ -1039,14 +999,10 @@ void lighting_command_refresh(struct bacnet_lighting_command_data *data)
     if (!data) {
         return;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     value = data->Tracking_Value;
     lighting_command_tracking_value_event(data, value, value);
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 }
 
 /**
@@ -1061,9 +1017,7 @@ void lighting_command_timer(
     if (!data) {
         return;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     if (data->Overridden) {
         data->Lighting_Operation = BACNET_LIGHTS_NONE;
     }
@@ -1107,9 +1061,7 @@ void lighting_command_timer(
             break;
     }
     lighting_command_timer_notify(data, milliseconds);
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 }
 
 /**
@@ -1124,9 +1076,7 @@ void lighting_command_fade_to(
     if (!data) {
         return;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     /* possibly interrupting a blink warn, so notify */
     lighting_command_blink_stop_notify_nolock(data);
     /* configure the lighting operation */
@@ -1137,9 +1087,7 @@ void lighting_command_fade_to(
         /* the last value that was greater than or equal to 1.0%.*/
         data->Last_On_Value = value;
     }
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 }
 
 /**
@@ -1154,9 +1102,7 @@ void lighting_command_ramp_to(
     if (!data) {
         return;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     /* possibly interrupting a blink warn, so notify */
     lighting_command_blink_stop_notify_nolock(data);
     /* configure the lighting operation */
@@ -1167,9 +1113,7 @@ void lighting_command_ramp_to(
         /* the last value that was greater than or equal to 1.0%.*/
         data->Last_On_Value = value;
     }
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 }
 
 /**
@@ -1188,9 +1132,7 @@ void lighting_command_step(
     if (!data) {
         return;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     /* possibly interrupting a blink warn, so notify */
     lighting_command_blink_stop_notify_nolock(data);
     /* configure the lighting operation */
@@ -1234,9 +1176,7 @@ void lighting_command_step(
     }
 
 done:
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 }
 
 /**
@@ -1253,9 +1193,7 @@ void lighting_command_blink_warn(
     if (!data || !blink) {
         return;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     /* possibly interrupting a blink warn, so notify */
     lighting_command_blink_stop_notify_nolock(data);
     /* configure the new warning */
@@ -1273,9 +1211,7 @@ void lighting_command_blink_warn(
     /* configure next interval */
     data->Blink.State = false;
     data->Blink.Interval = blink->Interval;
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 }
 
 /**
@@ -1288,9 +1224,7 @@ void lighting_command_stop(struct bacnet_lighting_command_data *data)
     if (!data) {
         return;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     /* possibly interrupting a blink warn, so notify */
     lighting_command_blink_stop_notify_nolock(data);
     /* configure the lighting operation */
@@ -1299,9 +1233,7 @@ void lighting_command_stop(struct bacnet_lighting_command_data *data)
         /* the last value that was greater than or equal to 1.0%.*/
         data->Last_On_Value = data->Tracking_Value;
     }
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 }
 
 /**
@@ -1314,16 +1246,12 @@ void lighting_command_none(struct bacnet_lighting_command_data *data)
     if (!data) {
         return;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     /* possibly interrupting a blink warn, so notify */
     lighting_command_blink_stop_notify_nolock(data);
     /* configure the lighting operation */
     data->Lighting_Operation = BACNET_LIGHTS_NONE;
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 }
 
 /**
@@ -1337,18 +1265,14 @@ void lighting_command_restore_on(
     if (!data) {
         return;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     /* possibly interrupting a blink warn, so notify */
     lighting_command_blink_stop_notify_nolock(data);
     /* configure the lighting operation */
     data->Fade_Time = fade_time;
     data->Lighting_Operation = BACNET_LIGHTS_RESTORE_ON;
     data->Target_Level = data->Last_On_Value;
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 }
 
 /**
@@ -1362,18 +1286,14 @@ void lighting_command_default_on(
     if (!data) {
         return;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     /* possibly interrupting a blink warn, so notify */
     lighting_command_blink_stop_notify_nolock(data);
     /* configure the lighting operation */
     data->Fade_Time = fade_time;
     data->Lighting_Operation = BACNET_LIGHTS_DEFAULT_ON;
     data->Target_Level = data->Default_On_Value;
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 }
 
 /**
@@ -1387,9 +1307,7 @@ void lighting_command_toggle_restore(
     if (!data) {
         return;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     /* possibly interrupting a blink warn, so notify */
     lighting_command_blink_stop_notify_nolock(data);
     /* configure the lighting operation */
@@ -1402,9 +1320,7 @@ void lighting_command_toggle_restore(
         /* not OFF, write 0.0% */
         data->Target_Level = 0.0f;
     }
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 }
 
 /**
@@ -1418,9 +1334,7 @@ void lighting_command_toggle_default(
     if (!data) {
         return;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     /* possibly interrupting a blink warn, so notify */
     lighting_command_blink_stop_notify_nolock(data);
     /* configure the lighting operation */
@@ -1433,9 +1347,7 @@ void lighting_command_toggle_default(
         /* not OFF, write 0.0% */
         data->Target_Level = 0.0f;
     }
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 }
 
 /**
@@ -1474,9 +1386,7 @@ void lighting_command_init(struct bacnet_lighting_command_data *data)
     if (!data) {
         return;
     }
-    if (data->Lock) {
-        data->Lock(data);
-    }
+    lighting_command_lock(data);
     data->Tracking_Value = 0.0f;
     data->Lighting_Operation = BACNET_LIGHTS_NONE;
     data->In_Progress = BACNET_LIGHTING_NOT_CONTROLLED;
@@ -1503,7 +1413,5 @@ void lighting_command_init(struct bacnet_lighting_command_data *data)
     data->Notification_Head.callback = NULL;
     data->Timer_Notification_Head.next = NULL;
     data->Timer_Notification_Head.callback = NULL;
-    if (data->Unlock) {
-        data->Unlock(data);
-    }
+    lighting_command_unlock(data);
 }

--- a/src/bacnet/basic/sys/lighting_command.c
+++ b/src/bacnet/basic/sys/lighting_command.c
@@ -46,6 +46,13 @@ void lighting_command_notification_add(
 {
     struct lighting_command_notification *head;
 
+    if (!data || !notification) {
+        return;
+    }
+    if (data->Lock) {
+        data->Lock(data);
+    }
+
     head = &data->Notification_Head;
     do {
         if (head->next == notification) {
@@ -58,6 +65,9 @@ void lighting_command_notification_add(
         }
         head = head->next;
     } while (head);
+    if (data->Unlock) {
+        data->Unlock(data);
+    }
 }
 
 /**
@@ -90,6 +100,13 @@ void lighting_command_timer_notfication_add(
 {
     struct lighting_command_timer_notification *head;
 
+    if (!data || !notification) {
+        return;
+    }
+    if (data->Lock) {
+        data->Lock(data);
+    }
+
     head = &data->Timer_Notification_Head;
     do {
         if (head->next == notification) {
@@ -102,6 +119,9 @@ void lighting_command_timer_notfication_add(
         }
         head = head->next;
     } while (head);
+    if (data->Unlock) {
+        data->Unlock(data);
+    }
 }
 
 /**
@@ -109,8 +129,8 @@ void lighting_command_timer_notfication_add(
  *        for WARN_OFF/WARN_RELINQUISH operations
  * @param data - dimmer data structure
  */
-static void
-lighting_command_blink_stop_notify(struct bacnet_lighting_command_data *data)
+static void lighting_command_blink_stop_notify_nolock(
+    struct bacnet_lighting_command_data *data)
 {
     if (data->Blink.Callback) {
         /* do some checking to avoid extra callbacks */
@@ -288,7 +308,7 @@ static float lighting_command_trim_fade(
  * @return value clamped within the operating range defined by the High_End_Trim
  *  and Low_End_Trim property values
  */
-float lighting_command_operating_range_clamp_fade(
+static float lighting_command_operating_range_clamp_fade_nolock(
     struct bacnet_lighting_command_data *data,
     float value,
     uint16_t milliseconds)
@@ -328,6 +348,28 @@ float lighting_command_operating_range_clamp_fade(
     return value;
 }
 
+float lighting_command_operating_range_clamp_fade(
+    struct bacnet_lighting_command_data *data,
+    float value,
+    uint16_t milliseconds)
+{
+    float clamped_value;
+
+    if (!data) {
+        return value;
+    }
+    if (data->Lock) {
+        data->Lock(data);
+    }
+    clamped_value = lighting_command_operating_range_clamp_fade_nolock(
+        data, value, milliseconds);
+    if (data->Unlock) {
+        data->Unlock(data);
+    }
+
+    return clamped_value;
+}
+
 /**
  * @brief Clamp the value within the operating range between low and high
  *  end trim values immediately.
@@ -342,10 +384,29 @@ float lighting_command_operating_range_clamp_fade(
  * @return value clamped within the operating range defined by the High_End_Trim
  *  and Low_End_Trim property values
  */
+static float lighting_command_operating_range_clamp_nolock(
+    struct bacnet_lighting_command_data *data, float value)
+{
+    return lighting_command_operating_range_clamp_fade_nolock(data, value, 0);
+}
+
 float lighting_command_operating_range_clamp(
     struct bacnet_lighting_command_data *data, float value)
 {
-    return lighting_command_operating_range_clamp_fade(data, value, 0);
+    float clamped_value;
+
+    if (!data) {
+        return value;
+    }
+    if (data->Lock) {
+        data->Lock(data);
+    }
+    clamped_value = lighting_command_operating_range_clamp_nolock(data, value);
+    if (data->Unlock) {
+        data->Unlock(data);
+    }
+
+    return clamped_value;
 }
 
 /**
@@ -364,7 +425,7 @@ float lighting_command_operating_range_clamp(
  * @return normalized value within the range defined by Min_Actual_Value
  *  and Max_Actual_Value
  */
-float lighting_command_normalized_on_range_clamp(
+static float lighting_command_normalized_on_range_clamp_nolock(
     struct bacnet_lighting_command_data *data, float value)
 {
     float min_value, max_value, swap_value;
@@ -389,6 +450,26 @@ float lighting_command_normalized_on_range_clamp(
     return value;
 }
 
+float lighting_command_normalized_on_range_clamp(
+    struct bacnet_lighting_command_data *data, float value)
+{
+    float clamped_value;
+
+    if (!data) {
+        return value;
+    }
+    if (data->Lock) {
+        data->Lock(data);
+    }
+    clamped_value =
+        lighting_command_normalized_on_range_clamp_nolock(data, value);
+    if (data->Unlock) {
+        data->Unlock(data);
+    }
+
+    return clamped_value;
+}
+
 /**
  * @brief Normalize the value to the min/max range
  * @details The physical output level, or non-normalized range,
@@ -405,7 +486,7 @@ float lighting_command_normalized_on_range_clamp(
  * @return normalized value within the range defined by
  *  0.0%, Min_Actual_Value, and Max_Actual_Value
  */
-float lighting_command_normalized_range_clamp(
+static float lighting_command_normalized_range_clamp_nolock(
     struct bacnet_lighting_command_data *data, float value)
 {
     float normalized_value;
@@ -434,6 +515,25 @@ float lighting_command_normalized_range_clamp(
     }
 
     return normalized_value;
+}
+
+float lighting_command_normalized_range_clamp(
+    struct bacnet_lighting_command_data *data, float value)
+{
+    float clamped_value;
+
+    if (!data) {
+        return value;
+    }
+    if (data->Lock) {
+        data->Lock(data);
+    }
+    clamped_value = lighting_command_normalized_range_clamp_nolock(data, value);
+    if (data->Unlock) {
+        data->Unlock(data);
+    }
+
+    return clamped_value;
 }
 
 /**
@@ -476,8 +576,8 @@ static void lighting_command_fade_handler(
 
     old_value = data->Tracking_Value;
     /* clamp Tracking value within the Normalized ON Range */
-    target_value =
-        lighting_command_normalized_on_range_clamp(data, data->Target_Level);
+    target_value = lighting_command_normalized_on_range_clamp_nolock(
+        data, data->Target_Level);
     if ((milliseconds >= data->Fade_Time) ||
         (!islessgreater(data->Tracking_Value, target_value))) {
         /* stop fading */
@@ -506,7 +606,7 @@ static void lighting_command_fade_handler(
         data->In_Progress = BACNET_LIGHTING_FADE_ACTIVE;
     }
     /* clamp Tracking Value inclusively within the Operating Range */
-    data->Tracking_Value = lighting_command_operating_range_clamp_fade(
+    data->Tracking_Value = lighting_command_operating_range_clamp_fade_nolock(
         data, data->Tracking_Value, milliseconds);
     /* notify */
     lighting_command_tracking_value_event(
@@ -536,8 +636,8 @@ static void lighting_command_ramp_handler(
 
     old_value = data->Tracking_Value;
     /* clamp Tracking value within the Normalized ON Range */
-    target_value =
-        lighting_command_normalized_on_range_clamp(data, data->Target_Level);
+    target_value = lighting_command_normalized_on_range_clamp_nolock(
+        data, data->Target_Level);
     if (!islessgreater(data->Tracking_Value, target_value)) {
         /* stop ramping */
         if (isless(data->Target_Level, 1.0f)) {
@@ -581,7 +681,7 @@ static void lighting_command_ramp_handler(
         }
         /* clamp target within min/max, if needed */
         step_value =
-            lighting_command_normalized_on_range_clamp(data, step_value);
+            lighting_command_normalized_on_range_clamp_nolock(data, step_value);
         if (data->Lighting_Operation == BACNET_LIGHTS_STOP) {
             if (isless(data->Target_Level, 1.0f)) {
                 /* jump target to OFF if below normalized min */
@@ -596,7 +696,7 @@ static void lighting_command_ramp_handler(
         }
     }
     /* clamp Tracking_Value inclusively within the Operating Range */
-    operating_value = lighting_command_operating_range_clamp_fade(
+    operating_value = lighting_command_operating_range_clamp_fade_nolock(
         data, data->Tracking_Value, milliseconds);
     data->Tracking_Value = operating_value;
     /* notify */
@@ -625,12 +725,13 @@ lighting_command_step_up_handler(struct bacnet_lighting_command_data *data)
             data->Tracking_Value, data->Step_Increment);
         /* clamp Tracking value within the Normalized ON Range */
         data->Tracking_Value =
-            lighting_command_normalized_on_range_clamp(data, target_value);
+            lighting_command_normalized_on_range_clamp_nolock(
+                data, target_value);
         data->In_Progress = BACNET_LIGHTING_IDLE;
         data->Lighting_Operation = BACNET_LIGHTS_STOP;
         /* clamp Tracking value inclusively within the Operating Range */
-        operating_value =
-            lighting_command_operating_range_clamp(data, data->Tracking_Value);
+        operating_value = lighting_command_operating_range_clamp_nolock(
+            data, data->Tracking_Value);
         data->Tracking_Value = operating_value;
         /* notify */
         lighting_command_tracking_value_event(
@@ -657,12 +758,12 @@ lighting_command_step_down_handler(struct bacnet_lighting_command_data *data)
         data->Tracking_Value, data->Step_Increment);
     /* clamp Tracking value within the Normalized ON Range */
     data->Tracking_Value =
-        lighting_command_normalized_on_range_clamp(data, target_value);
+        lighting_command_normalized_on_range_clamp_nolock(data, target_value);
     data->In_Progress = BACNET_LIGHTING_IDLE;
     data->Lighting_Operation = BACNET_LIGHTS_STOP;
     /* clamp Tracking value inclusively within the Operating Range */
-    operating_value =
-        lighting_command_operating_range_clamp(data, data->Tracking_Value);
+    operating_value = lighting_command_operating_range_clamp_nolock(
+        data, data->Tracking_Value);
     data->Tracking_Value = operating_value;
     /* notify */
     lighting_command_tracking_value_event(
@@ -687,12 +788,12 @@ lighting_command_step_on_handler(struct bacnet_lighting_command_data *data)
     target_value = lighting_command_step_up_target_value(
         data->Tracking_Value, data->Step_Increment);
     data->Tracking_Value =
-        lighting_command_normalized_range_clamp(data, target_value);
+        lighting_command_normalized_range_clamp_nolock(data, target_value);
     data->In_Progress = BACNET_LIGHTING_IDLE;
     data->Lighting_Operation = BACNET_LIGHTS_STOP;
     /* clamp Tracking value inclusively within the Operating Range */
-    operating_value =
-        lighting_command_operating_range_clamp(data, data->Tracking_Value);
+    operating_value = lighting_command_operating_range_clamp_nolock(
+        data, data->Tracking_Value);
     data->Tracking_Value = operating_value;
     /* notify */
     lighting_command_tracking_value_event(
@@ -717,12 +818,12 @@ lighting_command_step_off_handler(struct bacnet_lighting_command_data *data)
     target_value = lighting_command_step_down_target_value(
         data->Tracking_Value, data->Step_Increment);
     data->Tracking_Value =
-        lighting_command_normalized_range_clamp(data, target_value);
+        lighting_command_normalized_range_clamp_nolock(data, target_value);
     data->In_Progress = BACNET_LIGHTING_IDLE;
     data->Lighting_Operation = BACNET_LIGHTS_STOP;
     /* clamp Tracking value inclusively within the Operating Range */
-    operating_value =
-        lighting_command_operating_range_clamp(data, data->Tracking_Value);
+    operating_value = lighting_command_operating_range_clamp_nolock(
+        data, data->Tracking_Value);
     data->Tracking_Value = operating_value;
     /* notify */
     lighting_command_tracking_value_event(
@@ -767,7 +868,7 @@ static void lighting_command_blink_handler(
     }
     if (data->Blink.Duration == 0) {
         /* 'end' operation */
-        lighting_command_blink_stop_notify(data);
+        lighting_command_blink_stop_notify_nolock(data);
         data->In_Progress = BACNET_LIGHTING_IDLE;
         data->Lighting_Operation = BACNET_LIGHTS_STOP;
         target_value = data->Blink.End_Value;
@@ -799,7 +900,7 @@ static void lighting_command_blink_handler(
                 }
                 if (data->Blink.Count == 0) {
                     /* 'end' operation */
-                    lighting_command_blink_stop_notify(data);
+                    lighting_command_blink_stop_notify_nolock(data);
                     data->In_Progress = BACNET_LIGHTING_IDLE;
                     data->Lighting_Operation = BACNET_LIGHTS_STOP;
                     target_value = data->Blink.End_Value;
@@ -807,10 +908,11 @@ static void lighting_command_blink_handler(
             }
         }
     }
-    target_value = lighting_command_normalized_range_clamp(data, target_value);
+    target_value =
+        lighting_command_normalized_range_clamp_nolock(data, target_value);
     /* clamp Tracking value inclusively within the Operating Range */
     operating_value =
-        lighting_command_operating_range_clamp(data, target_value);
+        lighting_command_operating_range_clamp_nolock(data, target_value);
     /* note: The blink-warn notifications shall not be reflected
        in the tracking value. */
     if (data->In_Progress == BACNET_LIGHTING_IDLE) {
@@ -823,18 +925,34 @@ static void lighting_command_blink_handler(
  * @brief Overrides the current lighting command with the provided value
  * @param data [in] dimmer data
  */
-void lighting_command_override(
+static void lighting_command_override_nolock(
     struct bacnet_lighting_command_data *data, float value)
 {
     float old_value;
 
-    if (!data) {
-        return;
-    }
     old_value = data->Tracking_Value;
     data->Tracking_Value = lighting_command_physical_range_clamp(value);
     lighting_command_tracking_value_event(
         data, old_value, data->Tracking_Value);
+}
+
+/**
+ * @brief Overrides the current lighting command with the provided value
+ * @param data [in] dimmer data
+ */
+void lighting_command_override(
+    struct bacnet_lighting_command_data *data, float value)
+{
+    if (!data) {
+        return;
+    }
+    if (data->Lock) {
+        data->Lock(data);
+    }
+    lighting_command_override_nolock(data, value);
+    if (data->Unlock) {
+        data->Unlock(data);
+    }
 }
 
 /**
@@ -847,9 +965,15 @@ void lighting_command_override_set(
     if (!data) {
         return;
     }
+    if (data->Lock) {
+        data->Lock(data);
+    }
     data->Overridden = true;
     data->Overridden_Momentary = false;
-    lighting_command_override(data, value);
+    lighting_command_override_nolock(data, value);
+    if (data->Unlock) {
+        data->Unlock(data);
+    }
 }
 
 /**
@@ -864,16 +988,23 @@ void lighting_command_override_clear(
     if (!data) {
         return;
     }
+    if (data->Lock) {
+        data->Lock(data);
+    }
     data->Overridden = false;
     data->Overridden_Momentary = false;
     old_value = data->Tracking_Value;
     /* clamp Tracking value within the Normalized Range */
-    normalized_value = lighting_command_normalized_range_clamp(data, value);
+    normalized_value =
+        lighting_command_normalized_range_clamp_nolock(data, value);
     /* clamp Tracking value inclusively within the Operating Range */
     operating_value =
-        lighting_command_operating_range_clamp(data, normalized_value);
+        lighting_command_operating_range_clamp_nolock(data, normalized_value);
     data->Tracking_Value = operating_value;
     lighting_command_tracking_value_event(data, old_value, operating_value);
+    if (data->Unlock) {
+        data->Unlock(data);
+    }
 }
 
 /**
@@ -886,9 +1017,15 @@ void lighting_command_override_momentary(
     if (!data) {
         return;
     }
+    if (data->Lock) {
+        data->Lock(data);
+    }
     data->Overridden = true;
     data->Overridden_Momentary = true;
-    lighting_command_override(data, value);
+    lighting_command_override_nolock(data, value);
+    if (data->Unlock) {
+        data->Unlock(data);
+    }
 }
 
 /**
@@ -902,8 +1039,14 @@ void lighting_command_refresh(struct bacnet_lighting_command_data *data)
     if (!data) {
         return;
     }
+    if (data->Lock) {
+        data->Lock(data);
+    }
     value = data->Tracking_Value;
     lighting_command_tracking_value_event(data, value, value);
+    if (data->Unlock) {
+        data->Unlock(data);
+    }
 }
 
 /**
@@ -981,8 +1124,11 @@ void lighting_command_fade_to(
     if (!data) {
         return;
     }
+    if (data->Lock) {
+        data->Lock(data);
+    }
     /* possibly interrupting a blink warn, so notify */
-    lighting_command_blink_stop_notify(data);
+    lighting_command_blink_stop_notify_nolock(data);
     /* configure the lighting operation */
     data->Fade_Time = fade_time;
     data->Lighting_Operation = BACNET_LIGHTS_FADE_TO;
@@ -990,6 +1136,9 @@ void lighting_command_fade_to(
     if (isgreaterequal(value, 1.0)) {
         /* the last value that was greater than or equal to 1.0%.*/
         data->Last_On_Value = value;
+    }
+    if (data->Unlock) {
+        data->Unlock(data);
     }
 }
 
@@ -1005,8 +1154,11 @@ void lighting_command_ramp_to(
     if (!data) {
         return;
     }
+    if (data->Lock) {
+        data->Lock(data);
+    }
     /* possibly interrupting a blink warn, so notify */
-    lighting_command_blink_stop_notify(data);
+    lighting_command_blink_stop_notify_nolock(data);
     /* configure the lighting operation */
     data->Ramp_Rate = lighting_command_ramp_rate_clamp(ramp_rate);
     data->Lighting_Operation = BACNET_LIGHTS_RAMP_TO;
@@ -1014,6 +1166,9 @@ void lighting_command_ramp_to(
     if (isgreaterequal(value, 1.0)) {
         /* the last value that was greater than or equal to 1.0%.*/
         data->Last_On_Value = value;
+    }
+    if (data->Unlock) {
+        data->Unlock(data);
     }
 }
 
@@ -1033,15 +1188,18 @@ void lighting_command_step(
     if (!data) {
         return;
     }
+    if (data->Lock) {
+        data->Lock(data);
+    }
     /* possibly interrupting a blink warn, so notify */
-    lighting_command_blink_stop_notify(data);
+    lighting_command_blink_stop_notify_nolock(data);
     /* configure the lighting operation */
     if (((operation == BACNET_LIGHTS_STEP_UP) ||
          (operation == BACNET_LIGHTS_STEP_DOWN)) &&
         (!islessgreater(data->Tracking_Value, 0.0))) {
         /* If the starting level of Tracking_Value is 0.0%,
         then this operation is ignored. */
-        return;
+        goto done;
     }
     data->Lighting_Operation = operation;
     data->Fade_Time = 0;
@@ -1050,29 +1208,34 @@ void lighting_command_step(
     if (operation == BACNET_LIGHTS_STEP_UP) {
         target_value = lighting_command_step_up_target_value(
             data->Tracking_Value, data->Step_Increment);
-        target_value =
-            lighting_command_normalized_on_range_clamp(data, target_value);
+        target_value = lighting_command_normalized_on_range_clamp_nolock(
+            data, target_value);
     } else if (operation == BACNET_LIGHTS_STEP_DOWN) {
         target_value = lighting_command_step_down_target_value(
             data->Tracking_Value, data->Step_Increment);
-        target_value =
-            lighting_command_normalized_on_range_clamp(data, target_value);
+        target_value = lighting_command_normalized_on_range_clamp_nolock(
+            data, target_value);
     } else if (operation == BACNET_LIGHTS_STEP_ON) {
         target_value = lighting_command_step_up_target_value(
             data->Tracking_Value, data->Step_Increment);
         target_value =
-            lighting_command_normalized_range_clamp(data, target_value);
+            lighting_command_normalized_range_clamp_nolock(data, target_value);
     } else if (operation == BACNET_LIGHTS_STEP_OFF) {
         target_value = lighting_command_step_down_target_value(
             data->Tracking_Value, data->Step_Increment);
         target_value =
-            lighting_command_normalized_range_clamp(data, target_value);
+            lighting_command_normalized_range_clamp_nolock(data, target_value);
     } else {
-        return;
+        goto done;
     }
     if (isgreaterequal(target_value, 1.0)) {
         /* the last value that was greater than or equal to 1.0%.*/
         data->Last_On_Value = target_value;
+    }
+
+done:
+    if (data->Unlock) {
+        data->Unlock(data);
     }
 }
 
@@ -1087,11 +1250,14 @@ void lighting_command_blink_warn(
     BACNET_LIGHTING_OPERATION operation,
     struct bacnet_lighting_command_warn_data *blink)
 {
-    if (!data) {
+    if (!data || !blink) {
         return;
     }
+    if (data->Lock) {
+        data->Lock(data);
+    }
     /* possibly interrupting a blink warn, so notify */
-    lighting_command_blink_stop_notify(data);
+    lighting_command_blink_stop_notify_nolock(data);
     /* configure the new warning */
     data->Lighting_Operation = operation;
     data->Blink.Target_Interval = blink->Interval;
@@ -1107,6 +1273,9 @@ void lighting_command_blink_warn(
     /* configure next interval */
     data->Blink.State = false;
     data->Blink.Interval = blink->Interval;
+    if (data->Unlock) {
+        data->Unlock(data);
+    }
 }
 
 /**
@@ -1119,13 +1288,19 @@ void lighting_command_stop(struct bacnet_lighting_command_data *data)
     if (!data) {
         return;
     }
+    if (data->Lock) {
+        data->Lock(data);
+    }
     /* possibly interrupting a blink warn, so notify */
-    lighting_command_blink_stop_notify(data);
+    lighting_command_blink_stop_notify_nolock(data);
     /* configure the lighting operation */
     data->Lighting_Operation = BACNET_LIGHTS_STOP;
     if (isgreaterequal(data->Tracking_Value, 1.0)) {
         /* the last value that was greater than or equal to 1.0%.*/
         data->Last_On_Value = data->Tracking_Value;
+    }
+    if (data->Unlock) {
+        data->Unlock(data);
     }
 }
 
@@ -1139,10 +1314,16 @@ void lighting_command_none(struct bacnet_lighting_command_data *data)
     if (!data) {
         return;
     }
+    if (data->Lock) {
+        data->Lock(data);
+    }
     /* possibly interrupting a blink warn, so notify */
-    lighting_command_blink_stop_notify(data);
+    lighting_command_blink_stop_notify_nolock(data);
     /* configure the lighting operation */
     data->Lighting_Operation = BACNET_LIGHTS_NONE;
+    if (data->Unlock) {
+        data->Unlock(data);
+    }
 }
 
 /**
@@ -1156,12 +1337,18 @@ void lighting_command_restore_on(
     if (!data) {
         return;
     }
+    if (data->Lock) {
+        data->Lock(data);
+    }
     /* possibly interrupting a blink warn, so notify */
-    lighting_command_blink_stop_notify(data);
+    lighting_command_blink_stop_notify_nolock(data);
     /* configure the lighting operation */
     data->Fade_Time = fade_time;
     data->Lighting_Operation = BACNET_LIGHTS_RESTORE_ON;
     data->Target_Level = data->Last_On_Value;
+    if (data->Unlock) {
+        data->Unlock(data);
+    }
 }
 
 /**
@@ -1175,12 +1362,18 @@ void lighting_command_default_on(
     if (!data) {
         return;
     }
+    if (data->Lock) {
+        data->Lock(data);
+    }
     /* possibly interrupting a blink warn, so notify */
-    lighting_command_blink_stop_notify(data);
+    lighting_command_blink_stop_notify_nolock(data);
     /* configure the lighting operation */
     data->Fade_Time = fade_time;
     data->Lighting_Operation = BACNET_LIGHTS_DEFAULT_ON;
     data->Target_Level = data->Default_On_Value;
+    if (data->Unlock) {
+        data->Unlock(data);
+    }
 }
 
 /**
@@ -1194,8 +1387,11 @@ void lighting_command_toggle_restore(
     if (!data) {
         return;
     }
+    if (data->Lock) {
+        data->Lock(data);
+    }
     /* possibly interrupting a blink warn, so notify */
-    lighting_command_blink_stop_notify(data);
+    lighting_command_blink_stop_notify_nolock(data);
     /* configure the lighting operation */
     data->Fade_Time = fade_time;
     data->Lighting_Operation = BACNET_LIGHTS_TOGGLE_RESTORE;
@@ -1205,6 +1401,9 @@ void lighting_command_toggle_restore(
     } else {
         /* not OFF, write 0.0% */
         data->Target_Level = 0.0f;
+    }
+    if (data->Unlock) {
+        data->Unlock(data);
     }
 }
 
@@ -1219,8 +1418,11 @@ void lighting_command_toggle_default(
     if (!data) {
         return;
     }
+    if (data->Lock) {
+        data->Lock(data);
+    }
     /* possibly interrupting a blink warn, so notify */
-    lighting_command_blink_stop_notify(data);
+    lighting_command_blink_stop_notify_nolock(data);
     /* configure the lighting operation */
     data->Fade_Time = fade_time;
     data->Lighting_Operation = BACNET_LIGHTS_TOGGLE_DEFAULT;
@@ -1231,12 +1433,49 @@ void lighting_command_toggle_default(
         /* not OFF, write 0.0% */
         data->Target_Level = 0.0f;
     }
+    if (data->Unlock) {
+        data->Unlock(data);
+    }
 }
 
+/**
+ * @brief Locks the lighting command for exclusive access
+ * @param data [in] dimmer data
+ */
+void lighting_command_lock(struct bacnet_lighting_command_data *data)
+{
+    if (!data) {
+        return;
+    }
+    if (data->Lock) {
+        data->Lock(data);
+    }
+}
+
+/**
+ * @brief Unlocks the lighting command for exclusive access
+ * @param data [in] dimmer data
+ */
+void lighting_command_unlock(struct bacnet_lighting_command_data *data)
+{
+    if (!data) {
+        return;
+    }
+    if (data->Unlock) {
+        data->Unlock(data);
+    }
+}
+
+/**
+ * @brief Initializes the lighting command data structure to default values
+ */
 void lighting_command_init(struct bacnet_lighting_command_data *data)
 {
     if (!data) {
         return;
+    }
+    if (data->Lock) {
+        data->Lock(data);
     }
     data->Tracking_Value = 0.0f;
     data->Lighting_Operation = BACNET_LIGHTS_NONE;
@@ -1262,4 +1501,9 @@ void lighting_command_init(struct bacnet_lighting_command_data *data)
     data->Blink.State = false;
     data->Notification_Head.next = NULL;
     data->Notification_Head.callback = NULL;
+    data->Timer_Notification_Head.next = NULL;
+    data->Timer_Notification_Head.callback = NULL;
+    if (data->Unlock) {
+        data->Unlock(data);
+    }
 }

--- a/src/bacnet/basic/sys/lighting_command.h
+++ b/src/bacnet/basic/sys/lighting_command.h
@@ -42,6 +42,13 @@ struct lighting_command_timer_notification {
 };
 
 /**
+ * @brief Callback for locking shared state during lighting command processing
+ * @param data - dimmer data structure
+ */
+typedef void (*lighting_command_lock_callback)(
+    struct bacnet_lighting_command_data *);
+
+/**
  * @brief Callback that manipulates the value at the specified priority slot
     after a delay of Egress_Time seconds.
  * @param object_instance object-instance number of the object
@@ -91,6 +98,10 @@ typedef struct bacnet_lighting_command_data {
     uint32_t Key;
     struct lighting_command_notification Notification_Head;
     struct lighting_command_timer_notification Timer_Notification_Head;
+    /* lock for accessing shared state */
+    lighting_command_lock_callback Lock;
+    lighting_command_lock_callback Unlock;
+    void *Context;
 } BACNET_LIGHTING_COMMAND_DATA;
 
 #ifdef __cplusplus

--- a/src/bacnet/basic/sys/lighting_command.h
+++ b/src/bacnet/basic/sys/lighting_command.h
@@ -128,6 +128,10 @@ void lighting_command_blink_warn(
     BACNET_LIGHTING_OPERATION operation,
     struct bacnet_lighting_command_warn_data *blink);
 BACNET_STACK_EXPORT
+void lighting_command_blink_copy(
+    struct bacnet_lighting_command_data *data,
+    struct bacnet_lighting_command_warn_data *blink);
+BACNET_STACK_EXPORT
 void lighting_command_stop(struct bacnet_lighting_command_data *data);
 BACNET_STACK_EXPORT
 void lighting_command_none(struct bacnet_lighting_command_data *data);
@@ -177,6 +181,66 @@ float lighting_command_normalized_on_range_clamp(
     struct bacnet_lighting_command_data *data, float value);
 BACNET_STACK_EXPORT
 float lighting_command_physical_range_clamp(float value);
+
+BACNET_STACK_EXPORT
+void lighting_command_trim_set(
+    struct bacnet_lighting_command_data *data,
+    float High_End_Trim,
+    float Low_End_Trim,
+    uint32_t Trim_Fade_Time);
+BACNET_STACK_EXPORT
+void lighting_command_key_set(
+    struct bacnet_lighting_command_data *data, uint32_t key);
+BACNET_STACK_EXPORT
+void lighting_command_tracking_value_callback_set(
+    struct bacnet_lighting_command_data *data,
+    lighting_command_tracking_value_callback cb);
+BACNET_STACK_EXPORT
+BACNET_LIGHTING_IN_PROGRESS
+lighting_command_in_progress_get(struct bacnet_lighting_command_data *data);
+BACNET_STACK_EXPORT
+void lighting_command_in_progress_set(
+    struct bacnet_lighting_command_data *data,
+    BACNET_LIGHTING_IN_PROGRESS in_progress);
+BACNET_STACK_EXPORT
+float lighting_command_tracking_value_get(
+    struct bacnet_lighting_command_data *data);
+BACNET_STACK_EXPORT
+void lighting_command_tracking_value_set(
+    struct bacnet_lighting_command_data *data, float value);
+BACNET_STACK_EXPORT
+void lighting_command_blink_warn_feature_set(
+    struct bacnet_lighting_command_data *data,
+    float off_value,
+    uint16_t interval,
+    uint16_t count);
+BACNET_STACK_EXPORT
+bool lighting_command_blink_egress_active(
+    struct bacnet_lighting_command_data *data);
+BACNET_STACK_EXPORT
+bool lighting_command_out_of_service_get(
+    struct bacnet_lighting_command_data *data);
+BACNET_STACK_EXPORT
+void lighting_command_out_of_service_set(
+    struct bacnet_lighting_command_data *data, bool value);
+BACNET_STACK_EXPORT
+float lighting_command_last_on_value_get(
+    struct bacnet_lighting_command_data *data);
+BACNET_STACK_EXPORT
+void lighting_command_last_on_value_set(
+    struct bacnet_lighting_command_data *data, float value);
+BACNET_STACK_EXPORT
+float lighting_command_default_on_value_get(
+    struct bacnet_lighting_command_data *data);
+BACNET_STACK_EXPORT
+void lighting_command_default_on_value_set(
+    struct bacnet_lighting_command_data *data, float value);
+BACNET_STACK_EXPORT
+bool lighting_command_overridden_status(
+    struct bacnet_lighting_command_data *data);
+
+BACNET_STACK_EXPORT
+bool lighting_command_active(struct bacnet_lighting_command_data *data);
 
 BACNET_STACK_EXPORT
 void lighting_command_lock(struct bacnet_lighting_command_data *data);

--- a/src/bacnet/basic/sys/lighting_command.h
+++ b/src/bacnet/basic/sys/lighting_command.h
@@ -179,6 +179,11 @@ BACNET_STACK_EXPORT
 float lighting_command_physical_range_clamp(float value);
 
 BACNET_STACK_EXPORT
+void lighting_command_lock(struct bacnet_lighting_command_data *data);
+BACNET_STACK_EXPORT
+void lighting_command_unlock(struct bacnet_lighting_command_data *data);
+
+BACNET_STACK_EXPORT
 void lighting_command_refresh(struct bacnet_lighting_command_data *data);
 BACNET_STACK_EXPORT
 void lighting_command_init(struct bacnet_lighting_command_data *data);


### PR DESCRIPTION
This pull request introduces several improvements to the lighting command system, focusing on thread safety and API enhancements. The main changes include adding locking to critical sections in the lighting command logic to ensure thread safety, refactoring functions to provide both locked and non-locked variants and adding a new API for accessing lighting command data by object instance.

**Thread safety and locking improvements: **

* Added locking and unlocking in notification add functions and various value clamping and override functions in `lighting_command.c` to prevent race conditions when accessing or modifying shared lighting command data. New `_nolock` variants of several functions were introduced for internal use when the lock is already held.

**API enhancements: **

* Added a new function `Lighting_Output_Lighting_Command_Data` to retrieve the lighting command data for a given object instance, along with the corresponding declaration in the header file.
These changes improve the reliability and maintainability of the lighting command subsystem, especially in multi-threaded environments.