### PR TITLE
feat: add Modbus RTU to BACnet MS/TP gateway application

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1199,6 +1199,21 @@ if(BACNET_STACK_BUILD_APPS)
     )
   endif()
 
+  # Modbus Gateway - POSIX only (uses serial port / Modbus RTU)
+  if(NOT WIN32)
+    add_executable(modbusgw
+      apps/modbus-gateway/main.c
+      apps/modbus-gateway/point_table.c
+      apps/modbus-gateway/modbus_rtu.c
+      src/bacnet/basic/sys/cJSON.c)
+    target_include_directories(modbusgw PRIVATE
+      apps/modbus-gateway
+      src/bacnet/basic/sys)
+    target_link_libraries(modbusgw PRIVATE ${PROJECT_NAME} m)
+  else()
+    message(STATUS "BACNET: modbusgw skipped (Windows/MinGW not supported)")
+  endif()
+
   if(BACDL_BIP AND BACDL_BIP6)
     add_executable(
       router-ipv6

--- a/Makefile
+++ b/Makefile
@@ -256,6 +256,22 @@ mstpcap:
 mstpcrc:
 	$(MAKE) -s -C apps $@
 
+.PHONY: modbus-gateway
+modbus-gateway:
+	$(MAKE) -C apps modbus-gateway
+
+.PHONY: modbus-gateway-clean
+modbus-gateway-clean:
+	$(MAKE) -C apps modbus-gateway-clean
+
+.PHONY: modbus-gateway-mstp
+modbus-gateway-mstp:
+	$(MAKE) BACDL=mstp -C apps modbus-gateway-mstp
+
+.PHONY: modbus-gateway-mstp-clean
+modbus-gateway-mstp-clean:
+	$(MAKE) -C apps modbus-gateway-mstp-clean
+
 .PHONY: uevent
 uevent:
 	$(MAKE) -s -C apps $@

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -268,7 +268,8 @@ SUBDIRS = lib readprop writeprop readfile writefile reinit server dcc \
 	writepropm uptransfer getevent uevent abort error event ack-alarm \
 	server-client add-list-element remove-list-element create-object \
 	who-am-i you-are apdu writegroup dmbrcap \
-	delete-object server-discover server-basic server-mini
+	delete-object server-discover server-basic server-mini \
+	modbus-gateway
 
 ifneq (,$(filter $(BACDL),bip all))
 SUBDIRS += whoisrouter iamrouter initrouter whatisnetnum netnumis
@@ -533,6 +534,24 @@ router-mstp: $(BACNET_LIB_TARGET)
 .PHONY: router-mstp-clean
 router-mstp-clean:
 	$(MAKE) -C router-mstp clean
+
+.PHONY: modbus-gateway
+modbus-gateway: $(BACNET_LIB_TARGET)
+	$(MAKE) -B -C modbus-gateway
+
+.PHONY: modbus-gateway-clean
+modbus-gateway-clean:
+	$(MAKE) -C modbus-gateway clean
+	rm -f ../bin/modbusgw
+
+.PHONY: modbus-gateway-mstp
+modbus-gateway-mstp: $(BACNET_LIB_TARGET)
+	$(MAKE) BACDL=mstp -B -C modbus-gateway TARGET=modbusgw-mstp
+
+.PHONY: modbus-gateway-mstp-clean
+modbus-gateway-mstp-clean:
+	$(MAKE) -C modbus-gateway clean
+	rm -f ../bin/modbusgw-mstp
 
 .PHONY: fuzz-libfuzzer
 fuzz-libfuzzer: $(BACNET_LIB_TARGET)

--- a/apps/modbus-gateway/Makefile
+++ b/apps/modbus-gateway/Makefile
@@ -1,0 +1,97 @@
+# Makefile – Generic Modbus RTU <-> BACnet Gateway
+# Inherits common variables (CC, CFLAGS, LFLAGS, BACNET_LIB_TARGET, etc.) from apps/Makefile
+
+# Executable name (default: modbusgw; MS/TP specific build: modbusgw-mstp)
+TARGET = modbusgw
+
+# BACnet object directory (BACNET_SRC_DIR is set by the parent apps/Makefile)
+BACNET_OBJECT_DIR = $(BACNET_SRC_DIR)/bacnet/basic/object
+BACNET_SYS_DIR = $(BACNET_SRC_DIR)/bacnet/basic/sys
+
+# Source files
+SRC = main.c \
+	point_table.c \
+	modbus_rtu.c \
+	$(BACNET_SYS_DIR)/cJSON.c \
+	$(BACNET_OBJECT_DIR)/device.c \
+	$(BACNET_OBJECT_DIR)/ai.c \
+	$(BACNET_OBJECT_DIR)/ao.c \
+	$(BACNET_OBJECT_DIR)/av.c \
+	$(BACNET_OBJECT_DIR)/bi.c \
+	$(BACNET_OBJECT_DIR)/bo.c \
+	$(BACNET_OBJECT_DIR)/bv.c \
+	$(BACNET_OBJECT_DIR)/nc.c \
+	$(BACNET_OBJECT_DIR)/netport.c \
+	$(BACNET_OBJECT_DIR)/trendlog.c \
+	$(BACNET_OBJECT_DIR)/bacfile.c \
+	$(BACNET_OBJECT_DIR)/calendar.c \
+	$(BACNET_OBJECT_DIR)/schedule.c \
+	$(BACNET_OBJECT_DIR)/program.c \
+	$(BACNET_OBJECT_DIR)/lc.c \
+	$(BACNET_OBJECT_DIR)/lsp.c \
+	$(BACNET_OBJECT_DIR)/msv.c \
+	$(BACNET_OBJECT_DIR)/mso.c \
+	$(BACNET_OBJECT_DIR)/timer.c \
+	$(BACNET_OBJECT_DIR)/structured_view.c \
+	$(BACNET_OBJECT_DIR)/csv.c \
+	$(BACNET_OBJECT_DIR)/bitstring_value.c \
+	$(BACNET_OBJECT_DIR)/osv.c \
+	$(BACNET_OBJECT_DIR)/piv.c \
+	$(BACNET_OBJECT_DIR)/iv.c \
+	$(BACNET_OBJECT_DIR)/loop.c \
+	$(BACNET_OBJECT_DIR)/ms-input.c \
+	$(BACNET_OBJECT_DIR)/lo.c \
+	$(BACNET_OBJECT_DIR)/time_value.c \
+	$(BACNET_OBJECT_DIR)/command.c \
+	$(BACNET_OBJECT_DIR)/channel.c \
+	$(BACNET_OBJECT_DIR)/acc.c \
+	$(BACNET_OBJECT_DIR)/auditlog.c \
+	$(BACNET_OBJECT_DIR)/blo.c \
+	$(BACNET_OBJECT_DIR)/color_object.c \
+	$(BACNET_OBJECT_DIR)/color_temperature.c \
+	$(BACNET_OBJECT_DIR)/credential_data_input.c \
+	$(BACNET_OBJECT_DIR)/access_credential.c \
+	$(BACNET_OBJECT_DIR)/access_door.c \
+	$(BACNET_OBJECT_DIR)/access_point.c \
+	$(BACNET_OBJECT_DIR)/access_rights.c \
+	$(BACNET_OBJECT_DIR)/access_user.c \
+	$(BACNET_OBJECT_DIR)/access_zone.c \
+	$(BACNET_OBJECT_DIR)/lsz.c
+
+# TARGET_EXT is defined by the parent apps/Makefile (.exe or empty)
+TARGET_BIN = ${TARGET}$(TARGET_EXT)
+
+OBJS += ${SRC:.c=.o}
+
+# Add sys directory so cJSON.h can be found
+CFLAGS += -I$(BACNET_SYS_DIR)
+
+all: ${BACNET_LIB_TARGET} Makefile ${TARGET_BIN}
+
+${TARGET_BIN}: ${OBJS} Makefile ${BACNET_LIB_TARGET}
+	${CC} ${PFLAGS} ${OBJS} ${LFLAGS} -lm -o $@
+	size $@
+	cp $@ ../../bin
+
+${BACNET_LIB_TARGET}:
+	( cd ${BACNET_LIB_DIR} ; $(MAKE) clean ; $(MAKE) -s )
+
+.c.o:
+	${CC} -c ${CFLAGS} $*.c -o $@
+
+.PHONY: depend
+depend:
+	rm -f .depend
+	${CC} -MM ${CFLAGS} *.c >> .depend
+
+.PHONY: clean
+clean:
+	rm -f core ${TARGET_BIN} ${OBJS} $(TARGET).map
+	rm -f ../../bin/$(TARGET_BIN)
+
+.PHONY: install
+install: ${TARGET_BIN}
+	install -m 755 ${TARGET_BIN} /usr/local/bin/
+
+.PHONY: include
+include: .depend

--- a/apps/modbus-gateway/README.md
+++ b/apps/modbus-gateway/README.md
@@ -1,0 +1,236 @@
+# Modbus RTU ↔ BACnet Gateway
+
+A generic gateway that bridges **Modbus RTU** devices to a **BACnet** network.
+It reads Modbus registers/coils from one or more slaves and exposes them as BACnet
+Analog Input (AI), Analog Output (AO), Binary Input (BI), or Binary Output (BO)
+objects — all configured via a single JSON file at runtime.
+
+The BACnet datalink type is selected at runtime via `gateway_config.json`
+(`"mstp"`, `"bip"`, `"bip6"`, `"ethernet"`), so no recompilation is needed
+when switching between datalinks.
+
+Tested on Raspberry Pi (Raspberry Pi OS), but portable to any Linux/POSIX platform.
+
+---
+
+## Hardware Setup
+
+```
+  [Modbus RTU devices]──RS-485──[RS-485↔USB #1  /dev/ttyUSB1]──┐
+                                                                ├── Host (e.g. Raspberry Pi)
+  [BACnet MS/TP bus  ]──RS-485──[RS-485↔USB #0  /dev/ttyUSB0]──┘
+```
+
+> When using **BACnet/IP**, only one serial port (for Modbus) is needed.
+> The BACnet side communicates over the existing Ethernet/Wi-Fi interface.
+
+| Role                    | Default                  | Default Baud |
+|-------------------------|--------------------------|--------------|
+| BACnet MS/TP (master)   | `/dev/ttyUSB0`           | 38400 bps    |
+| BACnet/IP               | network interface (eth0) | —            |
+| Modbus RTU   (master)   | `/dev/ttyUSB1`           | 9600 bps     |
+
+---
+
+## Build
+
+### Prerequisites (Debian / Raspberry Pi OS)
+
+```bash
+sudo apt update
+sudo apt install -y build-essential
+```
+
+No external libraries are required. The gateway uses the bundled `cJSON` parser and
+the bacnet-stack data-link layer that is already part of this repository.
+
+### Compile
+
+```bash
+# From the repository root – default datalink (BACnet/IP)
+make modbus-gateway-clean
+make modbus-gateway
+
+# MS/TP specific build
+make modbus-gateway-mstp-clean
+make modbus-gateway-mstp
+```
+
+Output binary: `bin/modbusgw, apps/modbus-gateway/modbusgw` (or `bin/modbusgw-mstp, apps/modbus-gateway/modbusgw-mstp` for the MS/TP specific build)
+
+---
+
+## Configuration — `gateway_config.json`
+
+All runtime settings are read from `gateway_config.json` (in the working directory
+by default). Pass a different path as the first CLI argument if needed.
+
+```json
+{
+  "bacnet": {
+    "device_instance": 50001,
+    "device_name":     "Modbus-Gateway",
+    "vendor_id":       260,
+
+    "datalink_type":   "mstp",
+
+    "iface":           "/dev/ttyUSB0",
+
+    "mstp_baud":       38400,
+    "mstp_mac":        1,
+    "mstp_max_master": 5,
+    "mstp_net":        2,
+
+    "bip_port":        47808
+  },
+
+  "modbus": {
+    "port":             "/dev/ttyUSB1",
+    "baud":             9600,
+    "poll_interval_sec": 5
+  },
+
+  "points": [
+    {
+      "name":             "Temperature",
+      "description":      "Room Temperature",
+      "enabled":          true,
+      "bacnet_type":      "AI",
+      "bacnet_instance":  0,
+      "units":            "DEGREES_CELSIUS",
+      "modbus_slave":     1,
+      "modbus_func":      "HOLDING_REGISTER",
+      "modbus_address":   1,
+      "scale":            0.1,
+      "offset":           0.0,
+      "range_min":       -40.0,
+      "range_max":        125.0
+    },
+    {
+      "name":             "Humidity",
+      "description":      "Relative Humidity",
+      "enabled":          true,
+      "bacnet_type":      "AI",
+      "bacnet_instance":  1,
+      "units":            "PERCENT_RELATIVE_HUMIDITY",
+      "modbus_slave":     1,
+      "modbus_func":      "HOLDING_REGISTER",
+      "modbus_address":   0,
+      "scale":            0.1,
+      "offset":           0.0,
+      "range_min":        0.0,
+      "range_max":        100.0
+    }
+  ]
+}
+```
+
+### `bacnet` section
+
+| Key               | Type    | Description                                                      |
+|-------------------|---------|------------------------------------------------------------------|
+| `device_instance` | uint32  | BACnet Device Object Instance (1 – 4194302)                      |
+| `device_name`     | string  | BACnet Device Object Name                                        |
+| `vendor_id`       | uint16  | BACnet Vendor Identifier                                         |
+| `datalink_type`   | string  | Datalink type: `"mstp"`, `"bip"`, `"bip6"`, `"ethernet"`        |
+| `iface`           | string  | Serial port for MS/TP (e.g. `/dev/ttyUSB0`) or network interface for BACnet/IP (e.g. `eth0`) |
+| `mstp_baud`       | uint32  | MS/TP baud rate (e.g. 9600, 19200, 38400, 76800)                 |
+| `mstp_mac`        | uint8   | MS/TP MAC address of this node (0 – 127)                         |
+| `mstp_max_master` | uint8   | Highest MAC address polled in the token ring                     |
+| `mstp_net`        | uint16  | BACnet network number (0 = local)                                |
+| `bip_port`        | uint16  | UDP port for BACnet/IP (default: 47808)                          |
+
+### `modbus` section
+
+| Key                | Type   | Description                                      |
+|--------------------|--------|--------------------------------------------------|
+| `port`             | string | Serial port for Modbus RTU                       |
+| `baud`             | uint32 | Baud rate                                        |
+| `poll_interval_sec`| int    | Seconds between Modbus polling cycles            |
+
+### `points` array — per-point fields
+
+| Key               | Type    | Description                                                         |
+|-------------------|---------|---------------------------------------------------------------------|
+| `name`            | string  | BACnet Object Name (must be unique)                                 |
+| `description`     | string  | BACnet Description property                                         |
+| `enabled`         | bool    | `false` skips this point entirely                                   |
+| `bacnet_type`     | string  | `"AI"`, `"AO"`, `"BI"`, or `"BO"`                                  |
+| `bacnet_instance` | uint32  | BACnet Object Instance number                                       |
+| `units`           | string  | BACnet Engineering Units name (e.g. `"DEGREES_CELSIUS"`)           |
+| `modbus_slave`    | uint8   | Modbus slave ID (1 – 247)                                           |
+| `modbus_func`     | string  | `"COIL"`, `"DISCRETE_INPUT"`, `"HOLDING_REGISTER"`, `"INPUT_REGISTER"` |
+| `modbus_address`  | uint16  | Modbus register / coil address (0-based)                            |
+| `scale`           | float   | Multiplier applied to the raw value: `eng = raw × scale + offset`  |
+| `offset`          | float   | Offset added after scaling                                          |
+| `range_min/max`   | float   | Out-of-range check; sets Out-of-Service if violated                 |
+
+> **Compile-time defaults** (used when `gateway_config.json` is absent or a key is
+> missing) are defined in `gateway_config.h`.
+
+---
+
+## Running
+
+```bash
+# Use gateway_config.json in the current directory
+sudo ./modbusgw
+
+# Specify a different config file
+sudo ./modbusgw /etc/modbus-gateway/my_config.json
+
+# Override Device Instance at the command line
+sudo ./modbusgw 12345
+
+# Both config file and instance override
+sudo ./modbusgw /etc/modbus-gateway/my_config.json 12345
+```
+
+> To run without `sudo`, add your user to the `dialout` group:
+> ```bash
+> sudo usermod -aG dialout $USER
+> # Log out and back in for the change to take effect.
+> ```
+
+---
+
+## Operation Flow
+
+```
+[Startup]
+  │
+  ├─ Parse CLI arguments (config path, device instance override)
+  ├─ Load gateway_config.json  →  BACnet & Modbus settings + point table
+  ├─ Initialize BACnet datalink  (mstp / bip / bip6 / ethernet via dlenv_init)
+  ├─ Create BACnet objects from point table  (AI / AO / BI / BO)
+  ├─ Initialize Modbus RTU port
+  ├─ Broadcast I-Am
+  ├─ Initial Modbus poll
+  │
+  └─ [Main loop] ────────────────────────────────────────────────┐
+       │                                                         │
+       ├─ datalink_receive()                                     │
+       │     Receive BACnet frames → npdu_handler()             │
+       │                                                         │
+       ├─ 1-second BACnet timers                                 │
+       │     dcc_timer / tsm_timer / Device_Timer                │
+       │                                                         │
+       └─ Modbus poll  (every poll_interval_sec seconds)         │
+             Read registers/coils for each enabled point         │
+             → Update BACnet Present_Value                       │
+             → On failure: set Out-of-Service = true ────────────┘
+```
+
+---
+
+## File Overview
+
+| File                   | Description                                                      |
+|------------------------|------------------------------------------------------------------|
+| `gateway_config.json`  | Runtime configuration (BACnet, Modbus, point table)             |
+| `gateway_config.h`     | Compile-time defaults (fallback when JSON key is absent)        |
+| `point_table.h/c`      | JSON loader and Modbus-to-BACnet point mapping engine           |
+| `modbus_rtu.h/c`       | Modbus RTU master driver (CRC-16, FC01/02/03/04)                |
+| `main.c`               | Gateway main loop                                               |
+| `../../src/bacnet/basic/sys/cJSON.h/c`            | Bundled cJSON library for JSON parsing                          |
+| `Makefile`             | Build script                                                    |

--- a/apps/modbus-gateway/gateway_config.h
+++ b/apps/modbus-gateway/gateway_config.h
@@ -1,0 +1,51 @@
+/**
+ * @file gateway_config.h
+ * @brief Compile-time default constants for the Modbus RTU <-> BACnet MSTP
+ * gateway.
+ *
+ * These values are used when gateway_config.json is absent or incomplete.
+ * Override at runtime by editing gateway_config.json.
+ *
+ * @author Jihye Ahn <jen.ahn@lge.com>
+ *
+ * @copyright Copyright (c) 2026 LG Electronics Inc.
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef GATEWAY_CONFIG_H
+#define GATEWAY_CONFIG_H
+
+/* =======================================================================
+ * BACnet datalink defaults
+ * =======================================================================*/
+/** Default datalink type: "mstp", "bip", "bip6", "ethernet" */
+#define GW_DATALINK_TYPE "mstp"
+/** Default network interface / serial port used by the datalink */
+#define GW_BACNET_IFACE "/dev/ttyUSB0"
+
+/* =======================================================================
+ * BACnet MS/TP defaults (used when datalink_type == "mstp")
+ * =======================================================================*/
+#define GW_DEVICE_INSTANCE 50002U
+#define GW_DEVICE_NAME "Modbus Gateway"
+#define GW_MSTP_MAC_ADDRESS 2
+#define GW_MSTP_BAUD 38400
+#define GW_VENDOR_ID 260
+
+/* =======================================================================
+ * BACnet/IP defaults (used when datalink_type == "bip")
+ * =======================================================================*/
+#define GW_BIP_PORT 0xBAC0U /**< 47808 */
+
+/* =======================================================================
+ * Modbus RTU defaults
+ * =======================================================================*/
+#define GW_MODBUS_PORT "/dev/ttyUSB1"
+#define GW_MODBUS_BAUD 9600
+#define GW_POLL_INTERVAL_SEC 5
+
+/* =======================================================================
+ * Point table limits
+ * =======================================================================*/
+#define GW_MAX_POINTS 256
+
+#endif /* GATEWAY_CONFIG_H */

--- a/apps/modbus-gateway/main.c
+++ b/apps/modbus-gateway/main.c
@@ -1,0 +1,320 @@
+/**
+ * @file main.c
+ * @brief Generic Modbus RTU <-> BACnet Gateway
+ *
+ * Overview:
+ *  1. Load gateway_config.json  (BACnet settings, Modbus settings, point table)
+ *  2. Initialize BACnet datalink (MS/TP, BACnet/IP, Ethernet, etc.)
+ *  3. Create BACnet objects defined in the point table (AI / AO / BI / BO)
+ *  4. Initialize Modbus RTU master
+ *  5. Main loop
+ *     a) Receive and dispatch BACnet frames
+ *     b) Run 1-second BACnet timers
+ *     c) Poll Modbus every poll_interval_sec seconds
+ *
+ * Usage:
+ *   sudo ./modbusgw [config.json] [device_instance_override]
+ *
+ * Default config file: gateway_config.json (in the working directory)
+ *
+ * The BACnet datalink type is selected by the "datalink_type" field in the
+ * "bacnet" section of the JSON config file (e.g. "mstp", "bip", "bip6",
+ * "ethernet").  All datalink-specific parameters are also read from JSON.
+ * Alternatively, the standard BACNET_* environment variables can be used to
+ * override any setting before the process starts.
+ *
+ * @author Jihye Ahn <jen.ahn@lge.com>
+ *
+ * @copyright Copyright (c) 2026 LG Electronics Inc.
+ * SPDX-License-Identifier: GPL-2.0-or-later WITH GCC-exception-2.0
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ */
+
+/* ── Standard libraries ── */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <time.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+/* ── BACnet stack ── */
+#include "bacnet/bacdef.h"
+#include "bacnet/bacdcode.h"
+#include "bacnet/bacstr.h"
+#include "bacnet/npdu.h"
+#include "bacnet/apdu.h"
+#include "bacnet/iam.h"
+#include "bacnet/dcc.h"
+#include "bacnet/version.h"
+#include "bacnet/bacenum.h"
+#include "bacnet/basic/binding/address.h"
+#include "bacnet/basic/tsm/tsm.h"
+#include "bacnet/basic/services.h"
+#include "bacnet/basic/sys/debug.h"
+#include "bacnet/datalink/datalink.h"
+#include "bacnet/datalink/dlenv.h"
+#include "bacnet/basic/object/device.h"
+
+/* ── This project ── */
+#include "gateway_config.h"
+#include "modbus_rtu.h"
+#include "point_table.h"
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Helper macros
+ * ──────────────────────────────────────────────────────────────────────*/
+#define STRINGIFY_IMPL(x) #x
+#define STRINGIFY(x) STRINGIFY_IMPL(x)
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Globals
+ * ──────────────────────────────────────────────────────────────────────*/
+
+/** BACnet receive buffer */
+static uint8_t Rx_Buf[MAX_MPDU] = { 0 };
+
+/** Program running flag – cleared by SIGINT / SIGTERM */
+static volatile bool Running = true;
+
+/** Gateway configuration (loaded from JSON) */
+static GW_CONFIG Gw_Config;
+
+/** Point table (loaded from JSON) */
+static GW_POINT_TABLE Point_Table;
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Signal handler
+ * ──────────────────────────────────────────────────────────────────────*/
+static void signal_handler(int sig)
+{
+    (void)sig;
+    Running = false;
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Register BACnet service handlers
+ * ──────────────────────────────────────────────────────────────────────*/
+static void Init_Service_Handlers(void)
+{
+    Device_Init(NULL);
+
+    apdu_set_unconfirmed_handler(
+        SERVICE_UNCONFIRMED_WHO_IS, handler_who_is_unicast);
+    apdu_set_unconfirmed_handler(SERVICE_UNCONFIRMED_WHO_HAS, handler_who_has);
+    apdu_set_unrecognized_service_handler_handler(handler_unrecognized_service);
+    apdu_set_confirmed_handler(
+        SERVICE_CONFIRMED_READ_PROPERTY, handler_read_property);
+    apdu_set_confirmed_handler(
+        SERVICE_CONFIRMED_READ_PROP_MULTIPLE, handler_read_property_multiple);
+    apdu_set_confirmed_handler(
+        SERVICE_CONFIRMED_WRITE_PROPERTY, handler_write_property);
+    apdu_set_unconfirmed_handler(
+        SERVICE_UNCONFIRMED_UTC_TIME_SYNCHRONIZATION, handler_timesync_utc);
+    apdu_set_unconfirmed_handler(
+        SERVICE_UNCONFIRMED_TIME_SYNCHRONIZATION, handler_timesync);
+    apdu_set_confirmed_handler(
+        SERVICE_CONFIRMED_SUBSCRIBE_COV, handler_cov_subscribe);
+    apdu_set_confirmed_handler(
+        SERVICE_CONFIRMED_DEVICE_COMMUNICATION_CONTROL,
+        handler_device_communication_control);
+    apdu_set_confirmed_handler(
+        SERVICE_CONFIRMED_REINITIALIZE_DEVICE, handler_reinitialize_device);
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * main
+ * ──────────────────────────────────────────────────────────────────────*/
+int main(int argc, char *argv[])
+{
+    const char *config_file = "gateway_config.json";
+    uint32_t override_inst = 0;
+    BACNET_ADDRESS src = { 0 };
+    uint16_t pdu_len = 0;
+    time_t current_sec = 0;
+    time_t last_sec = 0;
+    time_t last_poll_sec = 0;
+    uint32_t elapsed_sec = 0;
+    char baud_str[16] = { 0 };
+    char mac_str[8] = { 0 };
+    char max_master_str[16] = { 0 };
+    char net_str[16] = { 0 };
+    char port_str[16] = { 0 };
+    int i;
+
+    /* ── Parse CLI arguments ──
+     *   argv[1] : optional path to JSON config file
+     *   argv[2] : optional Device Instance override (integer)
+     */
+    for (i = 1; i < argc; i++) {
+        char *end = NULL;
+        uint32_t v = (uint32_t)strtoul(argv[i], &end, 0);
+        if (end != argv[i] && *end == '\0' && v > 0 &&
+            v <= BACNET_MAX_INSTANCE) {
+            /* pure number → device instance override */
+            override_inst = v;
+        } else {
+            /* string → config file path */
+            config_file = argv[i];
+        }
+    }
+
+    signal(SIGINT, signal_handler);
+    signal(SIGTERM, signal_handler);
+
+    /* Set stdout/stderr to unbuffered so log output appears immediately */
+#if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
+    setbuf(stdout, NULL);
+    setbuf(stderr, NULL);
+#endif
+
+    /* ── Load configuration and point table from JSON ── */
+    if (!point_table_load_json(&Gw_Config, &Point_Table, config_file)) {
+        fprintf(
+            stderr, "[GW] Failed to load '%s'. Check the file.\n", config_file);
+        return 1;
+    }
+
+    /* Apply device instance override from CLI */
+    if (override_inst) {
+        Gw_Config.device_instance = override_inst;
+    }
+
+    printf("===========================================\n");
+    printf(" Generic Modbus RTU <-> BACnet Gateway\n");
+    printf(" BACnet Stack v%s\n", BACNET_VERSION_TEXT);
+    printf(" Config          : %s\n", config_file);
+    printf(
+        " Device          : %s [%u]\n", Gw_Config.device_name,
+        Gw_Config.device_instance);
+    printf(" Datalink        : %s\n", Gw_Config.datalink_type);
+    printf(" BACnet Iface    : %s\n", Gw_Config.bacnet_iface);
+    printf(
+        " Modbus Port     : %s @ %u bps\n", Gw_Config.modbus_port,
+        Gw_Config.modbus_baud);
+    printf(" Poll Interval   : %d sec\n", Gw_Config.poll_interval_sec);
+    printf(" Points          : %d\n", Point_Table.count);
+    printf("===========================================\n");
+
+    /* ── BACnet service handlers (Device_Init is called inside) ── */
+    Init_Service_Handlers();
+
+    /* ── BACnet Device configuration (must be after Device_Init) ── */
+    Device_Set_Object_Instance_Number(Gw_Config.device_instance);
+    {
+        BACNET_CHARACTER_STRING name_str;
+        characterstring_init_ansi(&name_str, Gw_Config.device_name);
+        Device_Set_Object_Name(&name_str);
+    }
+    Device_Set_System_Status(STATUS_OPERATIONAL, true);
+    Device_Set_Vendor_Identifier(Gw_Config.vendor_id);
+
+    /* ── Configure BACnet datalink via environment variables ──
+     *
+     * The datalink type is read from JSON ("datalink_type" field).
+     * Supported values: "mstp", "bip", "bip6", "ethernet"
+     * All standard BACNET_* env vars can also be pre-set externally to
+     * override any of these settings before the process starts.
+     */
+#if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
+    setenv("BACNET_DATALINK", Gw_Config.datalink_type, 0);
+    setenv("BACNET_IFACE", Gw_Config.bacnet_iface, 0);
+
+    if (strcmp(Gw_Config.datalink_type, "mstp") == 0) {
+        snprintf(baud_str, sizeof(baud_str), "%u", Gw_Config.mstp_baud);
+        snprintf(mac_str, sizeof(mac_str), "%u", Gw_Config.mstp_mac);
+        snprintf(
+            max_master_str, sizeof(max_master_str), "%u",
+            Gw_Config.mstp_max_master);
+        snprintf(net_str, sizeof(net_str), "%u", Gw_Config.mstp_net);
+        setenv("BACNET_MSTP_BAUD", baud_str, 1);
+        setenv("BACNET_MSTP_MAC", mac_str, 1);
+        setenv("BACNET_MAX_MASTER", max_master_str, 1);
+        setenv("BACNET_MSTP_NET", net_str, 1);
+    } else if (
+        strcmp(Gw_Config.datalink_type, "bip") == 0 ||
+        strcmp(Gw_Config.datalink_type, "bip6") == 0) {
+        if (Gw_Config.bip_port != 0) {
+            snprintf(port_str, sizeof(port_str), "%u", Gw_Config.bip_port);
+            setenv("BACNET_IP_PORT", port_str, 1);
+        }
+    }
+#endif /* __linux__ || __unix__ || __APPLE__ */
+    dlenv_init();
+
+    if (!datalink_init(NULL)) {
+        fprintf(
+            stderr, "[GW] datalink_init() failed (datalink=%s, iface=%s)\n",
+            Gw_Config.datalink_type, Gw_Config.bacnet_iface);
+        return 1;
+    }
+    atexit(datalink_cleanup);
+
+    /* ── Create BACnet objects from point table ── */
+    point_table_init_bacnet_objects(&Point_Table);
+
+    /* ── Initialize Modbus RTU ── */
+    if (!Modbus_RTU_Init(Gw_Config.modbus_port, Gw_Config.modbus_baud, 1)) {
+        fprintf(
+            stderr, "[GW] Modbus init failed on %s – will retry on next poll\n",
+            Gw_Config.modbus_port);
+    }
+    atexit(Modbus_RTU_Cleanup);
+
+    /* ── Broadcast I-Am ── */
+    Send_I_Am(&Handler_Transmit_Buffer[0]);
+
+    last_sec = last_poll_sec = time(NULL);
+
+    /* ── Initial poll immediately on startup ── */
+    point_table_poll_modbus(&Point_Table);
+    fflush(stdout);
+
+    /* ════════════════════════════════════════
+     * Main loop
+     * ════════════════════════════════════════*/
+    while (Running) {
+        current_sec = time(NULL);
+
+        /* ── Receive BACnet frames ── */
+        pdu_len = datalink_receive(&src, &Rx_Buf[0], MAX_MPDU, 10 /*ms*/);
+        if (pdu_len > 0) {
+            npdu_handler(&src, &Rx_Buf[0], pdu_len);
+        }
+
+        /* ── 1-second BACnet timer tasks ── */
+        elapsed_sec = (uint32_t)(current_sec - last_sec);
+        if (elapsed_sec > 0) {
+            last_sec = current_sec;
+            dcc_timer_seconds(elapsed_sec);
+            datalink_maintenance_timer(elapsed_sec);
+            dlenv_maintenance_timer(elapsed_sec);
+            tsm_timer_milliseconds(elapsed_sec * 1000);
+            Device_Timer(elapsed_sec * 1000);
+        }
+
+        /* ── COV task ── */
+        handler_cov_task();
+
+        /* ── Modbus polling ── */
+        if ((current_sec - last_poll_sec) >= Gw_Config.poll_interval_sec) {
+            last_poll_sec = current_sec;
+            point_table_poll_modbus(&Point_Table);
+        }
+    }
+
+    printf("\n[GW] Shutting down...\n");
+    return 0;
+}

--- a/apps/modbus-gateway/modbus_rtu.c
+++ b/apps/modbus-gateway/modbus_rtu.c
@@ -1,0 +1,697 @@
+/**
+ * @file modbus_rtu.c
+ * @brief Generic Modbus RTU master driver implementation.
+ *
+ * Supported: FC01, FC02, FC03, FC04, FC05, FC06
+ * CRC16 (polynomial 0xA001, Modbus standard)
+ *
+ * @author Jihye Ahn <jen.ahn@lge.com>
+ *
+ * @copyright Copyright (c) 2026 LG Electronics Inc.
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <time.h>
+#include <sys/ioctl.h>
+#include <sys/select.h>
+#include <termios.h>
+#endif /* __linux__ || __unix__ || __APPLE__ */
+
+#include "modbus_rtu.h"
+
+#if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
+
+/* -----------------------------------------------------------------------
+ * Internal state
+ * -----------------------------------------------------------------------*/
+static MODBUS_PORT g_port; /* fd is set to -1 in Modbus_RTU_Init() */
+static int g_port_initialized = 0; /* flag: first-time initialization done */
+
+/* -----------------------------------------------------------------------
+ * CRC16 (Modbus)
+ * -----------------------------------------------------------------------*/
+static uint16_t crc16_modbus(const uint8_t *buf, uint16_t len)
+{
+    uint16_t crc = 0xFFFF;
+    uint16_t i;
+    int j;
+    for (i = 0; i < len; i++) {
+        crc ^= buf[i];
+        for (j = 0; j < 8; j++) {
+            if (crc & 0x0001) {
+                crc = (crc >> 1) ^ 0xA001;
+            } else {
+                crc >>= 1;
+            }
+        }
+    }
+    return crc;
+}
+
+/* -----------------------------------------------------------------------
+ * Map baud rate to termios speed constant
+ * -----------------------------------------------------------------------*/
+static speed_t baud_to_speed(uint32_t baud)
+{
+    switch (baud) {
+        case 1200:
+            return B1200;
+        case 2400:
+            return B2400;
+        case 4800:
+            return B4800;
+        case 9600:
+            return B9600;
+        case 19200:
+            return B19200;
+        case 38400:
+            return B38400;
+        case 57600:
+            return B57600;
+        case 115200:
+            return B115200;
+        default:
+            return B9600;
+    }
+}
+
+/* -----------------------------------------------------------------------
+ * Open and configure the serial port
+ * -----------------------------------------------------------------------*/
+bool Modbus_RTU_Init(const char *port, uint32_t baud, uint8_t slave)
+{
+    struct termios tio;
+    speed_t spd;
+
+    /* Set fd to -1 on first call */
+    if (!g_port_initialized) {
+        g_port.fd = -1;
+        g_port_initialized = 1;
+    }
+
+    if (g_port.fd >= 0) {
+        /* Port is already open – close and re-initialize */
+        Modbus_RTU_Cleanup();
+    }
+
+    strncpy(
+        g_port.port, port ? port : MODBUS_DEFAULT_PORT,
+        sizeof(g_port.port) - 1);
+    g_port.baud = baud ? baud : MODBUS_DEFAULT_BAUD;
+    g_port.slave_id = slave ? slave : MODBUS_SENSOR_SLAVE_ID;
+
+    g_port.fd = open(g_port.port, O_RDWR | O_NOCTTY | O_NONBLOCK);
+    if (g_port.fd < 0) {
+        fprintf(
+            stderr, "[Modbus] Failed to open port: %s (%s)\n", g_port.port,
+            strerror(errno));
+        return false;
+    }
+
+    /* Switch to blocking mode */
+    fcntl(g_port.fd, F_SETFL, 0);
+
+    memset(&tio, 0, sizeof(tio));
+    /* 8N1 */
+    tio.c_cflag = CS8 | CREAD | CLOCAL;
+    tio.c_iflag = IGNPAR;
+    tio.c_oflag = 0;
+    tio.c_lflag = 0;
+    /* Non-blocking read; timeout handled by select() */
+    tio.c_cc[VMIN] = 0;
+    tio.c_cc[VTIME] = 0;
+
+    spd = baud_to_speed(g_port.baud);
+    cfsetispeed(&tio, spd);
+    cfsetospeed(&tio, spd);
+
+    if (tcsetattr(g_port.fd, TCSANOW, &tio) < 0) {
+        fprintf(
+            stderr, "[Modbus] Failed to configure port (%s)\n",
+            strerror(errno));
+        close(g_port.fd);
+        g_port.fd = -1;
+        return false;
+    }
+    tcflush(g_port.fd, TCIOFLUSH);
+
+    printf(
+        "[Modbus] Port opened: %s @ %u bps, Slave=%u\n", g_port.port,
+        g_port.baud, g_port.slave_id);
+    return true;
+}
+
+/* -----------------------------------------------------------------------
+ * Close and release the port
+ * -----------------------------------------------------------------------*/
+void Modbus_RTU_Cleanup(void)
+{
+    if (g_port.fd >= 0) {
+        close(g_port.fd);
+        g_port.fd = -1;
+        printf("[Modbus] Port closed: %s\n", g_port.port);
+    }
+}
+
+/* -----------------------------------------------------------------------
+ * Receive bytes with timeout
+ * -----------------------------------------------------------------------*/
+static int modbus_recv(uint8_t *buf, int max_len, int timeout_ms)
+{
+    int total = 0;
+    int ret;
+    int n;
+    struct timeval tv;
+    fd_set fds;
+
+    while (total < max_len) {
+        FD_ZERO(&fds);
+        FD_SET(g_port.fd, &fds);
+        tv.tv_sec = timeout_ms / 1000;
+        tv.tv_usec = (timeout_ms % 1000) * 1000;
+
+        ret = select(g_port.fd + 1, &fds, NULL, NULL, &tv);
+        if (ret <= 0) {
+            /* Timeout or error */
+            break;
+        }
+        n = (int)read(g_port.fd, buf + total, max_len - total);
+        if (n <= 0) {
+            break;
+        }
+        total += n;
+
+        /* Wait briefly after the minimum frame size to collect remaining bytes
+         */
+        if (total >= 5) {
+            usleep(2000); /* 2 ms */
+        }
+    }
+    return total;
+}
+
+/* -----------------------------------------------------------------------
+ * FC03 - Read Holding Registers
+ * -----------------------------------------------------------------------*/
+bool Modbus_Read_Holding_Registers(
+    uint8_t slave_id, uint16_t reg_addr, uint8_t count, uint16_t *regs)
+{
+    uint8_t req[8];
+    uint8_t resp[5 + 2 * 125 + 2]; /* maximum response size */
+    int resp_len;
+    int expected_len;
+    uint16_t crc_calc, crc_recv;
+    int retry;
+    int i;
+
+    if (g_port.fd < 0) {
+        fprintf(stderr, "[Modbus] Port is not initialized.\n");
+        return false;
+    }
+    if (!regs || count == 0 || count > 125) {
+        return false;
+    }
+
+    /* Build request frame */
+    req[0] = slave_id;
+    req[1] = 0x03; /* FC03 */
+    req[2] = (reg_addr >> 8) & 0xFF;
+    req[3] = reg_addr & 0xFF;
+    req[4] = 0x00;
+    req[5] = count;
+    crc_calc = crc16_modbus(req, 6);
+    req[6] = crc_calc & 0xFF; /* CRC Low byte */
+    req[7] = (crc_calc >> 8) & 0xFF; /* CRC High byte */
+
+    expected_len = 5 + 2 * count; /* ID + FC + ByteCount + data*2 + CRC*2 */
+
+    for (retry = 0; retry < MODBUS_MAX_RETRY; retry++) {
+        tcflush(g_port.fd, TCIOFLUSH);
+
+        if (write(g_port.fd, req, 8) != 8) {
+            fprintf(stderr, "[Modbus] Write error (%s)\n", strerror(errno));
+            usleep(50000);
+            continue;
+        }
+
+        resp_len = modbus_recv(resp, expected_len, MODBUS_TIMEOUT_MS);
+
+        if (resp_len < expected_len) {
+            fprintf(
+                stderr,
+                "[Modbus] Short response: received=%d, expected=%d (retry "
+                "%d)\n",
+                resp_len, expected_len, retry + 1);
+            usleep(100000);
+            continue;
+        }
+
+        /* Verify CRC */
+        crc_calc = crc16_modbus(resp, resp_len - 2);
+        crc_recv = (uint16_t)(resp[resp_len - 2]) |
+            ((uint16_t)(resp[resp_len - 1]) << 8);
+        if (crc_calc != crc_recv) {
+            fprintf(
+                stderr,
+                "[Modbus] CRC mismatch: calc=0x%04X, recv=0x%04X (retry %d)\n",
+                crc_calc, crc_recv, retry + 1);
+            usleep(100000);
+            continue;
+        }
+
+        /* Verify slave ID and function code */
+        if (resp[0] != slave_id || resp[1] != 0x03) {
+            /* Handle Modbus exception response */
+            if (resp[1] == 0x83) {
+                fprintf(
+                    stderr, "[Modbus] Exception response: code=0x%02X\n",
+                    resp[2]);
+            } else {
+                fprintf(
+                    stderr, "[Modbus] Unexpected response: ID=%u FC=%u\n",
+                    resp[0], resp[1]);
+            }
+            return false;
+        }
+
+        /* Parse register values */
+        for (i = 0; i < count; i++) {
+            regs[i] =
+                ((uint16_t)resp[3 + 2 * i] << 8) | (uint16_t)resp[4 + 2 * i];
+        }
+        return true;
+    }
+
+    return false;
+}
+
+/* -----------------------------------------------------------------------
+ * Read temperature and humidity from the sensor (legacy)
+ * -----------------------------------------------------------------------*/
+bool Modbus_Read_Sensor(uint8_t slave_id, SENSOR_DATA *data)
+{
+    uint16_t regs[2] = { 0 };
+
+    if (!data) {
+        return false;
+    }
+
+    data->valid = false;
+
+    /* Read registers 0x0000 (humidity) and 0x0001 (temperature) in one request
+     */
+    if (!Modbus_Read_Holding_Registers(slave_id, 0x0000, 2, regs)) {
+        return false;
+    }
+
+    /*
+     * Typical sensor scaling:
+     *   Humidity    (regs[0]): unit 0.1 %RH  -> divide by 10.0
+     *   Temperature (regs[1]): unit 0.1 deg C, signed -> cast to int16_t,
+     * divide by 10.0
+     */
+    data->humidity = (float)(regs[0]) / 10.0f;
+    data->temperature = (float)((int16_t)regs[1]) / 10.0f;
+    data->valid = true;
+
+    return true;
+}
+
+/* -----------------------------------------------------------------------
+ * Generic register read – FC03 (Holding) or FC04 (Input)
+ * -----------------------------------------------------------------------*/
+bool Modbus_Read_Register(
+    uint8_t slave_id, uint8_t func_code, uint16_t reg_addr, uint16_t *out_value)
+{
+    uint8_t req[8];
+    uint8_t resp[9]; /* 1+1+1+2+2 = 7 bytes minimum + 2 CRC */
+    int resp_len;
+    uint16_t crc_calc, crc_recv;
+    int retry;
+
+    if (g_port.fd < 0) {
+        fprintf(stderr, "[Modbus] Port not initialized.\n");
+        return false;
+    }
+    if (!out_value) {
+        return false;
+    }
+    if (func_code != MODBUS_FC_READ_HOLDING_REGS &&
+        func_code != MODBUS_FC_READ_INPUT_REGS) {
+        fprintf(
+            stderr, "[Modbus] Read_Register: invalid func_code 0x%02X\n",
+            func_code);
+        return false;
+    }
+
+    req[0] = slave_id;
+    req[1] = func_code;
+    req[2] = (reg_addr >> 8) & 0xFF;
+    req[3] = reg_addr & 0xFF;
+    req[4] = 0x00;
+    req[5] = 0x01; /* read 1 register */
+    crc_calc = crc16_modbus(req, 6);
+    req[6] = crc_calc & 0xFF;
+    req[7] = (crc_calc >> 8) & 0xFF;
+
+    for (retry = 0; retry < MODBUS_MAX_RETRY; retry++) {
+        tcflush(g_port.fd, TCIOFLUSH);
+
+        if (write(g_port.fd, req, 8) != 8) {
+            fprintf(
+                stderr,
+                "[Modbus] Write error slave=%u FC=0x%02X addr=0x%04X (%s)\n",
+                slave_id, func_code, reg_addr, strerror(errno));
+            usleep(50000);
+            continue;
+        }
+
+        resp_len = modbus_recv(resp, 7, MODBUS_TIMEOUT_MS);
+        if (resp_len < 7) {
+            fprintf(
+                stderr,
+                "[Modbus] Short resp: got=%d expected=7"
+                " slave=%u FC=0x%02X addr=0x%04X (retry %d)\n",
+                resp_len, slave_id, func_code, reg_addr, retry + 1);
+            usleep(100000);
+            continue;
+        }
+
+        crc_calc = crc16_modbus(resp, 5);
+        crc_recv = (uint16_t)(resp[5]) | ((uint16_t)(resp[6]) << 8);
+        if (crc_calc != crc_recv) {
+            fprintf(
+                stderr,
+                "[Modbus] CRC mismatch slave=%u FC=0x%02X addr=0x%04X"
+                " calc=0x%04X recv=0x%04X (retry %d)\n",
+                slave_id, func_code, reg_addr, crc_calc, crc_recv, retry + 1);
+            usleep(100000);
+            continue;
+        }
+
+        if (resp[0] != slave_id || resp[1] != func_code) {
+            fprintf(
+                stderr,
+                "[Modbus] Unexpected ID/FC: expected slave=%u FC=0x%02X,"
+                " got slave=%u FC=0x%02X\n",
+                slave_id, func_code, resp[0], resp[1]);
+            return false;
+        }
+
+        *out_value = ((uint16_t)resp[3] << 8) | (uint16_t)resp[4];
+        return true;
+    }
+
+    return false;
+}
+
+/* -----------------------------------------------------------------------
+ * Generic bit read – FC01 (Coils) or FC02 (Discrete Inputs)
+ * -----------------------------------------------------------------------*/
+bool Modbus_Read_Bit(
+    uint8_t slave_id, uint8_t func_code, uint16_t bit_addr, uint8_t *out_value)
+{
+    uint8_t req[8];
+    uint8_t resp[8]; /* ID+FC+ByteCount+1byte_data+CRC2 = 6 min */
+    int resp_len;
+    uint16_t crc_calc, crc_recv;
+    int retry;
+
+    if (g_port.fd < 0) {
+        fprintf(stderr, "[Modbus] Port not initialized.\n");
+        return false;
+    }
+    if (!out_value) {
+        return false;
+    }
+    if (func_code != MODBUS_FC_READ_COILS &&
+        func_code != MODBUS_FC_READ_DISCRETE_INPUTS) {
+        fprintf(
+            stderr, "[Modbus] Read_Bit: invalid func_code 0x%02X\n", func_code);
+        return false;
+    }
+
+    req[0] = slave_id;
+    req[1] = func_code;
+    req[2] = (bit_addr >> 8) & 0xFF;
+    req[3] = bit_addr & 0xFF;
+    req[4] = 0x00;
+    req[5] = 0x01; /* read 1 bit */
+    crc_calc = crc16_modbus(req, 6);
+    req[6] = crc_calc & 0xFF;
+    req[7] = (crc_calc >> 8) & 0xFF;
+
+    for (retry = 0; retry < MODBUS_MAX_RETRY; retry++) {
+        tcflush(g_port.fd, TCIOFLUSH);
+
+        if (write(g_port.fd, req, 8) != 8) {
+            fprintf(
+                stderr,
+                "[Modbus] Write error slave=%u FC=0x%02X addr=0x%04X (%s)\n",
+                slave_id, func_code, bit_addr, strerror(errno));
+            usleep(50000);
+            continue;
+        }
+
+        resp_len = modbus_recv(resp, 6, MODBUS_TIMEOUT_MS);
+        if (resp_len < 6) {
+            fprintf(
+                stderr,
+                "[Modbus] Short resp: got=%d expected=6"
+                " slave=%u FC=0x%02X addr=0x%04X (retry %d)\n",
+                resp_len, slave_id, func_code, bit_addr, retry + 1);
+            usleep(100000);
+            continue;
+        }
+
+        crc_calc = crc16_modbus(resp, 4);
+        crc_recv = (uint16_t)(resp[4]) | ((uint16_t)(resp[5]) << 8);
+        if (crc_calc != crc_recv) {
+            fprintf(
+                stderr,
+                "[Modbus] CRC mismatch slave=%u FC=0x%02X addr=0x%04X"
+                " calc=0x%04X recv=0x%04X (retry %d)\n",
+                slave_id, func_code, bit_addr, crc_calc, crc_recv, retry + 1);
+            usleep(100000);
+            continue;
+        }
+
+        if (resp[0] != slave_id || resp[1] != func_code) {
+            fprintf(
+                stderr,
+                "[Modbus] Unexpected ID/FC: expected slave=%u FC=0x%02X,"
+                " got slave=%u FC=0x%02X\n",
+                slave_id, func_code, resp[0], resp[1]);
+            return false;
+        }
+
+        *out_value = resp[3] & 0x01;
+        return true;
+    }
+
+    return false;
+}
+
+/* -----------------------------------------------------------------------
+ * FC06 – Write Single Holding Register
+ * -----------------------------------------------------------------------*/
+bool Modbus_Write_Register(uint8_t slave_id, uint16_t reg_addr, uint16_t value)
+{
+    uint8_t req[8];
+    uint8_t resp[8];
+    int resp_len;
+    uint16_t crc_calc, crc_recv;
+    int retry;
+
+    if (g_port.fd < 0) {
+        fprintf(stderr, "[Modbus] Port not initialized.\n");
+        return false;
+    }
+
+    req[0] = slave_id;
+    req[1] = MODBUS_FC_WRITE_SINGLE_REG;
+    req[2] = (reg_addr >> 8) & 0xFF;
+    req[3] = reg_addr & 0xFF;
+    req[4] = (value >> 8) & 0xFF;
+    req[5] = value & 0xFF;
+    crc_calc = crc16_modbus(req, 6);
+    req[6] = crc_calc & 0xFF;
+    req[7] = (crc_calc >> 8) & 0xFF;
+
+    for (retry = 0; retry < MODBUS_MAX_RETRY; retry++) {
+        tcflush(g_port.fd, TCIOFLUSH);
+        if (write(g_port.fd, req, 8) != 8) {
+            fprintf(
+                stderr,
+                "[Modbus] Write error slave=%u FC=0x06 addr=0x%04X (%s)\n",
+                slave_id, reg_addr, strerror(errno));
+            usleep(50000);
+            continue;
+        }
+        /* Echo response: same 8 bytes */
+        resp_len = modbus_recv(resp, 8, MODBUS_TIMEOUT_MS);
+        if (resp_len < 8) {
+            fprintf(
+                stderr,
+                "[Modbus] Short resp: got=%d expected=8"
+                " slave=%u FC=0x06 addr=0x%04X (retry %d)\n",
+                resp_len, slave_id, reg_addr, retry + 1);
+            usleep(100000);
+            continue;
+        }
+        crc_calc = crc16_modbus(resp, 6);
+        crc_recv = (uint16_t)(resp[6]) | ((uint16_t)(resp[7]) << 8);
+        if (crc_calc != crc_recv) {
+            fprintf(
+                stderr,
+                "[Modbus] CRC mismatch slave=%u FC=0x06 addr=0x%04X"
+                " calc=0x%04X recv=0x%04X (retry %d)\n",
+                slave_id, reg_addr, crc_calc, crc_recv, retry + 1);
+            usleep(100000);
+            continue;
+        }
+        if (resp[0] == slave_id && resp[1] == MODBUS_FC_WRITE_SINGLE_REG) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* -----------------------------------------------------------------------
+ * FC05 – Write Single Coil
+ * -----------------------------------------------------------------------*/
+bool Modbus_Write_Coil(uint8_t slave_id, uint16_t coil_addr, bool on)
+{
+    uint8_t req[8];
+    uint8_t resp[8];
+    int resp_len;
+    uint16_t crc_calc, crc_recv;
+    int retry;
+    uint16_t coil_val = on ? 0xFF00 : 0x0000;
+
+    if (g_port.fd < 0) {
+        fprintf(stderr, "[Modbus] Port not initialized.\n");
+        return false;
+    }
+
+    req[0] = slave_id;
+    req[1] = MODBUS_FC_WRITE_SINGLE_COIL;
+    req[2] = (coil_addr >> 8) & 0xFF;
+    req[3] = coil_addr & 0xFF;
+    req[4] = (coil_val >> 8) & 0xFF;
+    req[5] = coil_val & 0xFF;
+    crc_calc = crc16_modbus(req, 6);
+    req[6] = crc_calc & 0xFF;
+    req[7] = (crc_calc >> 8) & 0xFF;
+
+    for (retry = 0; retry < MODBUS_MAX_RETRY; retry++) {
+        tcflush(g_port.fd, TCIOFLUSH);
+        if (write(g_port.fd, req, 8) != 8) {
+            fprintf(
+                stderr,
+                "[Modbus] Write error slave=%u FC=0x05 addr=0x%04X (%s)\n",
+                slave_id, coil_addr, strerror(errno));
+            usleep(50000);
+            continue;
+        }
+        resp_len = modbus_recv(resp, 8, MODBUS_TIMEOUT_MS);
+        if (resp_len < 8) {
+            fprintf(
+                stderr,
+                "[Modbus] Short resp: got=%d expected=8"
+                " slave=%u FC=0x05 addr=0x%04X (retry %d)\n",
+                resp_len, slave_id, coil_addr, retry + 1);
+            usleep(100000);
+            continue;
+        }
+        crc_calc = crc16_modbus(resp, 6);
+        crc_recv = (uint16_t)(resp[6]) | ((uint16_t)(resp[7]) << 8);
+        if (crc_calc != crc_recv) {
+            fprintf(
+                stderr,
+                "[Modbus] CRC mismatch slave=%u FC=0x05 addr=0x%04X"
+                " calc=0x%04X recv=0x%04X (retry %d)\n",
+                slave_id, coil_addr, crc_calc, crc_recv, retry + 1);
+            usleep(100000);
+            continue;
+        }
+        if (resp[0] == slave_id && resp[1] == MODBUS_FC_WRITE_SINGLE_COIL) {
+            return true;
+        }
+    }
+    return false;
+}
+
+#else /* !(__linux__ || __unix__ || __APPLE__) */
+
+/* -----------------------------------------------------------------------
+ * Stub implementations for non-POSIX platforms
+ * -----------------------------------------------------------------------*/
+bool Modbus_RTU_Init(const char *port, uint32_t baud, uint8_t slave)
+{
+    (void)port;
+    (void)baud;
+    (void)slave;
+    fprintf(stderr, "[Modbus] Platform not supported.\n");
+    return false;
+}
+void Modbus_RTU_Cleanup(void)
+{
+}
+bool Modbus_Read_Holding_Registers(
+    uint8_t s, uint16_t a, uint8_t c, uint16_t *r)
+{
+    (void)s;
+    (void)a;
+    (void)c;
+    (void)r;
+    return false;
+}
+bool Modbus_Read_Register(uint8_t s, uint8_t f, uint16_t a, uint16_t *v)
+{
+    (void)s;
+    (void)f;
+    (void)a;
+    (void)v;
+    return false;
+}
+bool Modbus_Read_Bit(uint8_t s, uint8_t f, uint16_t a, uint8_t *v)
+{
+    (void)s;
+    (void)f;
+    (void)a;
+    (void)v;
+    return false;
+}
+bool Modbus_Write_Register(uint8_t s, uint16_t a, uint16_t v)
+{
+    (void)s;
+    (void)a;
+    (void)v;
+    return false;
+}
+bool Modbus_Write_Coil(uint8_t s, uint16_t a, bool on)
+{
+    (void)s;
+    (void)a;
+    (void)on;
+    return false;
+}
+bool Modbus_Read_Sensor(uint8_t s, SENSOR_DATA *d)
+{
+    (void)s;
+    (void)d;
+    return false;
+}
+
+#endif /* __linux__ || __unix__ || __APPLE__ */

--- a/apps/modbus-gateway/modbus_rtu.h
+++ b/apps/modbus-gateway/modbus_rtu.h
@@ -1,0 +1,165 @@
+/**
+ * @file modbus_rtu.h
+ * @brief Generic Modbus RTU master driver header.
+ *
+ * Supported function codes:
+ *   FC01 - Read Coils
+ *   FC02 - Read Discrete Inputs
+ *   FC03 - Read Holding Registers
+ *   FC04 - Read Input Registers
+ *   FC05 - Write Single Coil
+ *   FC06 - Write Single Register
+ *
+ * @author Jihye Ahn <jen.ahn@lge.com>
+ *
+ * @copyright Copyright (c) 2026 LG Electronics Inc.
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef MODBUS_RTU_H
+#define MODBUS_RTU_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* -----------------------------------------------------------------------
+ * Configuration constants
+ * -----------------------------------------------------------------------*/
+
+/** Default serial port for the Modbus RTU sensor (RS-485 to USB adapter) */
+#define MODBUS_DEFAULT_PORT "/dev/ttyUSB1"
+
+/** Default baud rate (typical factory default for temperature/humidity sensors)
+ */
+#define MODBUS_DEFAULT_BAUD 9600
+
+/** Maximum response wait time for Modbus RTU [ms] */
+#define MODBUS_TIMEOUT_MS 500
+
+/** Maximum number of retries on communication failure */
+#define MODBUS_MAX_RETRY 3
+
+/** Default Modbus Slave ID for the sensor (adjust to match the actual device)
+ */
+#define MODBUS_SENSOR_SLAVE_ID 1
+
+/* Modbus function codes */
+#define MODBUS_FC_READ_COILS 0x01
+#define MODBUS_FC_READ_DISCRETE_INPUTS 0x02
+#define MODBUS_FC_READ_HOLDING_REGS 0x03
+#define MODBUS_FC_READ_INPUT_REGS 0x04
+#define MODBUS_FC_WRITE_SINGLE_COIL 0x05
+#define MODBUS_FC_WRITE_SINGLE_REG 0x06
+
+/* -----------------------------------------------------------------------
+ * Data structures
+ * -----------------------------------------------------------------------*/
+
+/** Modbus RTU port handle */
+typedef struct {
+#if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
+    int fd; /**< POSIX file descriptor */
+#else
+    void *handle; /**< Platform-specific port handle (unused/stub) */
+#endif
+    char port[64]; /**< Port name */
+    uint32_t baud; /**< Baud rate */
+    uint8_t slave_id; /**< Default slave ID */
+} MODBUS_PORT;
+
+/** Temperature and humidity sensor data (legacy, kept for compatibility) */
+typedef struct {
+    float temperature; /**< Temperature [deg C] */
+    float humidity; /**< Relative humidity [%RH] */
+    bool valid; /**< True when data is valid */
+} SENSOR_DATA;
+
+/* -----------------------------------------------------------------------
+ * API
+ * -----------------------------------------------------------------------*/
+
+/**
+ * @brief Initialize the Modbus RTU serial port.
+ * @param port   Path to the serial port (e.g. "/dev/ttyUSB1")
+ * @param baud   Baud rate (e.g. 9600)
+ * @param slave  Default slave ID
+ * @return true on success
+ */
+bool Modbus_RTU_Init(const char *port, uint32_t baud, uint8_t slave);
+
+/**
+ * @brief Close and release the Modbus RTU port.
+ */
+void Modbus_RTU_Cleanup(void);
+
+/**
+ * @brief FC03 - Read Holding Registers.
+ * @param slave_id   Slave ID
+ * @param reg_addr   Starting register address
+ * @param count      Number of registers to read
+ * @param regs       Output buffer (uint16_t array, at least @p count elements)
+ * @return true on success
+ */
+bool Modbus_Read_Holding_Registers(
+    uint8_t slave_id, uint16_t reg_addr, uint8_t count, uint16_t *regs);
+
+/**
+ * @brief Generic register read (FC03 or FC04).
+ * @param slave_id   Slave ID
+ * @param func_code  MODBUS_FC_READ_HOLDING_REGS or MODBUS_FC_READ_INPUT_REGS
+ * @param reg_addr   Register address
+ * @param out_value  Single register value output
+ * @return true on success
+ */
+bool Modbus_Read_Register(
+    uint8_t slave_id,
+    uint8_t func_code,
+    uint16_t reg_addr,
+    uint16_t *out_value);
+
+/**
+ * @brief Generic bit read (FC01 or FC02).
+ * @param slave_id   Slave ID
+ * @param func_code  MODBUS_FC_READ_COILS or MODBUS_FC_READ_DISCRETE_INPUTS
+ * @param bit_addr   Coil/input address
+ * @param out_value  Output: 0 or 1
+ * @return true on success
+ */
+bool Modbus_Read_Bit(
+    uint8_t slave_id, uint8_t func_code, uint16_t bit_addr, uint8_t *out_value);
+
+/**
+ * @brief FC06 - Write Single Holding Register.
+ * @param slave_id   Slave ID
+ * @param reg_addr   Register address
+ * @param value      16-bit value to write
+ * @return true on success
+ */
+bool Modbus_Write_Register(uint8_t slave_id, uint16_t reg_addr, uint16_t value);
+
+/**
+ * @brief FC05 - Write Single Coil.
+ * @param slave_id   Slave ID
+ * @param coil_addr  Coil address
+ * @param on         true = ON (0xFF00), false = OFF (0x0000)
+ * @return true on success
+ */
+bool Modbus_Write_Coil(uint8_t slave_id, uint16_t coil_addr, bool on);
+
+/**
+ * @brief Read temperature and humidity from the Modbus RTU sensor (legacy).
+ * @param slave_id   Slave ID
+ * @param data       Output sensor data
+ * @return true on success
+ */
+bool Modbus_Read_Sensor(uint8_t slave_id, SENSOR_DATA *data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MODBUS_RTU_H */

--- a/apps/modbus-gateway/point_table.c
+++ b/apps/modbus-gateway/point_table.c
@@ -1,0 +1,665 @@
+/**
+ * @file point_table.c
+ * @brief JSON loading, BACnet object creation, and Modbus polling for the
+ *        generic Modbus RTU <-> BACnet gateway.
+ *
+ * JSON schema (gateway_config.json):
+ * {
+ *   "bacnet": {
+ *     "device_instance":..., "device_name":..., "vendor_id":...,
+ *     "datalink_type": "mstp"|"bip"|"bip6"|"ethernet",
+ *     "iface": "/dev/ttyUSB0" or "eth0",
+ *     "mstp_baud":..., "mstp_mac":..., "mstp_max_master":..., "mstp_net":...,
+ *     "bip_port":...
+ *   },
+ *   "modbus": { "port":..., "baud":..., "poll_interval_sec":... },
+ *   "points": [
+ *     { "name":..., "description":...,
+ *       "bacnet_type": "AI"|"AO"|"BI"|"BO",
+ *       "bacnet_instance":...,
+ *       "units": "DEGREES_CELSIUS"|"PERCENT_RELATIVE_HUMIDITY"|...,
+ *       "modbus_slave":...,
+ *       "modbus_func":
+ * "COIL"|"DISCRETE_INPUT"|"HOLDING_REGISTER"|"INPUT_REGISTER",
+ *       "modbus_address":...,
+ *       "scale":..., "offset":...,
+ *       "range_min":..., "range_max":... },
+ *     ...
+ *   ]
+ * }
+ *
+ * @author Jihye Ahn <jen.ahn@lge.com>
+ *
+ * @copyright Copyright (c) 2026 LG Electronics Inc.
+ * SPDX-License-Identifier: GPL-2.0-or-later WITH GCC-exception-2.0
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "point_table.h"
+#include "modbus_rtu.h"
+#include "cJSON.h"
+
+/* BACnet object headers */
+#include "bacnet/bacdef.h"
+#include "bacnet/basic/object/ai.h"
+#include "bacnet/basic/object/ao.h"
+#include "bacnet/basic/object/bi.h"
+#include "bacnet/basic/object/bo.h"
+
+/* -----------------------------------------------------------------------
+ * Internal helpers – string to enum conversion
+ * -----------------------------------------------------------------------*/
+static GW_BACNET_TYPE parse_bacnet_type(const char *s)
+{
+    if (!s) {
+        return GW_BACNET_TYPE_AI;
+    }
+    if (strcmp(s, "AI") == 0) {
+        return GW_BACNET_TYPE_AI;
+    }
+    if (strcmp(s, "AO") == 0) {
+        return GW_BACNET_TYPE_AO;
+    }
+    if (strcmp(s, "BI") == 0) {
+        return GW_BACNET_TYPE_BI;
+    }
+    if (strcmp(s, "BO") == 0) {
+        return GW_BACNET_TYPE_BO;
+    }
+    fprintf(stderr, "[PT] Unknown bacnet_type '%s', defaulting to AI\n", s);
+    return GW_BACNET_TYPE_AI;
+}
+
+static GW_MODBUS_FUNC parse_modbus_func(const char *s)
+{
+    if (!s) {
+        return GW_MODBUS_FUNC_INPUT_REG;
+    }
+    if (strcmp(s, "COIL") == 0) {
+        return GW_MODBUS_FUNC_COIL;
+    }
+    if (strcmp(s, "DISCRETE_INPUT") == 0) {
+        return GW_MODBUS_FUNC_DISCRETE_INPUT;
+    }
+    if (strcmp(s, "HOLDING_REGISTER") == 0) {
+        return GW_MODBUS_FUNC_HOLDING_REG;
+    }
+    if (strcmp(s, "INPUT_REGISTER") == 0) {
+        return GW_MODBUS_FUNC_INPUT_REG;
+    }
+    fprintf(
+        stderr, "[PT] Unknown modbus_func '%s', defaulting to INPUT_REGISTER\n",
+        s);
+    return GW_MODBUS_FUNC_INPUT_REG;
+}
+
+static BACNET_ENGINEERING_UNITS parse_units(const char *s)
+{
+    if (!s) {
+        return UNITS_NO_UNITS;
+    }
+    if (strcmp(s, "DEGREES_CELSIUS") == 0) {
+        return UNITS_DEGREES_CELSIUS;
+    }
+    if (strcmp(s, "DEGREES_FAHRENHEIT") == 0) {
+        return UNITS_DEGREES_FAHRENHEIT;
+    }
+    if (strcmp(s, "PERCENT_RELATIVE_HUMIDITY") == 0) {
+        return UNITS_PERCENT_RELATIVE_HUMIDITY;
+    }
+    if (strcmp(s, "PERCENT") == 0) {
+        return UNITS_PERCENT;
+    }
+    if (strcmp(s, "PASCALS") == 0) {
+        return UNITS_PASCALS;
+    }
+    if (strcmp(s, "KILOPASCALS") == 0) {
+        return UNITS_KILOPASCALS;
+    }
+    if (strcmp(s, "WATTS") == 0) {
+        return UNITS_WATTS;
+    }
+    if (strcmp(s, "KILOWATTS") == 0) {
+        return UNITS_KILOWATTS;
+    }
+    if (strcmp(s, "WATT_HOURS") == 0) {
+        return UNITS_WATT_HOURS;
+    }
+    if (strcmp(s, "KILOWATT_HOURS") == 0) {
+        return UNITS_KILOWATT_HOURS;
+    }
+    if (strcmp(s, "AMPERES") == 0) {
+        return UNITS_AMPERES;
+    }
+    if (strcmp(s, "VOLTS") == 0) {
+        return UNITS_VOLTS;
+    }
+    if (strcmp(s, "HERTZ") == 0) {
+        return UNITS_HERTZ;
+    }
+    if (strcmp(s, "RPM") == 0) {
+        return UNITS_REVOLUTIONS_PER_MINUTE;
+    }
+    if (strcmp(s, "LITERS_PER_SECOND") == 0) {
+        return UNITS_LITERS_PER_SECOND;
+    }
+    if (strcmp(s, "CUBIC_METERS_PER_HOUR") == 0) {
+        return UNITS_CUBIC_METERS_PER_HOUR;
+    }
+    if (strcmp(s, "NO_UNITS") == 0) {
+        return UNITS_NO_UNITS;
+    }
+    fprintf(stderr, "[PT] Unknown units '%s', using NO_UNITS\n", s);
+    return UNITS_NO_UNITS;
+}
+
+static const char *bacnet_type_str(GW_BACNET_TYPE t)
+{
+    switch (t) {
+        case GW_BACNET_TYPE_AI:
+            return "AI";
+        case GW_BACNET_TYPE_AO:
+            return "AO";
+        case GW_BACNET_TYPE_BI:
+            return "BI";
+        case GW_BACNET_TYPE_BO:
+            return "BO";
+        default:
+            return "??";
+    }
+}
+
+/* -----------------------------------------------------------------------
+ * Read and parse a JSON file into a cJSON tree
+ * -----------------------------------------------------------------------*/
+static cJSON *load_json_file(const char *filename)
+{
+    FILE *fp = NULL;
+    long len = 0;
+    char *buf = NULL;
+    cJSON *root = NULL;
+
+    fp = fopen(filename, "rb");
+    if (!fp) {
+        fprintf(stderr, "[PT] Cannot open '%s'\n", filename);
+        return NULL;
+    }
+    fseek(fp, 0, SEEK_END);
+    len = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+
+    buf = (char *)malloc((size_t)len + 1);
+    if (!buf) {
+        fclose(fp);
+        return NULL;
+    }
+
+    if (fread(buf, 1, (size_t)len, fp) != (size_t)len) {
+        fprintf(stderr, "[PT] Failed to read '%s'\n", filename);
+        free(buf);
+        fclose(fp);
+        return NULL;
+    }
+    buf[len] = '\0';
+    fclose(fp);
+
+    root = cJSON_Parse(buf);
+    free(buf);
+
+    if (!root) {
+        fprintf(
+            stderr, "[PT] JSON parse error near: %s\n", cJSON_GetErrorPtr());
+    }
+    return root;
+}
+
+/* -----------------------------------------------------------------------
+ * point_table_load_json
+ * -----------------------------------------------------------------------*/
+bool point_table_load_json(
+    GW_CONFIG *cfg, GW_POINT_TABLE *table, const char *filename)
+{
+    cJSON *root = NULL;
+    cJSON *sec = NULL;
+    cJSON *points_arr = NULL;
+    cJSON *item = NULL;
+    cJSON *j = NULL;
+    int idx = 0;
+
+    if (!cfg || !table || !filename) {
+        return false;
+    }
+
+    /* ── Apply compile-time defaults first ── */
+    memset(cfg, 0, sizeof(*cfg));
+    memset(table, 0, sizeof(*table));
+
+    cfg->device_instance = GW_DEVICE_INSTANCE;
+    cfg->mstp_baud = GW_MSTP_BAUD;
+    cfg->mstp_mac = GW_MSTP_MAC_ADDRESS;
+    cfg->vendor_id = GW_VENDOR_ID;
+    cfg->modbus_baud = GW_MODBUS_BAUD;
+    cfg->poll_interval_sec = GW_POLL_INTERVAL_SEC;
+    cfg->bip_port = GW_BIP_PORT;
+    strncpy(cfg->device_name, GW_DEVICE_NAME, sizeof(cfg->device_name) - 1);
+    strncpy(
+        cfg->datalink_type, GW_DATALINK_TYPE, sizeof(cfg->datalink_type) - 1);
+    strncpy(cfg->bacnet_iface, GW_BACNET_IFACE, sizeof(cfg->bacnet_iface) - 1);
+    strncpy(cfg->modbus_port, GW_MODBUS_PORT, sizeof(cfg->modbus_port) - 1);
+
+    root = load_json_file(filename);
+    if (!root) {
+        fprintf(stderr, "[PT] Failed to load JSON file\n");
+        return false;
+    }
+
+    /* ── bacnet section ── */
+    sec = cJSON_GetObjectItem(root, "bacnet");
+    if (sec) {
+        j = cJSON_GetObjectItem(sec, "device_instance");
+        if (cJSON_IsNumber(j)) {
+            double val = j->valuedouble;
+
+            if (val >= 1 && val <= BACNET_MAX_INSTANCE) {
+                cfg->device_instance = (uint32_t)val;
+            } else {
+                fprintf(stderr, "Invalid device_instance: %.0f\n", val);
+                return false;
+            }
+        }
+
+        j = cJSON_GetObjectItem(sec, "device_name");
+        if (cJSON_IsString(j)) {
+            strncpy(
+                cfg->device_name, j->valuestring, sizeof(cfg->device_name) - 1);
+        }
+
+        j = cJSON_GetObjectItem(sec, "datalink_type");
+        if (cJSON_IsString(j)) {
+            strncpy(
+                cfg->datalink_type, j->valuestring,
+                sizeof(cfg->datalink_type) - 1);
+        }
+
+        j = cJSON_GetObjectItem(sec, "iface");
+        if (cJSON_IsString(j)) {
+            strncpy(
+                cfg->bacnet_iface, j->valuestring,
+                sizeof(cfg->bacnet_iface) - 1);
+        }
+
+        j = cJSON_GetObjectItem(sec, "mstp_baud");
+        if (cJSON_IsNumber(j)) {
+            cfg->mstp_baud = (uint32_t)j->valuedouble;
+        }
+
+        j = cJSON_GetObjectItem(sec, "mstp_mac");
+        if (cJSON_IsNumber(j)) {
+            double mstp_mac = j->valuedouble;
+            if ((mstp_mac >= 0.0) && (mstp_mac <= 127.0) &&
+                (fabs(floor(mstp_mac) - mstp_mac) < 0.5)) {
+                cfg->mstp_mac = (uint8_t)mstp_mac;
+            } else {
+                fprintf(
+                    stderr,
+                    "[PT] Invalid mstp_mac '%g'; expected integer range "
+                    "0..127. Keeping existing value %u\n",
+                    mstp_mac, (unsigned)cfg->mstp_mac);
+            }
+        }
+
+        j = cJSON_GetObjectItem(sec, "mstp_max_master");
+        if (cJSON_IsNumber(j)) {
+            cfg->mstp_max_master = (uint16_t)j->valuedouble;
+        }
+
+        j = cJSON_GetObjectItem(sec, "mstp_net");
+        if (cJSON_IsNumber(j)) {
+            cfg->mstp_net = (uint16_t)j->valuedouble;
+        }
+
+        j = cJSON_GetObjectItem(sec, "bip_port");
+        if (cJSON_IsNumber(j)) {
+            cfg->bip_port = (uint16_t)j->valuedouble;
+        }
+
+        j = cJSON_GetObjectItem(sec, "vendor_id");
+        if (cJSON_IsNumber(j)) {
+            cfg->vendor_id = (uint16_t)j->valuedouble;
+        }
+    }
+
+    /* ── modbus section ── */
+    sec = cJSON_GetObjectItem(root, "modbus");
+    if (sec) {
+        j = cJSON_GetObjectItem(sec, "port");
+        if (cJSON_IsString(j)) {
+            strncpy(
+                cfg->modbus_port, j->valuestring, sizeof(cfg->modbus_port) - 1);
+        }
+        j = cJSON_GetObjectItem(sec, "baud");
+        if (cJSON_IsNumber(j)) {
+            cfg->modbus_baud = (uint32_t)j->valuedouble;
+        }
+
+        j = cJSON_GetObjectItem(sec, "poll_interval_sec");
+        if (cJSON_IsNumber(j)) {
+            cfg->poll_interval_sec = (int)j->valuedouble;
+        }
+    }
+
+    /* ── points array ── */
+    points_arr = cJSON_GetObjectItem(root, "points");
+    if (!cJSON_IsArray(points_arr)) {
+        fprintf(stderr, "[PT] 'points' array not found in JSON\n");
+        cJSON_Delete(root);
+        return false;
+    }
+
+    cJSON_ArrayForEach(item, points_arr)
+    {
+        if (idx >= GW_MAX_POINTS) {
+            fprintf(
+                stderr, "[PT] Max points (%d) reached, remaining ignored\n",
+                GW_MAX_POINTS);
+            break;
+        }
+
+        /* If enabled is false, skip this point entirely. */
+        j = cJSON_GetObjectItem(item, "enabled");
+        if (cJSON_IsFalse(j)) {
+            j = cJSON_GetObjectItem(item, "name");
+            printf(
+                "[PT] SKIP (disabled): %s\n",
+                cJSON_IsString(j) ? j->valuestring : "(unnamed)");
+            continue;
+        }
+
+        GW_POINT *p = &table->points[idx];
+
+        j = cJSON_GetObjectItem(item, "name");
+        if (cJSON_IsString(j)) {
+            strncpy(p->name, j->valuestring, sizeof(p->name) - 1);
+        } else {
+            snprintf(p->name, sizeof(p->name), "Point_%d", idx);
+        }
+
+        j = cJSON_GetObjectItem(item, "description");
+        if (cJSON_IsString(j)) {
+            strncpy(p->description, j->valuestring, sizeof(p->description) - 1);
+        }
+
+        j = cJSON_GetObjectItem(item, "bacnet_type");
+        p->bacnet_type =
+            parse_bacnet_type(cJSON_IsString(j) ? j->valuestring : NULL);
+
+        j = cJSON_GetObjectItem(item, "bacnet_instance");
+        p->bacnet_instance =
+            cJSON_IsNumber(j) ? (uint32_t)j->valuedouble : (uint32_t)idx;
+
+        j = cJSON_GetObjectItem(item, "units");
+        p->units = parse_units(cJSON_IsString(j) ? j->valuestring : NULL);
+
+        j = cJSON_GetObjectItem(item, "modbus_slave");
+        if (cJSON_IsNumber(j)) {
+            double modbus_slave = j->valuedouble;
+            if ((modbus_slave < 1.0) || (modbus_slave > 247.0) ||
+                (fabs(floor(modbus_slave) - modbus_slave) > 0.5)) {
+                fprintf(
+                    stderr,
+                    "[PT] Invalid modbus_slave %.17g for point '%s' (index "
+                    "%d): "
+                    "expected an integer in the range 1..247; rejecting "
+                    "point\n",
+                    modbus_slave, p->name, idx);
+                continue;
+            }
+            p->modbus_slave = (uint8_t)modbus_slave;
+        } else {
+            p->modbus_slave = 1;
+        }
+
+        j = cJSON_GetObjectItem(item, "modbus_func");
+        p->modbus_func =
+            parse_modbus_func(cJSON_IsString(j) ? j->valuestring : NULL);
+
+        j = cJSON_GetObjectItem(item, "modbus_address");
+        p->modbus_address = cJSON_IsNumber(j) ? (uint16_t)j->valuedouble : 0;
+
+        j = cJSON_GetObjectItem(item, "scale");
+        p->scale = cJSON_IsNumber(j) ? (float)j->valuedouble : 1.0f;
+
+        j = cJSON_GetObjectItem(item, "offset");
+        p->offset = cJSON_IsNumber(j) ? (float)j->valuedouble : 0.0f;
+
+        j = cJSON_GetObjectItem(item, "range_min");
+        p->range_min = cJSON_IsNumber(j) ? (float)j->valuedouble : -1e9f;
+
+        j = cJSON_GetObjectItem(item, "range_max");
+        p->range_max = cJSON_IsNumber(j) ? (float)j->valuedouble : 1e9f;
+
+        p->enabled = true; /* enabled: false는 위에서 이미 skip됨 */
+        p->initialized = false;
+        p->comm_error = true;
+
+        printf(
+            "[PT] [%3d] %-20s -> %s:%-4u  slave=%u fc=%u addr=0x%04X"
+            "  scale=%.4g offset=%.4g  [%.2g, %.2g]  %s\n",
+            idx, p->name, bacnet_type_str(p->bacnet_type), p->bacnet_instance,
+            p->modbus_slave, (unsigned)p->modbus_func, p->modbus_address,
+            p->scale, p->offset, p->range_min, p->range_max,
+            p->enabled ? "ENABLED" : "DISABLED");
+
+        idx++;
+    }
+
+    table->count = idx;
+    cJSON_Delete(root);
+
+    printf("[PT] Loaded %d point(s) from '%s'\n", table->count, filename);
+    return (table->count > 0);
+}
+
+/* -----------------------------------------------------------------------
+ * point_table_init_bacnet_objects
+ * -----------------------------------------------------------------------*/
+void point_table_init_bacnet_objects(const GW_POINT_TABLE *table)
+{
+    int i;
+    if (!table) {
+        return;
+    }
+
+    for (i = 0; i < table->count; i++) {
+        const GW_POINT *p = &table->points[i];
+
+        if (!p->enabled) {
+            continue;
+        }
+
+        switch (p->bacnet_type) {
+            case GW_BACNET_TYPE_AI:
+                Analog_Input_Create(p->bacnet_instance);
+                Analog_Input_Name_Set(p->bacnet_instance, p->name);
+                Analog_Input_Description_Set(
+                    p->bacnet_instance, p->description);
+                Analog_Input_Units_Set(p->bacnet_instance, p->units);
+                Analog_Input_Present_Value_Set(p->bacnet_instance, 0.0f);
+                Analog_Input_Out_Of_Service_Set(p->bacnet_instance, true);
+                break;
+
+            case GW_BACNET_TYPE_AO:
+                Analog_Output_Create(p->bacnet_instance);
+                Analog_Output_Name_Set(p->bacnet_instance, p->name);
+                Analog_Output_Description_Set(
+                    p->bacnet_instance, p->description);
+                Analog_Output_Units_Set(p->bacnet_instance, p->units);
+                break;
+
+            case GW_BACNET_TYPE_BI:
+                Binary_Input_Create(p->bacnet_instance);
+                Binary_Input_Name_Set(p->bacnet_instance, p->name);
+                Binary_Input_Description_Set(
+                    p->bacnet_instance, p->description);
+                Binary_Input_Out_Of_Service_Set(p->bacnet_instance, true);
+                break;
+
+            case GW_BACNET_TYPE_BO:
+                Binary_Output_Create(p->bacnet_instance);
+                Binary_Output_Name_Set(p->bacnet_instance, p->name);
+                Binary_Output_Description_Set(
+                    p->bacnet_instance, p->description);
+                break;
+            default:
+                break;
+        }
+    }
+    printf("[BACnet] %d object(s) created\n", table->count);
+}
+
+/* -----------------------------------------------------------------------
+ * point_table_poll_modbus
+ * -----------------------------------------------------------------------*/
+void point_table_poll_modbus(GW_POINT_TABLE *table)
+{
+    int i;
+    if (!table) {
+        return;
+    }
+
+    for (i = 0; i < table->count; i++) {
+        GW_POINT *p = &table->points[i];
+        uint16_t raw_u16 = 0;
+        uint8_t raw_bit = 0;
+        float eng_val = 0.0f;
+        bool ok = false;
+        bool in_range;
+
+        if (!p->enabled) {
+            continue;
+        }
+
+        /* ── Read from Modbus ── */
+        switch (p->modbus_func) {
+            case GW_MODBUS_FUNC_COIL:
+            case GW_MODBUS_FUNC_DISCRETE_INPUT:
+                ok = Modbus_Read_Bit(
+                    p->modbus_slave, (uint8_t)p->modbus_func, p->modbus_address,
+                    &raw_bit);
+                eng_val = (float)raw_bit;
+                break;
+
+            case GW_MODBUS_FUNC_HOLDING_REG:
+            case GW_MODBUS_FUNC_INPUT_REG:
+                ok = Modbus_Read_Register(
+                    p->modbus_slave, (uint8_t)p->modbus_func, p->modbus_address,
+                    &raw_u16);
+                eng_val = (float)raw_u16 * p->scale + p->offset;
+                break;
+            default:
+                break;
+        }
+
+        p->comm_error = !ok;
+
+        /* ── Communication failure → Out-of-Service ── */
+        if (!ok) {
+            if (p->bacnet_type == GW_BACNET_TYPE_AI) {
+                Analog_Input_Out_Of_Service_Set(p->bacnet_instance, true);
+            } else if (p->bacnet_type == GW_BACNET_TYPE_BI) {
+                Binary_Input_Out_Of_Service_Set(p->bacnet_instance, true);
+            }
+            fprintf(
+                stderr, "[PT] Comm error on '%s' (slave=%u addr=0x%04X)\n",
+                p->name, p->modbus_slave, p->modbus_address);
+            continue;
+        }
+
+        /* ── Range check ── */
+        in_range = (eng_val >= p->range_min && eng_val <= p->range_max);
+
+        /* ── Update BACnet object ── */
+        switch (p->bacnet_type) {
+            case GW_BACNET_TYPE_AI:
+                if (in_range) {
+                    Analog_Input_Present_Value_Set(p->bacnet_instance, eng_val);
+                    Analog_Input_Out_Of_Service_Set(p->bacnet_instance, false);
+                    printf(
+                        "[PT] %-20s = %.4g  (AI:%u)\n", p->name, eng_val,
+                        p->bacnet_instance);
+                } else {
+                    Analog_Input_Out_Of_Service_Set(p->bacnet_instance, true);
+                    fprintf(
+                        stderr,
+                        "[PT] Range error: '%s' = %.4g (min=%.4g max=%.4g)\n",
+                        p->name, eng_val, p->range_min, p->range_max);
+                }
+                break;
+
+            case GW_BACNET_TYPE_BI:
+                if (in_range) {
+                    Binary_Input_Present_Value_Set(
+                        p->bacnet_instance,
+                        (fabsf(eng_val) > 0.5f) ? BINARY_ACTIVE
+                                                : BINARY_INACTIVE);
+                    Binary_Input_Out_Of_Service_Set(p->bacnet_instance, false);
+                    printf(
+                        "[PT] %-20s = %s  (BI:%u)\n", p->name,
+                        (fabsf(eng_val) > 0.5f) ? "ACTIVE" : "INACTIVE",
+                        p->bacnet_instance);
+                } else {
+                    Binary_Input_Out_Of_Service_Set(p->bacnet_instance, true);
+                    fprintf(
+                        stderr,
+                        "[PT] Range error: '%s' = %.4g (min=%.4g max=%.4g)\n",
+                        p->name, eng_val, p->range_min, p->range_max);
+                }
+                break;
+
+            case GW_BACNET_TYPE_AO:
+                if (in_range) {
+                    Analog_Output_Present_Value_Set(
+                        p->bacnet_instance, eng_val, BACNET_NO_PRIORITY);
+                    Analog_Output_Out_Of_Service_Set(p->bacnet_instance, false);
+                    printf(
+                        "[PT] %-20s = %.4g  (AO:%u)\n", p->name, eng_val,
+                        p->bacnet_instance);
+                } else {
+                    Analog_Output_Out_Of_Service_Set(p->bacnet_instance, true);
+                    fprintf(
+                        stderr,
+                        "[PT] Range error: '%s' = %.4g (min=%.4g max=%.4g)\n",
+                        p->name, eng_val, p->range_min, p->range_max);
+                }
+                break;
+            case GW_BACNET_TYPE_BO:
+                if (in_range) {
+                    Binary_Output_Present_Value_Set(
+                        p->bacnet_instance,
+                        (fabsf(eng_val) > 0.5f) ? BINARY_ACTIVE
+                                                : BINARY_INACTIVE,
+                        BACNET_NO_PRIORITY);
+                    Binary_Output_Out_Of_Service_Set(p->bacnet_instance, false);
+                    printf(
+                        "[PT] %-20s = %s  (BO:%u)\n", p->name,
+                        (fabsf(eng_val) > 0.5f) ? "ACTIVE" : "INACTIVE",
+                        p->bacnet_instance);
+                } else {
+                    Binary_Output_Out_Of_Service_Set(p->bacnet_instance, true);
+                    fprintf(
+                        stderr,
+                        "[PT] Range error: '%s' = %.4g (min=%.4g max=%.4g)\n",
+                        p->name, eng_val, p->range_min, p->range_max);
+                }
+                break;
+            default:
+                break;
+        }
+
+        p->initialized = true;
+    }
+}

--- a/apps/modbus-gateway/point_table.h
+++ b/apps/modbus-gateway/point_table.h
@@ -1,0 +1,144 @@
+/**
+ * @file point_table.h
+ * @brief Generic Modbus-to-BACnet point mapping table.
+ *
+ * Each entry maps one Modbus register/coil to one BACnet object (AI/AO/BI/BO).
+ * The table is loaded at startup from gateway_config.json.
+ *
+ * @author Jihye Ahn <jen.ahn@lge.com>
+ *
+ * @copyright Copyright (c) 2026 LG Electronics Inc.
+ * SPDX-License-Identifier: GPL-2.0-or-later WITH GCC-exception-2.0
+ */
+
+#ifndef POINT_TABLE_H
+#define POINT_TABLE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "bacnet/bacenum.h"
+#include "gateway_config.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* -----------------------------------------------------------------------
+ * Enumerations
+ * -----------------------------------------------------------------------*/
+
+/** BACnet object types supported by this gateway */
+typedef enum {
+    GW_BACNET_TYPE_AI = 0, /**< Analog Input  */
+    GW_BACNET_TYPE_AO, /**< Analog Output */
+    GW_BACNET_TYPE_BI, /**< Binary Input  */
+    GW_BACNET_TYPE_BO, /**< Binary Output */
+} GW_BACNET_TYPE;
+
+/** Modbus function codes */
+typedef enum {
+    GW_MODBUS_FUNC_COIL = 0x01, /**< FC01 Read Coils */
+    GW_MODBUS_FUNC_DISCRETE_INPUT = 0x02, /**< FC02 Read Discrete Inputs */
+    GW_MODBUS_FUNC_HOLDING_REG = 0x03, /**< FC03 Read Holding Registers */
+    GW_MODBUS_FUNC_INPUT_REG = 0x04, /**< FC04 Read Input Registers */
+} GW_MODBUS_FUNC;
+
+/* -----------------------------------------------------------------------
+ * Point entry
+ * -----------------------------------------------------------------------*/
+typedef struct {
+    /* Identification */
+    char name[64];
+    char description[128];
+
+    /* BACnet side */
+    GW_BACNET_TYPE bacnet_type;
+    uint32_t bacnet_instance;
+    BACNET_ENGINEERING_UNITS units;
+
+    /* Modbus side */
+    uint8_t modbus_slave;
+    GW_MODBUS_FUNC modbus_func;
+    uint16_t modbus_address;
+
+    /* Value conversion: eng_value = raw * scale + offset */
+    float scale;
+    float offset;
+
+    /* Valid engineering-value range; Out-of-Service when out of range */
+    float range_min;
+    float range_max;
+
+    /* Runtime state (managed by point_table_poll_modbus) */
+    bool enabled;
+    bool initialized;
+    bool comm_error;
+} GW_POINT;
+
+/* -----------------------------------------------------------------------
+ * Point table
+ * -----------------------------------------------------------------------*/
+typedef struct {
+    GW_POINT points[GW_MAX_POINTS];
+    int count;
+} GW_POINT_TABLE;
+
+/* -----------------------------------------------------------------------
+ * Gateway-level configuration read from JSON
+ * -----------------------------------------------------------------------*/
+typedef struct {
+    uint32_t device_instance;
+    char device_name[64];
+    uint16_t vendor_id;
+
+    /* ── BACnet datalink ── */
+    char datalink_type[32]; /**< "mstp", "bip", "bip6", "ethernet", etc. */
+    char bacnet_iface[64]; /**< network interface or serial port */
+
+    /* MS/TP specific (used when datalink_type == "mstp") */
+    uint32_t mstp_baud;
+    uint8_t mstp_mac;
+    uint16_t mstp_max_master;
+    uint16_t mstp_net;
+
+    /* BACnet/IP specific (used when datalink_type == "bip") */
+    uint16_t bip_port; /**< UDP port, default 0xBAC0 (47808) */
+
+    /* ── Modbus ── */
+    char modbus_port[64];
+    uint32_t modbus_baud;
+    int poll_interval_sec;
+} GW_CONFIG;
+
+/* -----------------------------------------------------------------------
+ * Public API
+ * -----------------------------------------------------------------------*/
+
+/**
+ * @brief Load gateway config + point table from a JSON file.
+ * @param cfg      Output: gateway-level configuration.
+ * @param table    Output: point table.
+ * @param filename Path to gateway_config.json.
+ * @return true if at least one point was loaded successfully.
+ */
+bool point_table_load_json(
+    GW_CONFIG *cfg, GW_POINT_TABLE *table, const char *filename);
+
+/**
+ * @brief Create BACnet objects for all points in the table.
+ * Must be called after Device_Init() and before the main loop.
+ * @param table  Populated point table.
+ */
+void point_table_init_bacnet_objects(const GW_POINT_TABLE *table);
+
+/**
+ * @brief Poll Modbus for all points and update BACnet Present_Value.
+ * Called periodically from the main loop.
+ * @param table  Point table (updated in-place).
+ */
+void point_table_poll_modbus(GW_POINT_TABLE *table);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* POINT_TABLE_H */

--- a/src/bacnet/basic/sys/cJSON.c
+++ b/src/bacnet/basic/sys/cJSON.c
@@ -1,0 +1,475 @@
+/*
+  Copyright (c) 2009-2017 Dave Gamble and cJSON contributors
+  SPDX-License-Identifier: MIT
+
+  Trimmed cJSON implementation for embedded / gateway use.
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <ctype.h>
+#include <limits.h>
+#include <float.h>
+
+#include "cJSON.h"
+
+/* ------------------------------------------------------------------ */
+/* Internal state                                                       */
+/* ------------------------------------------------------------------ */
+static const char *global_ep = NULL;
+
+const char *cJSON_GetErrorPtr(void)
+{
+    return global_ep;
+}
+
+/* ------------------------------------------------------------------ */
+/* Memory helpers                                                       */
+/* ------------------------------------------------------------------ */
+static cJSON *cJSON_New_Item(void)
+{
+    cJSON *node = (cJSON *)calloc(1, sizeof(cJSON));
+    return node;
+}
+
+void cJSON_Delete(cJSON *c)
+{
+    cJSON *next;
+    while (c) {
+        next = c->next;
+        if (!(c->type & cJSON_IsReference) && c->child) {
+            cJSON_Delete(c->child);
+        }
+        if (!(c->type & cJSON_IsReference) && c->valuestring) {
+            free(c->valuestring);
+        }
+        if (!(c->type & cJSON_StringIsConst) && c->string) {
+            free(c->string);
+        }
+        free(c);
+        c = next;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Parse number                                                         */
+/* ------------------------------------------------------------------ */
+static const char *parse_number(cJSON *item, const char *num)
+{
+    double n = 0;
+    double sign = 1.0;
+    double scale = 0;
+    int subscale = 0, signsubscale = 1;
+
+    if (*num == '-') {
+        sign = -1.0;
+        num++;
+    }
+    if (*num == '0') {
+        num++;
+    } else if (*num >= '1' && *num <= '9') {
+        do {
+            n = n * 10.0 + (*num - '0');
+            num++;
+        } while (*num >= '0' && *num <= '9');
+    }
+    if (*num == '.') {
+        num++;
+        while (*num >= '0' && *num <= '9') {
+            n = n * 10.0 + (*num - '0');
+            scale--;
+            num++;
+        }
+    }
+    if (*num == 'e' || *num == 'E') {
+        num++;
+        if (*num == '+') {
+            num++;
+        } else if (*num == '-') {
+            signsubscale = -1;
+            num++;
+        }
+        while (*num >= '0' && *num <= '9') {
+            subscale = subscale * 10 + (*num - '0');
+            num++;
+        }
+    }
+    n = sign * n * pow(10.0, scale + subscale * signsubscale);
+    item->valuedouble = n;
+    item->valueint = (int)n;
+    item->type = cJSON_Number;
+    return num;
+}
+
+/* ------------------------------------------------------------------ */
+/* Parse string (stored without surrounding quotes)                     */
+/* ------------------------------------------------------------------ */
+static unsigned parse_hex4(const char *str)
+{
+    unsigned h = 0;
+    int i;
+    for (i = 0; i < 4; i++) {
+        if (*str >= '0' && *str <= '9') {
+            h = h * 16 + (*str - '0');
+        } else if (*str >= 'A' && *str <= 'F') {
+            h = h * 16 + (*str - 'A') + 10;
+        } else if (*str >= 'a' && *str <= 'f') {
+            h = h * 16 + (*str - 'a') + 10;
+        } else {
+            return 0;
+        }
+        str++;
+    }
+    return h;
+}
+
+static const char *parse_string(cJSON *item, const char *str)
+{
+    const char *ptr = str + 1;
+    char *ptr2;
+    char *out;
+    int len = 0;
+    unsigned uc, uc2;
+
+    if (*str != '\"') {
+        global_ep = str;
+        return NULL;
+    }
+
+    while (*ptr != '\"' && *ptr && ++len) {
+        if (*ptr++ == '\\') {
+            ptr++;
+        }
+    }
+
+    out = (char *)malloc(len + 1);
+    if (!out) {
+        return NULL;
+    }
+
+    ptr = str + 1;
+    ptr2 = out;
+    while (*ptr != '\"' && *ptr) {
+        if (*ptr != '\\') {
+            *ptr2++ = *ptr++;
+        } else {
+            ptr++;
+            switch (*ptr) {
+                case 'b':
+                    *ptr2++ = '\b';
+                    break;
+                case 'f':
+                    *ptr2++ = '\f';
+                    break;
+                case 'n':
+                    *ptr2++ = '\n';
+                    break;
+                case 'r':
+                    *ptr2++ = '\r';
+                    break;
+                case 't':
+                    *ptr2++ = '\t';
+                    break;
+                case 'u':
+                    uc = parse_hex4(ptr + 1);
+                    ptr += 4;
+                    if (uc >= 0xD800 && uc <= 0xDBFF) {
+                        if (ptr[1] == '\\' && ptr[2] == 'u') {
+                            uc2 = parse_hex4(ptr + 3);
+                            ptr += 6;
+                            uc = 0x10000 +
+                                (((uc & 0x3FF) << 10) | (uc2 & 0x3FF));
+                        }
+                    }
+                    if (uc < 0x80) {
+                        *ptr2++ = (char)uc;
+                    } else if (uc < 0x800) {
+                        *ptr2++ = (char)(0xC0 | (uc >> 6));
+                        *ptr2++ = (char)(0x80 | (uc & 0x3F));
+                    } else if (uc < 0x10000) {
+                        *ptr2++ = (char)(0xE0 | (uc >> 12));
+                        *ptr2++ = (char)(0x80 | ((uc >> 6) & 0x3F));
+                        *ptr2++ = (char)(0x80 | (uc & 0x3F));
+                    } else {
+                        *ptr2++ = (char)(0xF0 | (uc >> 18));
+                        *ptr2++ = (char)(0x80 | ((uc >> 12) & 0x3F));
+                        *ptr2++ = (char)(0x80 | ((uc >> 6) & 0x3F));
+                        *ptr2++ = (char)(0x80 | (uc & 0x3F));
+                    }
+                    break;
+                default:
+                    *ptr2++ = *ptr;
+                    break;
+            }
+            ptr++;
+        }
+    }
+    *ptr2 = '\0';
+    if (*ptr == '\"') {
+        ptr++;
+    }
+    item->valuestring = out;
+    item->type = cJSON_String;
+    return ptr;
+}
+
+/* ------------------------------------------------------------------ */
+/* Skip whitespace / comments                                           */
+/* ------------------------------------------------------------------ */
+static const char *skip(const char *in)
+{
+    while (in && *in && (unsigned char)*in <= ' ') {
+        in++;
+    }
+    return in;
+}
+
+/* ------------------------------------------------------------------ */
+/* Forward declare                                                      */
+/* ------------------------------------------------------------------ */
+static const char *parse_value(cJSON *item, const char *value);
+static const char *parse_array(cJSON *item, const char *value);
+static const char *parse_object(cJSON *item, const char *value);
+
+/* ------------------------------------------------------------------ */
+/* parse_value                                                          */
+/* ------------------------------------------------------------------ */
+static const char *parse_value(cJSON *item, const char *value)
+{
+    if (!value) {
+        return NULL;
+    }
+    if (!strncmp(value, "null", 4)) {
+        item->type = cJSON_NULL;
+        return value + 4;
+    }
+    if (!strncmp(value, "false", 5)) {
+        item->type = cJSON_False;
+        return value + 5;
+    }
+    if (!strncmp(value, "true", 4)) {
+        item->type = cJSON_True;
+        item->valueint = 1;
+        return value + 4;
+    }
+    if (*value == '\"') {
+        return parse_string(item, value);
+    }
+    if (*value == '-' || (*value >= '0' && *value <= '9')) {
+        return parse_number(item, value);
+    }
+    if (*value == '[') {
+        return parse_array(item, value);
+    }
+    if (*value == '{') {
+        return parse_object(item, value);
+    }
+    global_ep = value;
+    return NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/* parse_array                                                          */
+/* ------------------------------------------------------------------ */
+static const char *parse_array(cJSON *item, const char *value)
+{
+    cJSON *child;
+    if (*value != '[') {
+        global_ep = value;
+        return NULL;
+    }
+    item->type = cJSON_Array;
+    value = skip(value + 1);
+    if (*value == ']') {
+        return value + 1;
+    }
+
+    item->child = child = cJSON_New_Item();
+    if (!item->child) {
+        return NULL;
+    }
+    value = skip(parse_value(child, skip(value)));
+    if (!value) {
+        return NULL;
+    }
+
+    while (*value == ',') {
+        cJSON *new_item = cJSON_New_Item();
+        if (!new_item) {
+            return NULL;
+        }
+        child->next = new_item;
+        new_item->prev = child;
+        child = new_item;
+        value = skip(parse_value(child, skip(value + 1)));
+        if (!value) {
+            return NULL;
+        }
+    }
+    if (*value == ']') {
+        return value + 1;
+    }
+    global_ep = value;
+    return NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/* parse_object                                                         */
+/* ------------------------------------------------------------------ */
+static const char *parse_object(cJSON *item, const char *value)
+{
+    cJSON *child;
+    if (*value != '{') {
+        global_ep = value;
+        return NULL;
+    }
+    item->type = cJSON_Object;
+    value = skip(value + 1);
+    if (*value == '}') {
+        return value + 1;
+    }
+
+    item->child = child = cJSON_New_Item();
+    if (!item->child) {
+        return NULL;
+    }
+
+    value = skip(parse_string(child, skip(value)));
+    if (!value) {
+        return NULL;
+    }
+    child->string = child->valuestring;
+    child->valuestring = NULL;
+
+    if (*value != ':') {
+        global_ep = value;
+        return NULL;
+    }
+    value = skip(parse_value(child, skip(value + 1)));
+    if (!value) {
+        return NULL;
+    }
+
+    while (*value == ',') {
+        cJSON *new_item = cJSON_New_Item();
+        if (!new_item) {
+            return NULL;
+        }
+        child->next = new_item;
+        new_item->prev = child;
+        child = new_item;
+
+        value = skip(parse_string(child, skip(value + 1)));
+        if (!value) {
+            return NULL;
+        }
+        child->string = child->valuestring;
+        child->valuestring = NULL;
+
+        if (*value != ':') {
+            global_ep = value;
+            return NULL;
+        }
+        value = skip(parse_value(child, skip(value + 1)));
+        if (!value) {
+            return NULL;
+        }
+    }
+    if (*value == '}') {
+        return value + 1;
+    }
+    global_ep = value;
+    return NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/* Public API                                                           */
+/* ------------------------------------------------------------------ */
+cJSON *cJSON_Parse(const char *value)
+{
+    cJSON *c = cJSON_New_Item();
+    global_ep = NULL;
+    if (!c) {
+        return NULL;
+    }
+    if (!parse_value(c, skip(value))) {
+        cJSON_Delete(c);
+        return NULL;
+    }
+    return c;
+}
+
+cJSON *cJSON_GetArrayItem(const cJSON *array, int item)
+{
+    cJSON *c = array ? array->child : NULL;
+    while (c && item > 0) {
+        item--;
+        c = c->next;
+    }
+    return c;
+}
+
+int cJSON_GetArraySize(const cJSON *array)
+{
+    cJSON *c = array ? array->child : NULL;
+    int i = 0;
+    while (c) {
+        i++;
+        c = c->next;
+    }
+    return i;
+}
+
+cJSON *cJSON_GetObjectItem(const cJSON *const object, const char *const string)
+{
+    cJSON *c = object ? object->child : NULL;
+    while (c && c->string && strcmp(c->string, string)) {
+        c = c->next;
+    }
+    return c;
+}
+
+/* Type check helpers */
+int cJSON_IsInvalid(const cJSON *const item)
+{
+    return item ? (item->type & 0xFF) == cJSON_Invalid : 0;
+}
+int cJSON_IsFalse(const cJSON *const item)
+{
+    return item ? (item->type & 0xFF) == cJSON_False : 0;
+}
+int cJSON_IsTrue(const cJSON *const item)
+{
+    return item ? (item->type & 0xFF) == cJSON_True : 0;
+}
+int cJSON_IsBool(const cJSON *const item)
+{
+    return item ? ((item->type & 0xFF) == cJSON_True ||
+                   (item->type & 0xFF) == cJSON_False)
+                : 0;
+}
+int cJSON_IsNull(const cJSON *const item)
+{
+    return item ? (item->type & 0xFF) == cJSON_NULL : 0;
+}
+int cJSON_IsNumber(const cJSON *const item)
+{
+    return item ? (item->type & 0xFF) == cJSON_Number : 0;
+}
+int cJSON_IsString(const cJSON *const item)
+{
+    return item ? (item->type & 0xFF) == cJSON_String : 0;
+}
+int cJSON_IsArray(const cJSON *const item)
+{
+    return item ? (item->type & 0xFF) == cJSON_Array : 0;
+}
+int cJSON_IsObject(const cJSON *const item)
+{
+    return item ? (item->type & 0xFF) == cJSON_Object : 0;
+}
+int cJSON_IsRaw(const cJSON *const item)
+{
+    return item ? (item->type & 0xFF) == cJSON_Raw : 0;
+}

--- a/src/bacnet/basic/sys/cJSON.h
+++ b/src/bacnet/basic/sys/cJSON.h
@@ -1,0 +1,75 @@
+/*
+  Copyright (c) 2009-2017 Dave Gamble and cJSON contributors
+  SPDX-License-Identifier: MIT
+
+  Trimmed single-header cJSON for embedded use.
+*/
+#ifndef CJSON_H
+#define CJSON_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+
+/* cJSON Types */
+#define cJSON_Invalid (0)
+#define cJSON_False (1 << 0)
+#define cJSON_True (1 << 1)
+#define cJSON_NULL (1 << 2)
+#define cJSON_Number (1 << 3)
+#define cJSON_String (1 << 4)
+#define cJSON_Array (1 << 5)
+#define cJSON_Object (1 << 6)
+#define cJSON_Raw (1 << 7)
+
+#define cJSON_IsReference 256
+#define cJSON_StringIsConst 512
+
+typedef struct cJSON {
+    struct cJSON *next;
+    struct cJSON *prev;
+    struct cJSON *child;
+    int type;
+    char *valuestring;
+    int valueint; /* DEPRECATED, use cJSON_SetNumberValue */
+    double valuedouble;
+    char *string;
+} cJSON;
+
+/* Parses a JSON string and returns a cJSON tree. */
+cJSON *cJSON_Parse(const char *value);
+
+/* Deletes a cJSON tree. */
+void cJSON_Delete(cJSON *item);
+
+/* Returns the error pointer after a failed parse. */
+const char *cJSON_GetErrorPtr(void);
+
+/* Array / object access */
+cJSON *cJSON_GetArrayItem(const cJSON *array, int index);
+int cJSON_GetArraySize(const cJSON *array);
+cJSON *cJSON_GetObjectItem(const cJSON *const object, const char *const string);
+
+/* Type checks */
+int cJSON_IsInvalid(const cJSON *const item);
+int cJSON_IsFalse(const cJSON *const item);
+int cJSON_IsTrue(const cJSON *const item);
+int cJSON_IsBool(const cJSON *const item);
+int cJSON_IsNull(const cJSON *const item);
+int cJSON_IsNumber(const cJSON *const item);
+int cJSON_IsString(const cJSON *const item);
+int cJSON_IsArray(const cJSON *const item);
+int cJSON_IsObject(const cJSON *const item);
+int cJSON_IsRaw(const cJSON *const item);
+
+/* Iterate over array/object – uses next pointer */
+#define cJSON_ArrayForEach(element, array)                    \
+    for ((element) = (array != NULL) ? (array)->child : NULL; \
+         (element) != NULL; (element) = (element)->next)
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* CJSON_H */


### PR DESCRIPTION
Introduce a new generic gateway application (bacgw-mstp) that bridges Modbus RTU devices to a BACnet MS/TP network via a JSON-based runtime configuration.

Key features:
- Exposes Modbus registers/coils as BACnet AI/AO/BI/BO objects
- Runtime configuration via gateway_config.json (device instance, MS/TP port/baud/MAC, Modbus port/baud, per-point mapping table)
- Per-point scale/offset transform and out-of-range detection (sets Out-of-Service on range violation or Modbus failure)
- Supports Modbus FC01/02/03/04 (coil, discrete input, holding register, input register)
- Compile-time fallback defaults in gateway_config.h
- Bundled cJSON library for JSON parsing (no external dependencies)
- systemd service unit file (bacgw-mstp.service) included
- Tested on Raspberry Pi OS; portable to any Linux/POSIX platform with two RS-485 serial ports