### PR TITLE
Support routed virtual device backup/restore reinitialization

### DIFF
--- a/src/bacnet/basic/object/device.c
+++ b/src/bacnet/basic/object/device.c
@@ -1460,17 +1460,14 @@ static uint32_t Database_Revision = 0;
 /* Auto_Slave_Discovery */
 /* Slave_Address_Binding */
 /* Profile_Name */
-static BACNET_REINITIALIZED_STATE Reinitialize_State = BACNET_REINIT_IDLE;
-static const char *Reinit_Password = "filister";
+static BACNET_DEVICE_REINITIALIZE_DATA Reinitialize_Data = {
+    .State = BACNET_REINIT_IDLE, .Password = "filister"
+};
 static write_property_function Device_Write_Property_Store_Callback;
 static list_element_function Device_Add_List_Element_Callback;
 static list_element_function Device_Remove_List_Element_Callback;
 /* backup and restore */
 #if defined BACNET_BACKUP_RESTORE
-/* number of backup files */
-#ifndef BACNET_BACKUP_FILE_COUNT
-#define BACNET_BACKUP_FILE_COUNT 1
-#endif
 
 /* device A will read the Configuration_Files property of the Device object.
    This property will be used to determine the files to read and in what
@@ -1530,31 +1527,22 @@ static bool Device_Routed_Virtual_Device(void)
     return Device_Router_Mode && (Routed_Device_Object_Index() > 0);
 }
 
-static BACNET_REINITIALIZED_STATE *Device_Reinitialize_State_Value(void)
-{
-    DEVICE_OBJECT_DATA *pDev = Device_Routed_Data();
-
-    if (pDev) {
-        return &pDev->Reinitialize_State;
-    }
-
-    return &Reinitialize_State;
-}
-
-static const char **Device_Reinit_Password_Value(void)
-{
-    DEVICE_OBJECT_DATA *pDev = Device_Routed_Data();
-
-    if (pDev) {
-        return &pDev->Reinit_Password;
-    }
-
-    return &Reinit_Password;
-}
 #endif
 
+static BACNET_DEVICE_REINITIALIZE_DATA *Device_Reinitialize_Data(void)
+{
+#if defined(BAC_ROUTING)
+    DEVICE_OBJECT_DATA *pDev = Device_Routed_Data();
+
+    if (pDev) {
+        return &pDev->Reinitialize;
+    }
+#endif
+
+    return &Reinitialize_Data;
+}
+
 #if defined(BACNET_BACKUP_RESTORE)
-#if BACNET_BACKUP_FILE_COUNT
 static uint32_t *Device_Configuration_Files_Value(void)
 {
 #if defined(BAC_ROUTING)
@@ -1567,7 +1555,6 @@ static uint32_t *Device_Configuration_Files_Value(void)
 
     return Configuration_Files;
 }
-#endif
 
 static BACNET_TIMESTAMP *Device_Last_Restore_Time_Value(void)
 {
@@ -1674,13 +1661,10 @@ static BACNET_BACKUP_STATE *Device_Backup_State_Value(void)
  */
 bool Device_Reinitialize_Password_Set(const char *password)
 {
-#if defined(BAC_ROUTING)
-    const char **reinit_password = Device_Reinit_Password_Value();
+    BACNET_DEVICE_REINITIALIZE_DATA *reinitialize_data =
+        Device_Reinitialize_Data();
 
-    *reinit_password = password;
-#else
-    Reinit_Password = password;
-#endif
+    reinitialize_data->Password = password;
 
     return true;
 }
@@ -1704,14 +1688,10 @@ bool Device_Reinitialize(BACNET_REINITIALIZE_DEVICE_DATA *rd_data)
     bool password_success = false;
     unsigned i;
     size_t length;
-#if defined(BAC_ROUTING)
-    BACNET_REINITIALIZED_STATE *reinitialize_state =
-        Device_Reinitialize_State_Value();
-    const char *reinit_password = *Device_Reinit_Password_Value();
-#else
-    BACNET_REINITIALIZED_STATE *reinitialize_state = &Reinitialize_State;
-    const char *reinit_password = Reinit_Password;
-#endif
+    BACNET_DEVICE_REINITIALIZE_DATA *reinitialize_data =
+        Device_Reinitialize_Data();
+    BACNET_REINITIALIZED_STATE *reinitialize_state = &reinitialize_data->State;
+    const char *reinit_password = reinitialize_data->Password;
 #if defined BACNET_BACKUP_RESTORE
     BACNET_BACKUP_STATE *backup_state = Device_Backup_State_Value();
 #endif
@@ -1854,23 +1834,13 @@ bool Device_Reinitialize(BACNET_REINITIALIZE_DEVICE_DATA *rd_data)
 
 BACNET_REINITIALIZED_STATE Device_Reinitialized_State(void)
 {
-#if defined(BAC_ROUTING)
-    return *Device_Reinitialize_State_Value();
-#else
-    return Reinitialize_State;
-#endif
+    return Device_Reinitialize_Data()->State;
 }
 
 bool Device_Reinitialize_State_Set(BACNET_REINITIALIZED_STATE state)
 {
-#if defined(BAC_ROUTING)
-    BACNET_REINITIALIZED_STATE *reinitialize_state =
-        Device_Reinitialize_State_Value();
+    Device_Reinitialize_Data()->State = state;
 
-    *reinitialize_state = state;
-#else
-    Reinitialize_State = state;
-#endif
     return true;
 }
 
@@ -2618,7 +2588,7 @@ uint32_t Device_Interval_Offset(void)
 bool Device_Configuration_File_Set(unsigned index, uint32_t instance)
 {
     bool status = false;
-#if BACNET_BACKUP_FILE_COUNT
+#if defined(BACNET_BACKUP_RESTORE)
     uint32_t *configuration_files = Device_Configuration_Files_Value();
 
     if (index < BACNET_BACKUP_FILE_COUNT) {
@@ -2636,8 +2606,7 @@ bool Device_Configuration_File_Set(unsigned index, uint32_t instance)
 uint32_t Device_Configuration_File(unsigned index)
 {
     uint32_t instance = BACNET_MAX_INSTANCE + 1;
-
-#if BACNET_BACKUP_FILE_COUNT
+#if defined(BACNET_BACKUP_RESTORE)
     uint32_t *configuration_files = Device_Configuration_Files_Value();
 
     if (index < BACNET_BACKUP_FILE_COUNT) {
@@ -2660,8 +2629,7 @@ uint32_t Device_Configuration_File(unsigned index)
 bool Device_Is_Configuration_File(uint32_t instance)
 {
     bool status = false;
-
-#if BACNET_BACKUP_FILE_COUNT
+#if defined(BACNET_BACKUP_RESTORE)
     unsigned i;
     uint32_t *configuration_files = Device_Configuration_Files_Value();
 
@@ -2694,7 +2662,7 @@ int Device_Configuration_File_Encode(
     int apdu_len = BACNET_STATUS_ERROR;
 
     (void)object_instance;
-#if BACNET_BACKUP_FILE_COUNT
+#if defined(BACNET_BACKUP_RESTORE)
     uint32_t *configuration_files = Device_Configuration_Files_Value();
 
     if (array_index < BACNET_BACKUP_FILE_COUNT) {
@@ -4053,9 +4021,7 @@ void Device_Start_Backup(void)
     bool status = false;
     int32_t len = 0, offset = 0;
     BACNET_BACKUP_STATE *backup_state = Device_Backup_State_Value();
-#if BACNET_BACKUP_FILE_COUNT
     uint32_t *configuration_files = Device_Configuration_Files_Value();
-#endif
 
     object_count = Device_Object_List_Count();
     for (i = 0; i < object_count; i++) {
@@ -4076,11 +4042,9 @@ void Device_Start_Backup(void)
                 property_list.Proprietary.pList, writable_properties,
                 Device_Read_Property);
             if (len > 0) {
-#if BACNET_BACKUP_FILE_COUNT
                 (void)bacfile_write_offset(
                     configuration_files[0], offset, &object_apdu[0],
                     (uint32_t)len);
-#endif
                 offset += len;
             }
         }
@@ -4117,18 +4081,14 @@ void Device_End_Restore(void)
     int decoded_len = 0;
     BACNET_BACKUP_STATE *backup_state = Device_Backup_State_Value();
     BACNET_TIMESTAMP *last_restore_time = Device_Last_Restore_Time_Value();
-#if BACNET_BACKUP_FILE_COUNT
     uint32_t *configuration_files = Device_Configuration_Files_Value();
-#endif
 
     datetime_local(&bdateTime.date, &bdateTime.time, NULL, NULL);
     bacapp_timestamp_datetime_set(last_restore_time, &bdateTime);
     /* delete all existing objects before restore */
     Device_Delete_Objects();
     /* create objects from the backup file */
-#if BACNET_BACKUP_FILE_COUNT
     file_size = bacfile_file_size(configuration_files[0]);
-#endif
     while (offset < file_size) {
         apdu_len = bacfile_read_offset(
             configuration_files[0], offset, &apdu[0], sizeof(apdu));

--- a/src/bacnet/basic/object/device.c
+++ b/src/bacnet/basic/object/device.c
@@ -1515,6 +1515,150 @@ static BACNET_BACKUP_STATE Backup_State = BACKUP_STATE_IDLE;
 
 #ifdef BAC_ROUTING
 static bool Device_Router_Mode = false;
+
+static DEVICE_OBJECT_DATA *Device_Routed_Data(void)
+{
+    if (Device_Router_Mode) {
+        return Get_Routed_Device_Object(-1);
+    }
+
+    return NULL;
+}
+
+static bool Device_Routed_Virtual_Device(void)
+{
+    return Device_Router_Mode && (Routed_Device_Object_Index() > 0);
+}
+
+static BACNET_REINITIALIZED_STATE *Device_Reinitialize_State_Value(void)
+{
+    DEVICE_OBJECT_DATA *pDev = Device_Routed_Data();
+
+    if (pDev) {
+        return &pDev->Reinitialize_State;
+    }
+
+    return &Reinitialize_State;
+}
+
+static const char **Device_Reinit_Password_Value(void)
+{
+    DEVICE_OBJECT_DATA *pDev = Device_Routed_Data();
+
+    if (pDev) {
+        return &pDev->Reinit_Password;
+    }
+
+    return &Reinit_Password;
+}
+#endif
+
+#if defined(BACNET_BACKUP_RESTORE)
+#if BACNET_BACKUP_FILE_COUNT
+static uint32_t *Device_Configuration_Files_Value(void)
+{
+#if defined(BAC_ROUTING)
+    DEVICE_OBJECT_DATA *pDev = Device_Routed_Data();
+
+    if (pDev) {
+        return pDev->Backup.Configuration_Files;
+    }
+#endif
+
+    return Configuration_Files;
+}
+#endif
+
+static BACNET_TIMESTAMP *Device_Last_Restore_Time_Value(void)
+{
+#if defined(BAC_ROUTING)
+    DEVICE_OBJECT_DATA *pDev = Device_Routed_Data();
+
+    if (pDev) {
+        return &pDev->Backup.Last_Restore_Time;
+    }
+#endif
+
+    return &Last_Restore_Time;
+}
+
+static uint16_t *Device_Backup_Failure_Timeout_Value(void)
+{
+#if defined(BAC_ROUTING)
+    DEVICE_OBJECT_DATA *pDev = Device_Routed_Data();
+
+    if (pDev) {
+        return &pDev->Backup.Backup_Failure_Timeout;
+    }
+#endif
+
+    return &Backup_Failure_Timeout;
+}
+
+static uint32_t *Device_Backup_Failure_Timeout_Milliseconds_Value(void)
+{
+#if defined(BAC_ROUTING)
+    DEVICE_OBJECT_DATA *pDev = Device_Routed_Data();
+
+    if (pDev) {
+        return &pDev->Backup.Backup_Failure_Timeout_Milliseconds;
+    }
+#endif
+
+    return &Backup_Failure_Timeout_Milliseconds;
+}
+
+static uint16_t *Device_Backup_Preparation_Time_Value(void)
+{
+#if defined(BAC_ROUTING)
+    DEVICE_OBJECT_DATA *pDev = Device_Routed_Data();
+
+    if (pDev) {
+        return &pDev->Backup.Backup_Preparation_Time;
+    }
+#endif
+
+    return &Backup_Preparation_Time;
+}
+
+static uint16_t *Device_Restore_Preparation_Time_Value(void)
+{
+#if defined(BAC_ROUTING)
+    DEVICE_OBJECT_DATA *pDev = Device_Routed_Data();
+
+    if (pDev) {
+        return &pDev->Backup.Restore_Preparation_Time;
+    }
+#endif
+
+    return &Restore_Preparation_Time;
+}
+
+static uint16_t *Device_Restore_Completion_Time_Value(void)
+{
+#if defined(BAC_ROUTING)
+    DEVICE_OBJECT_DATA *pDev = Device_Routed_Data();
+
+    if (pDev) {
+        return &pDev->Backup.Restore_Completion_Time;
+    }
+#endif
+
+    return &Restore_Completion_Time;
+}
+
+static BACNET_BACKUP_STATE *Device_Backup_State_Value(void)
+{
+#if defined(BAC_ROUTING)
+    DEVICE_OBJECT_DATA *pDev = Device_Routed_Data();
+
+    if (pDev) {
+        return &pDev->Backup.Backup_State;
+    }
+#endif
+
+    return &Backup_State;
+}
 #endif
 
 /**
@@ -1530,7 +1674,13 @@ static bool Device_Router_Mode = false;
  */
 bool Device_Reinitialize_Password_Set(const char *password)
 {
+#if defined(BAC_ROUTING)
+    const char **reinit_password = Device_Reinit_Password_Value();
+
+    *reinit_password = password;
+#else
     Reinit_Password = password;
+#endif
 
     return true;
 }
@@ -1554,6 +1704,17 @@ bool Device_Reinitialize(BACNET_REINITIALIZE_DEVICE_DATA *rd_data)
     bool password_success = false;
     unsigned i;
     size_t length;
+#if defined(BAC_ROUTING)
+    BACNET_REINITIALIZED_STATE *reinitialize_state =
+        Device_Reinitialize_State_Value();
+    const char *reinit_password = *Device_Reinit_Password_Value();
+#else
+    BACNET_REINITIALIZED_STATE *reinitialize_state = &Reinitialize_State;
+    const char *reinit_password = Reinit_Password;
+#endif
+#if defined BACNET_BACKUP_RESTORE
+    BACNET_BACKUP_STATE *backup_state = Device_Backup_State_Value();
+#endif
 
     /* From 16.4.1.1.2 Password
         This optional parameter shall be a CharacterString of up to
@@ -1561,7 +1722,7 @@ bool Device_Reinitialize(BACNET_REINITIALIZE_DEVICE_DATA *rd_data)
         protection, the service request shall be denied if the parameter
         is absent or if the password is incorrect. For those devices that
         do not require a password, this parameter shall be ignored.*/
-    if (Reinit_Password && strlen(Reinit_Password) > 0) {
+    if (reinit_password && strlen(reinit_password) > 0) {
         if (characterstring_encoding(&rd_data->password) == CHARACTER_UTF8) {
             length = characterstring_utf8_length(&rd_data->password);
         } else {
@@ -1571,7 +1732,7 @@ bool Device_Reinitialize(BACNET_REINITIALIZE_DEVICE_DATA *rd_data)
             rd_data->error_class = ERROR_CLASS_SERVICES;
             rd_data->error_code = ERROR_CODE_PARAMETER_OUT_OF_RANGE;
         } else if (characterstring_ansi_same(
-                       &rd_data->password, Reinit_Password)) {
+                       &rd_data->password, reinit_password)) {
             password_success = true;
         } else {
             rd_data->error_class = ERROR_CLASS_SECURITY;
@@ -1581,13 +1742,24 @@ bool Device_Reinitialize(BACNET_REINITIALIZE_DEVICE_DATA *rd_data)
         password_success = true;
     }
     if (password_success) {
+#if defined(BAC_ROUTING)
+        if (Device_Routed_Virtual_Device() &&
+            ((rd_data->state == BACNET_REINIT_COLDSTART) ||
+             (rd_data->state == BACNET_REINIT_WARMSTART) ||
+             (rd_data->state == BACNET_REINIT_ACTIVATE_CHANGES))) {
+            rd_data->error_class = ERROR_CLASS_SERVICES;
+            rd_data->error_code =
+                ERROR_CODE_OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED;
+            return false;
+        }
+#endif
         switch (rd_data->state) {
             case BACNET_REINIT_COLDSTART:
                 dcc_set_status_duration(COMMUNICATION_ENABLE, 0);
                 /* note: you probably want to restart *after* the
                    simple ack has been sent from the return handler
                    so just set a flag from here */
-                Reinitialize_State = rd_data->state;
+                *reinitialize_state = rd_data->state;
                 status = true;
                 break;
             case BACNET_REINIT_WARMSTART:
@@ -1599,50 +1771,50 @@ bool Device_Reinitialize(BACNET_REINITIALIZE_DEVICE_DATA *rd_data)
                 /* note: you probably want to restart *after* the
                    simple ack has been sent from the return handler
                    so just set a flag from here */
-                Reinitialize_State = rd_data->state;
+                *reinitialize_state = rd_data->state;
                 status = true;
                 break;
 #if defined BACNET_BACKUP_RESTORE
             case BACNET_REINIT_STARTBACKUP:
-                if (Device_Backup_State_In_Progress(Backup_State)) {
+                if (Device_Backup_State_In_Progress(*backup_state)) {
                     rd_data->error_class = ERROR_CLASS_DEVICE;
                     rd_data->error_code = ERROR_CODE_CONFIGURATION_IN_PROGRESS;
                     break;
                 }
-                Backup_State = BACKUP_STATE_PREPARING_FOR_BACKUP;
+                *backup_state = BACKUP_STATE_PREPARING_FOR_BACKUP;
                 Device_Backup_Failure_Timeout_Restart();
                 Device_Start_Backup();
-                Reinitialize_State = rd_data->state;
+                *reinitialize_state = rd_data->state;
                 status = true;
                 break;
             case BACNET_REINIT_STARTRESTORE:
-                if (Device_Backup_State_In_Progress(Backup_State)) {
+                if (Device_Backup_State_In_Progress(*backup_state)) {
                     rd_data->error_class = ERROR_CLASS_DEVICE;
                     rd_data->error_code = ERROR_CODE_CONFIGURATION_IN_PROGRESS;
                     break;
                 }
-                Backup_State = BACKUP_STATE_PREPARING_FOR_RESTORE;
+                *backup_state = BACKUP_STATE_PREPARING_FOR_RESTORE;
                 Device_Backup_Failure_Timeout_Restart();
                 Device_Start_Restore();
-                Reinitialize_State = rd_data->state;
+                *reinitialize_state = rd_data->state;
                 status = true;
                 break;
             case BACNET_REINIT_ENDRESTORE:
-                if (Backup_State != BACKUP_STATE_PERFORMING_A_RESTORE) {
+                if (*backup_state != BACKUP_STATE_PERFORMING_A_RESTORE) {
                     rd_data->error_class = ERROR_CLASS_DEVICE;
                     rd_data->error_code = ERROR_CODE_CONFIGURATION_IN_PROGRESS;
                     break;
                 }
                 Device_Backup_Failure_Timeout_Restart();
                 Device_End_Restore();
-                Reinitialize_State = rd_data->state;
+                *reinitialize_state = rd_data->state;
                 status = true;
                 break;
             case BACNET_REINIT_ENDBACKUP:
             case BACNET_REINIT_ABORTRESTORE:
-                Backup_State = BACKUP_STATE_IDLE;
+                *backup_state = BACKUP_STATE_IDLE;
                 Device_Backup_Failure_Timeout_Reset();
-                Reinitialize_State = rd_data->state;
+                *reinitialize_state = rd_data->state;
                 status = true;
                 break;
 #else
@@ -1667,7 +1839,7 @@ bool Device_Reinitialize(BACNET_REINITIALIZE_DEVICE_DATA *rd_data)
                     Network_Port_Changes_Pending_Activate(
                         Network_Port_Index_To_Instance(i));
                 }
-                Reinitialize_State = rd_data->state;
+                *reinitialize_state = rd_data->state;
                 status = true;
                 break;
             default:
@@ -1682,12 +1854,23 @@ bool Device_Reinitialize(BACNET_REINITIALIZE_DEVICE_DATA *rd_data)
 
 BACNET_REINITIALIZED_STATE Device_Reinitialized_State(void)
 {
+#if defined(BAC_ROUTING)
+    return *Device_Reinitialize_State_Value();
+#else
     return Reinitialize_State;
+#endif
 }
 
 bool Device_Reinitialize_State_Set(BACNET_REINITIALIZED_STATE state)
 {
+#if defined(BAC_ROUTING)
+    BACNET_REINITIALIZED_STATE *reinitialize_state =
+        Device_Reinitialize_State_Value();
+
+    *reinitialize_state = state;
+#else
     Reinitialize_State = state;
+#endif
     return true;
 }
 
@@ -2436,8 +2619,10 @@ bool Device_Configuration_File_Set(unsigned index, uint32_t instance)
 {
     bool status = false;
 #if BACNET_BACKUP_FILE_COUNT
+    uint32_t *configuration_files = Device_Configuration_Files_Value();
+
     if (index < BACNET_BACKUP_FILE_COUNT) {
-        Configuration_Files[index] = instance;
+        configuration_files[index] = instance;
         status = true;
     }
 #else
@@ -2453,8 +2638,10 @@ uint32_t Device_Configuration_File(unsigned index)
     uint32_t instance = BACNET_MAX_INSTANCE + 1;
 
 #if BACNET_BACKUP_FILE_COUNT
+    uint32_t *configuration_files = Device_Configuration_Files_Value();
+
     if (index < BACNET_BACKUP_FILE_COUNT) {
-        instance = Configuration_Files[index];
+        instance = configuration_files[index];
     }
 #else
     (void)index;
@@ -2476,8 +2663,10 @@ bool Device_Is_Configuration_File(uint32_t instance)
 
 #if BACNET_BACKUP_FILE_COUNT
     unsigned i;
+    uint32_t *configuration_files = Device_Configuration_Files_Value();
+
     for (i = 0; i < BACNET_BACKUP_FILE_COUNT; i++) {
-        if (Configuration_Files[i] == instance) {
+        if (configuration_files[i] == instance) {
             status = true;
             break;
         }
@@ -2506,9 +2695,11 @@ int Device_Configuration_File_Encode(
 
     (void)object_instance;
 #if BACNET_BACKUP_FILE_COUNT
+    uint32_t *configuration_files = Device_Configuration_Files_Value();
+
     if (array_index < BACNET_BACKUP_FILE_COUNT) {
         apdu_len = encode_application_object_id(
-            apdu, OBJECT_FILE, Configuration_Files[array_index]);
+            apdu, OBJECT_FILE, configuration_files[array_index]);
     }
 #else
     (void)array_index;
@@ -2586,56 +2777,67 @@ static BACNET_ERROR_CODE Device_Configuration_File_Write(
 
 uint16_t Device_Backup_Failure_Timeout(void)
 {
-    return Backup_Failure_Timeout;
+    return *Device_Backup_Failure_Timeout_Value();
 }
 
 bool Device_Backup_Failure_Timeout_Set(uint16_t timeout)
 {
-    Backup_Failure_Timeout = timeout;
+    uint16_t *backup_failure_timeout = Device_Backup_Failure_Timeout_Value();
+
+    *backup_failure_timeout = timeout;
     return true;
 }
 
 uint16_t Device_Backup_Preparation_Time(void)
 {
-    return Backup_Preparation_Time;
+    return *Device_Backup_Preparation_Time_Value();
 }
 
 bool Device_Backup_Preparation_Time_Set(uint16_t time)
 {
-    Backup_Preparation_Time = time;
+    uint16_t *backup_preparation_time = Device_Backup_Preparation_Time_Value();
+
+    *backup_preparation_time = time;
     return true;
 }
 
 uint16_t Device_Restore_Preparation_Time(void)
 {
-    return Restore_Preparation_Time;
+    return *Device_Restore_Preparation_Time_Value();
 }
 
 bool Device_Restore_Preparation_Time_Set(uint16_t time)
 {
-    Restore_Preparation_Time = time;
+    uint16_t *restore_preparation_time =
+        Device_Restore_Preparation_Time_Value();
+
+    *restore_preparation_time = time;
     return true;
 }
 
 uint16_t Device_Restore_Completion_Time(void)
 {
-    return Restore_Completion_Time;
+    return *Device_Restore_Completion_Time_Value();
 }
 
 bool Device_Restore_Completion_Time_Set(uint16_t time)
 {
-    Restore_Completion_Time = time;
+    uint16_t *restore_completion_time = Device_Restore_Completion_Time_Value();
+
+    *restore_completion_time = time;
     return true;
 }
 
 BACNET_BACKUP_STATE Device_Backup_And_Restore_State(void)
 {
-    return Backup_State;
+    return *Device_Backup_State_Value();
 }
 
 bool Device_Backup_And_Restore_State_Set(BACNET_BACKUP_STATE state)
 {
-    Backup_State = state;
+    BACNET_BACKUP_STATE *backup_state = Device_Backup_State_Value();
+
+    *backup_state = state;
     return true;
 }
 
@@ -2646,7 +2848,10 @@ bool Device_Backup_And_Restore_State_Set(BACNET_BACKUP_STATE state)
  */
 void Device_Backup_Failure_Timeout_Reset(void)
 {
-    Backup_Failure_Timeout_Milliseconds = 0;
+    uint32_t *backup_failure_timeout_milliseconds =
+        Device_Backup_Failure_Timeout_Milliseconds_Value();
+
+    *backup_failure_timeout_milliseconds = 0;
 }
 #endif
 
@@ -2675,10 +2880,15 @@ bool Device_Backup_State_In_Progress(BACNET_BACKUP_STATE state)
 void Device_Backup_Failure_Timeout_Restart(void)
 {
 #if defined(BACNET_BACKUP_RESTORE)
-    if (Device_Backup_State_In_Progress(Backup_State)) {
+    BACNET_BACKUP_STATE *backup_state = Device_Backup_State_Value();
+    uint16_t *backup_failure_timeout = Device_Backup_Failure_Timeout_Value();
+    uint32_t *backup_failure_timeout_milliseconds =
+        Device_Backup_Failure_Timeout_Milliseconds_Value();
+
+    if (Device_Backup_State_In_Progress(*backup_state)) {
         /* service related to backup & restore will reset the backup failure
            timeout during a backup or restore operation */
-        Backup_Failure_Timeout_Milliseconds = Backup_Failure_Timeout * 1000UL;
+        *backup_failure_timeout_milliseconds = *backup_failure_timeout * 1000UL;
     }
 #endif
 }
@@ -2700,20 +2910,24 @@ void Device_Backup_Failure_Timeout_Restart(void)
 void Device_Backup_Failure_Timeout_Countdown(uint32_t milliseconds)
 {
 #if defined(BACNET_BACKUP_RESTORE)
-    if (Device_Backup_State_In_Progress(Backup_State)) {
+    BACNET_BACKUP_STATE *backup_state = Device_Backup_State_Value();
+    uint32_t *backup_failure_timeout_milliseconds =
+        Device_Backup_Failure_Timeout_Milliseconds_Value();
+
+    if (Device_Backup_State_In_Progress(*backup_state)) {
         /* service related to backup & restore will restart the backup
            failure timer during a backup or restore operation */
-        if (Backup_Failure_Timeout_Milliseconds > 0) {
-            if (milliseconds >= Backup_Failure_Timeout_Milliseconds) {
-                Backup_Failure_Timeout_Milliseconds = 0;
+        if (*backup_failure_timeout_milliseconds > 0) {
+            if (milliseconds >= *backup_failure_timeout_milliseconds) {
+                *backup_failure_timeout_milliseconds = 0;
             } else {
-                Backup_Failure_Timeout_Milliseconds -= milliseconds;
+                *backup_failure_timeout_milliseconds -= milliseconds;
             }
-            if (Backup_Failure_Timeout_Milliseconds == 0) {
-                if (Backup_State == BACKUP_STATE_PERFORMING_A_BACKUP) {
-                    Backup_State = BACKUP_STATE_BACKUP_FAILURE;
-                } else if (Backup_State == BACKUP_STATE_PERFORMING_A_RESTORE) {
-                    Backup_State = BACKUP_STATE_RESTORE_FAILURE;
+            if (*backup_failure_timeout_milliseconds == 0) {
+                if (*backup_state == BACKUP_STATE_PERFORMING_A_BACKUP) {
+                    *backup_state = BACKUP_STATE_BACKUP_FAILURE;
+                } else if (*backup_state == BACKUP_STATE_PERFORMING_A_RESTORE) {
+                    *backup_state = BACKUP_STATE_RESTORE_FAILURE;
                 }
             }
         }
@@ -3838,6 +4052,10 @@ void Device_Start_Backup(void)
     BACNET_CREATE_OBJECT_DATA create_data = { 0 };
     bool status = false;
     int32_t len = 0, offset = 0;
+    BACNET_BACKUP_STATE *backup_state = Device_Backup_State_Value();
+#if BACNET_BACKUP_FILE_COUNT
+    uint32_t *configuration_files = Device_Configuration_Files_Value();
+#endif
 
     object_count = Device_Object_List_Count();
     for (i = 0; i < object_count; i++) {
@@ -3858,14 +4076,16 @@ void Device_Start_Backup(void)
                 property_list.Proprietary.pList, writable_properties,
                 Device_Read_Property);
             if (len > 0) {
+#if BACNET_BACKUP_FILE_COUNT
                 (void)bacfile_write_offset(
-                    Configuration_Files[0], offset, &object_apdu[0],
+                    configuration_files[0], offset, &object_apdu[0],
                     (uint32_t)len);
+#endif
                 offset += len;
             }
         }
     }
-    Backup_State = BACKUP_STATE_PERFORMING_A_BACKUP;
+    *backup_state = BACKUP_STATE_PERFORMING_A_BACKUP;
 #endif
 }
 
@@ -3876,7 +4096,9 @@ void Device_Start_Backup(void)
 void Device_Start_Restore(void)
 {
 #if defined BACNET_BACKUP_RESTORE
-    Backup_State = BACKUP_STATE_PERFORMING_A_RESTORE;
+    BACNET_BACKUP_STATE *backup_state = Device_Backup_State_Value();
+
+    *backup_state = BACKUP_STATE_PERFORMING_A_RESTORE;
 #endif
 }
 
@@ -3893,16 +4115,23 @@ void Device_End_Restore(void)
     uint8_t apdu[MAX_APDU] = { 0 };
     int32_t apdu_len = 0, offset = 0, file_size = 0;
     int decoded_len = 0;
+    BACNET_BACKUP_STATE *backup_state = Device_Backup_State_Value();
+    BACNET_TIMESTAMP *last_restore_time = Device_Last_Restore_Time_Value();
+#if BACNET_BACKUP_FILE_COUNT
+    uint32_t *configuration_files = Device_Configuration_Files_Value();
+#endif
 
     datetime_local(&bdateTime.date, &bdateTime.time, NULL, NULL);
-    bacapp_timestamp_datetime_set(&Last_Restore_Time, &bdateTime);
+    bacapp_timestamp_datetime_set(last_restore_time, &bdateTime);
     /* delete all existing objects before restore */
     Device_Delete_Objects();
     /* create objects from the backup file */
-    file_size = bacfile_file_size(Configuration_Files[0]);
+#if BACNET_BACKUP_FILE_COUNT
+    file_size = bacfile_file_size(configuration_files[0]);
+#endif
     while (offset < file_size) {
         apdu_len = bacfile_read_offset(
-            Configuration_Files[0], offset, &apdu[0], sizeof(apdu));
+            configuration_files[0], offset, &apdu[0], sizeof(apdu));
         if (apdu_len > 0) {
             decoded_len = create_object_decode_service_request(
                 apdu, apdu_len, &create_data);
@@ -3917,18 +4146,18 @@ void Device_End_Restore(void)
                     /* error creating object - keep going */
                 }
             } else {
-                Backup_State = BACKUP_STATE_RESTORE_FAILURE;
+                *backup_state = BACKUP_STATE_RESTORE_FAILURE;
                 /* error while decoding object  */
                 break;
             }
         } else {
-            Backup_State = BACKUP_STATE_RESTORE_FAILURE;
+            *backup_state = BACKUP_STATE_RESTORE_FAILURE;
             /* error while reading file  */
             break;
         }
     }
-    if (Backup_State != BACKUP_STATE_RESTORE_FAILURE) {
-        Backup_State = BACKUP_STATE_IDLE;
+    if (*backup_state != BACKUP_STATE_RESTORE_FAILURE) {
+        *backup_state = BACKUP_STATE_IDLE;
     }
 #endif
 }
@@ -4113,23 +4342,31 @@ void Device_Timer(uint16_t milliseconds)
 #ifdef BAC_ROUTING
     uint16_t dev_id = 0;
     uint16_t current_dev_id = Routed_Device_Object_Index();
-    /* TODO: Multi-device Backup/Restore support
-     * Currently only Gateway (dev_id=0) supports Backup/Restore.
-     * Virtual devices are blocked by Routed_Device_Service_Approval().
-     * Plan to support after discussing with maintainer.
-     *
-     * To enable per-device Backup/Restore:
-     * 1. Move Backup-related static variables to DEVICE_OBJECT_DATA:
-     *    - Backup_State, Backup_Failure_Timeout_Milliseconds
-     *    - Backup_Failure_Timeout, Configuration_Files[]
-     *    - Last_Restore_Time, Backup/Restore_Preparation_Time
-     * 2. Modify Routed_Device_Service_Approval() to allow RD on virtual devices
-     * 3. Call Device_Backup_Failure_Timeout_Countdown() inside the for loop
-     *    for each device
-     */
-    Device_Backup_Failure_Timeout_Countdown(milliseconds);
-    for (dev_id = 0; dev_id < Get_Num_Managed_Devices(); dev_id++) {
-        Set_Routed_Device_Object_Index(dev_id);
+
+    if (Device_Router_Mode) {
+        for (dev_id = 0; dev_id < Get_Num_Managed_Devices(); dev_id++) {
+            Set_Routed_Device_Object_Index(dev_id);
+            Device_Backup_Failure_Timeout_Countdown(milliseconds);
+            pObject = Object_Table;
+            while (pObject->Object_Type < MAX_BACNET_OBJECT_TYPE) {
+                count = 0;
+                if (pObject->Object_Count) {
+                    count = pObject->Object_Count();
+                }
+                while (count) {
+                    count--;
+                    if ((pObject->Object_Timer) &&
+                        (pObject->Object_Index_To_Instance)) {
+                        instance = pObject->Object_Index_To_Instance(count);
+                        pObject->Object_Timer(instance, milliseconds);
+                    }
+                }
+                pObject++;
+            }
+        }
+        Set_Routed_Device_Object_Index(current_dev_id);
+    } else {
+        Device_Backup_Failure_Timeout_Countdown(milliseconds);
         pObject = Object_Table;
         while (pObject->Object_Type < MAX_BACNET_OBJECT_TYPE) {
             count = 0;
@@ -4147,7 +4384,6 @@ void Device_Timer(uint16_t milliseconds)
             pObject++;
         }
     }
-    Set_Routed_Device_Object_Index(current_dev_id);
 #else
     Device_Backup_Failure_Timeout_Countdown(milliseconds);
     pObject = Object_Table;
@@ -4190,6 +4426,7 @@ void Routing_Device_Init(uint32_t first_object_instance)
     Device_Router_Mode = true;
 
     /* Initialize with our preset strings */
+    Routed_Device_Table_Reset();
     Add_Routed_Device(first_object_instance, &My_Object_Name, Description);
 
     /* Now substitute our routed versions of the main object functions. */

--- a/src/bacnet/basic/object/device.h
+++ b/src/bacnet/basic/object/device.h
@@ -178,10 +178,17 @@ typedef struct commonBacObj_s {
  *  This may be useful for implementations which manage multiple Devices,
  *  eg, a Gateway.
  */
-#if defined(BAC_ROUTING) && defined(BACNET_BACKUP_RESTORE)
+/* number of backup files */
+#if defined(BACNET_BACKUP_RESTORE)
 #ifndef BACNET_BACKUP_FILE_COUNT
 #define BACNET_BACKUP_FILE_COUNT 1
+#elif (BACNET_BACKUP_FILE_COUNT < 1)
+#error \
+    "BACNET_BACKUP_FILE_COUNT must be at least 1 when BACNET_BACKUP_RESTORE is enabled"
 #endif
+#endif
+
+#if defined(BAC_ROUTING) && defined(BACNET_BACKUP_RESTORE)
 typedef struct bacnet_backup_restore_data_s {
     BACNET_BACKUP_STATE Backup_State;
     uint16_t Backup_Failure_Timeout;
@@ -193,6 +200,11 @@ typedef struct bacnet_backup_restore_data_s {
     uint16_t Restore_Completion_Time;
 } BACNET_BACKUP_RESTORE_DATA;
 #endif
+
+typedef struct bacnet_device_reinitialize_data_s {
+    BACNET_REINITIALIZED_STATE State;
+    const char *Password;
+} BACNET_DEVICE_REINITIALIZE_DATA;
 
 typedef struct devObj_s {
     /** The BACnet Device Address for this device; ->len depends on DLL type. */
@@ -209,8 +221,7 @@ typedef struct devObj_s {
     uint32_t Database_Revision;
 
 #if defined(BAC_ROUTING)
-    BACNET_REINITIALIZED_STATE Reinitialize_State;
-    const char *Reinit_Password;
+    BACNET_DEVICE_REINITIALIZE_DATA Reinitialize;
 #if defined(BACNET_BACKUP_RESTORE)
     BACNET_BACKUP_RESTORE_DATA Backup;
 #endif

--- a/src/bacnet/basic/object/device.h
+++ b/src/bacnet/basic/object/device.h
@@ -178,6 +178,22 @@ typedef struct commonBacObj_s {
  *  This may be useful for implementations which manage multiple Devices,
  *  eg, a Gateway.
  */
+#if defined(BAC_ROUTING) && defined(BACNET_BACKUP_RESTORE)
+#ifndef BACNET_BACKUP_FILE_COUNT
+#define BACNET_BACKUP_FILE_COUNT 1
+#endif
+typedef struct bacnet_backup_restore_data_s {
+    BACNET_BACKUP_STATE Backup_State;
+    uint16_t Backup_Failure_Timeout;
+    uint32_t Backup_Failure_Timeout_Milliseconds;
+    uint32_t Configuration_Files[BACNET_BACKUP_FILE_COUNT];
+    BACNET_TIMESTAMP Last_Restore_Time;
+    uint16_t Backup_Preparation_Time;
+    uint16_t Restore_Preparation_Time;
+    uint16_t Restore_Completion_Time;
+} BACNET_BACKUP_RESTORE_DATA;
+#endif
+
 typedef struct devObj_s {
     /** The BACnet Device Address for this device; ->len depends on DLL type. */
     BACNET_ADDRESS bacDevAddr;
@@ -191,6 +207,14 @@ typedef struct devObj_s {
     /** The upcounter that shows if the Device ID or object structure has
      * changed. */
     uint32_t Database_Revision;
+
+#if defined(BAC_ROUTING)
+    BACNET_REINITIALIZED_STATE Reinitialize_State;
+    const char *Reinit_Password;
+#if defined(BACNET_BACKUP_RESTORE)
+    BACNET_BACKUP_RESTORE_DATA Backup;
+#endif
+#endif
 } DEVICE_OBJECT_DATA;
 
 #ifdef __cplusplus
@@ -496,6 +520,8 @@ uint16_t Add_Routed_Device(
     uint32_t Object_Instance,
     const BACNET_CHARACTER_STRING *Object_Name,
     const char *Description);
+BACNET_STACK_EXPORT
+void Routed_Device_Table_Reset(void);
 BACNET_STACK_EXPORT
 DEVICE_OBJECT_DATA *Get_Routed_Device_Object(int idx);
 BACNET_STACK_EXPORT

--- a/src/bacnet/basic/object/gateway/gw_device.c
+++ b/src/bacnet/basic/object/gateway/gw_device.c
@@ -75,6 +75,14 @@ uint16_t Num_Managed_Devices = 0;
  */
 uint16_t iCurrent_Device_Idx = 0;
 
+/** Reset the routed Device table before rebuilding the gateway/virtual list. */
+void Routed_Device_Table_Reset(void)
+{
+    memset(&Devices[0], 0, sizeof(Devices));
+    Num_Managed_Devices = 0;
+    iCurrent_Device_Idx = 0;
+}
+
 /** Get the current routed device object index.
  * @return Index of the currently active routed device in Devices[] array
  */
@@ -150,6 +158,15 @@ uint16_t Add_Routed_Device(
             Routed_Device_Set_Description("No Descr", strlen("No Descr"));
         }
         pDev->Database_Revision = 0; /* Reset/Initialize now */
+#if defined(BAC_ROUTING)
+        pDev->Reinitialize_State = BACNET_REINIT_IDLE;
+        pDev->Reinit_Password = "filister";
+#if defined(BACNET_BACKUP_RESTORE)
+        memset(&pDev->Backup, 0, sizeof(pDev->Backup));
+        pDev->Backup.Backup_State = BACKUP_STATE_IDLE;
+        pDev->Backup.Backup_Failure_Timeout = 60 * 60;
+#endif
+#endif
         return i;
     } else {
         return UINT16_MAX;
@@ -606,8 +623,8 @@ void Routed_Device_Inc_Database_Revision(void)
 }
 
 /** Check to see if the current Device supports this service.
- * Presently checks for RD and DCC and only allows them if the current
- * device is the gateway device.
+ * Presently allows ReinitializeDevice for routed virtual devices and keeps
+ * DeviceCommunicationControl restricted to the gateway device.
  *
  * @param service [in] The service being requested.
  * @param service_argument [in] An optional argument (eg, service type).
@@ -629,16 +646,9 @@ int Routed_Device_Service_Approval(
     (void)service_argument;
     switch (service) {
         case SERVICE_SUPPORTED_REINITIALIZE_DEVICE:
-            /* If not the gateway device, we don't support RD */
-            if (iCurrent_Device_Idx > 0) {
-                if (apdu_buff != NULL) {
-                    len = reject_encode_apdu(
-                        apdu_buff, invoke_id,
-                        REJECT_REASON_UNRECOGNIZED_SERVICE);
-                } else {
-                    len = 1; /* Non-zero return */
-                }
-            }
+            /* RD is accepted for virtual devices. Device_Reinitialize()
+               handles state-specific support and returns service errors for
+               virtual-device states that have gateway/system side effects. */
             break;
         case SERVICE_SUPPORTED_DEVICE_COMMUNICATION_CONTROL:
             /* If not the gateway device, we don't support DCC */

--- a/src/bacnet/basic/object/gateway/gw_device.c
+++ b/src/bacnet/basic/object/gateway/gw_device.c
@@ -159,8 +159,8 @@ uint16_t Add_Routed_Device(
         }
         pDev->Database_Revision = 0; /* Reset/Initialize now */
 #if defined(BAC_ROUTING)
-        pDev->Reinitialize_State = BACNET_REINIT_IDLE;
-        pDev->Reinit_Password = "filister";
+        pDev->Reinitialize.State = BACNET_REINIT_IDLE;
+        pDev->Reinitialize.Password = "filister";
 #if defined(BACNET_BACKUP_RESTORE)
         memset(&pDev->Backup, 0, sizeof(pDev->Backup));
         pDev->Backup.Backup_State = BACKUP_STATE_IDLE;

--- a/src/bacnet/basic/server/bacnet_device.c
+++ b/src/bacnet/basic/server/bacnet_device.c
@@ -1362,7 +1362,7 @@ static const char *Device_Location_Default = BACNET_DEVICE_LOCATION_NAME;
 static const char *Device_Description_Default = BACNET_DEVICE_DESCRIPTION;
 static uint32_t Database_Revision;
 static BACNET_REINITIALIZED_STATE Reinitialize_State = BACNET_REINIT_IDLE;
-static BACNET_CHARACTER_STRING Reinit_Password;
+static const char *Reinit_Password = "filister";
 static write_property_function Device_Write_Property_Store_Callback;
 static list_element_function Device_Add_List_Element_Callback;
 static list_element_function Device_Remove_List_Element_Callback;
@@ -1445,7 +1445,7 @@ static BACNET_BACKUP_STATE Backup_State = BACKUP_STATE_IDLE;
  */
 bool Device_Reinitialize_Password_Set(const char *password)
 {
-    characterstring_init_ansi(&Reinit_Password, password);
+    Reinit_Password = password;
 
     return true;
 }
@@ -1477,7 +1477,7 @@ bool Device_Reinitialize(BACNET_REINITIALIZE_DEVICE_DATA *rd_data)
         protection, the service request shall be denied if the parameter
         is absent or if the password is incorrect. For those devices that
         do not require a password, this parameter shall be ignored.*/
-    if (characterstring_length(&Reinit_Password) > 0) {
+    if (Reinit_Password && strlen(Reinit_Password) > 0) {
         if (characterstring_encoding(&rd_data->password) == CHARACTER_UTF8) {
             length = characterstring_utf8_length(&rd_data->password);
         } else {
@@ -1486,7 +1486,8 @@ bool Device_Reinitialize(BACNET_REINITIALIZE_DEVICE_DATA *rd_data)
         if (length > 20) {
             rd_data->error_class = ERROR_CLASS_SERVICES;
             rd_data->error_code = ERROR_CODE_PARAMETER_OUT_OF_RANGE;
-        } else if (characterstring_same(&rd_data->password, &Reinit_Password)) {
+        } else if (characterstring_ansi_same(
+                       &rd_data->password, Reinit_Password)) {
             password_success = true;
         } else {
             rd_data->error_class = ERROR_CLASS_SECURITY;

--- a/test/bacnet/basic/object/device/CMakeLists.txt
+++ b/test/bacnet/basic/object/device/CMakeLists.txt
@@ -158,24 +158,16 @@ function(configure_device_test_target
     endif()
 endfunction()
 
-function(add_device_test_variant
-    target_name test_name routing_enabled backup_restore_enabled)
-    add_executable(${target_name}
-        ${TEST_DEVICE_SOURCES}
-        )
-    configure_device_test_target(
-        ${target_name} ${routing_enabled} ${backup_restore_enabled})
-    add_test(
-        NAME build_${test_name}
-        COMMAND ${CMAKE_COMMAND}
-            --build "${CMAKE_BINARY_DIR}"
-            --config $<CONFIG>
-            --target ${target_name}
-        )
-    add_test(
-        NAME test_${test_name}
-        COMMAND $<TARGET_FILE:${target_name}>
-        )
+# Register a CTest build/run pair for one device test binary.
+function(
+  add_device_ctest
+  target_name
+  test_name)
+  add_test(NAME build_${test_name} COMMAND ${CMAKE_COMMAND} --build "${CMAKE_BINARY_DIR}" --config $<CONFIG> --target
+                                           ${target_name})
+  add_test(NAME test_${test_name} COMMAND $<TARGET_FILE:${target_name}>)
+  set_tests_properties(test_${test_name} PROPERTIES FIXTURES_REQUIRED fixture_${test_name})
+  set_tests_properties(build_${test_name} PROPERTIES FIXTURES_SETUP fixture_${test_name})
 endfunction()
 
 add_executable(${PROJECT_NAME}
@@ -183,10 +175,30 @@ add_executable(${PROJECT_NAME}
     )
 configure_device_test_target(${PROJECT_NAME} OFF OFF)
 
-add_device_test_variant(
-    ${PROJECT_NAME}_backup_restore ${basename}_backup_restore OFF ON)
-add_device_test_variant(
-    ${PROJECT_NAME}_bac_routing ${basename}_bac_routing ON OFF)
-add_device_test_variant(
-    ${PROJECT_NAME}_bac_routing_backup_restore
-    ${basename}_bac_routing_backup_restore ON ON)
+# Backup/Restore-only test binary.
+add_executable(${PROJECT_NAME}_backup_restore ${TEST_DEVICE_SOURCES})
+configure_device_test_target(
+  ${PROJECT_NAME}_backup_restore
+  OFF
+  ON)
+
+# BAC_ROUTING-only test binary.
+add_executable(${PROJECT_NAME}_bac_routing ${TEST_DEVICE_SOURCES})
+configure_device_test_target(
+  ${PROJECT_NAME}_bac_routing
+  ON
+  OFF)
+
+# BAC_ROUTING with Backup/Restore test binary.
+add_executable(${PROJECT_NAME}_bac_routing_backup_restore ${TEST_DEVICE_SOURCES})
+configure_device_test_target(
+  ${PROJECT_NAME}_bac_routing_backup_restore
+  ON
+  ON)
+
+# CTest pair for the Backup/Restore-only binary.
+add_device_ctest(${PROJECT_NAME}_backup_restore ${basename}_backup_restore)
+# CTest pair for the BAC_ROUTING-only binary.
+add_device_ctest(${PROJECT_NAME}_bac_routing ${basename}_bac_routing)
+# CTest pair for the BAC_ROUTING with Backup/Restore binary.
+add_device_ctest(${PROJECT_NAME}_bac_routing_backup_restore ${basename}_bac_routing_backup_restore)

--- a/test/bacnet/basic/object/device/CMakeLists.txt
+++ b/test/bacnet/basic/object/device/CMakeLists.txt
@@ -30,7 +30,7 @@ include_directories(
     ${TST_DIR}/ztest/include
     )
 
-add_executable(${PROJECT_NAME}
+set(TEST_DEVICE_SOURCES
     # File(s) under test
     ${SRC_DIR}/bacnet/basic/object/device.c
     # Support files and stubs (pathname alphabetical)
@@ -140,3 +140,53 @@ add_executable(${PROJECT_NAME}
     ${ZTST_DIR}/ztest_mock.c
     ${ZTST_DIR}/ztest.c
     )
+
+function(configure_device_test_target
+    target_name routing_enabled backup_restore_enabled)
+    if(routing_enabled)
+        target_sources(${target_name} PRIVATE
+            ${SRC_DIR}/bacnet/basic/object/gateway/gw_device.c
+            )
+        target_compile_definitions(${target_name} PRIVATE
+            BAC_ROUTING
+            )
+    endif()
+    if(backup_restore_enabled)
+        target_compile_definitions(${target_name} PRIVATE
+            BACNET_BACKUP_RESTORE
+            )
+    endif()
+endfunction()
+
+function(add_device_test_variant
+    target_name test_name routing_enabled backup_restore_enabled)
+    add_executable(${target_name}
+        ${TEST_DEVICE_SOURCES}
+        )
+    configure_device_test_target(
+        ${target_name} ${routing_enabled} ${backup_restore_enabled})
+    add_test(
+        NAME build_${test_name}
+        COMMAND ${CMAKE_COMMAND}
+            --build "${CMAKE_BINARY_DIR}"
+            --config $<CONFIG>
+            --target ${target_name}
+        )
+    add_test(
+        NAME test_${test_name}
+        COMMAND $<TARGET_FILE:${target_name}>
+        )
+endfunction()
+
+add_executable(${PROJECT_NAME}
+    ${TEST_DEVICE_SOURCES}
+    )
+configure_device_test_target(${PROJECT_NAME} OFF OFF)
+
+add_device_test_variant(
+    ${PROJECT_NAME}_backup_restore ${basename}_backup_restore OFF ON)
+add_device_test_variant(
+    ${PROJECT_NAME}_bac_routing ${basename}_bac_routing ON OFF)
+add_device_test_variant(
+    ${PROJECT_NAME}_bac_routing_backup_restore
+    ${basename}_bac_routing_backup_restore ON ON)

--- a/test/bacnet/basic/object/device/src/main.c
+++ b/test/bacnet/basic/object/device/src/main.c
@@ -91,6 +91,49 @@ static bool Write_Property_Proprietary(BACNET_WRITE_PROPERTY_DATA *data)
     return status;
 }
 
+#if defined(BAC_ROUTING)
+/**
+ * @brief Verify routed virtual devices still do not expose DCC.
+ */
+#if defined(CONFIG_ZTEST_NEW_API)
+ZTEST(device_tests, test_Routed_Device_DCC_Remains_Blocked)
+#else
+static void test_Routed_Device_DCC_Remains_Blocked(void)
+#endif
+{
+    BACNET_CHARACTER_STRING object_name = { 0 };
+    uint8_t apdu[MAX_APDU] = { 0 };
+    uint16_t device_index = 0;
+    int len = 0;
+    bool status = false;
+
+    Device_Init(NULL);
+    Routing_Device_Init(1000);
+    status = characterstring_init_ansi(&object_name, "Virtual Device");
+    zassert_true(status, NULL);
+    device_index = Add_Routed_Device(1001, &object_name, "Virtual Device");
+    zassert_equal(device_index, 1, NULL);
+
+    status = Set_Routed_Device_Object_Index(0);
+    zassert_true(status, NULL);
+    len = Routed_Device_Service_Approval(
+        SERVICE_SUPPORTED_DEVICE_COMMUNICATION_CONTROL, 0, NULL, 0);
+    zassert_equal(len, 0, NULL);
+
+    status = Set_Routed_Device_Object_Index(device_index);
+    zassert_true(status, NULL);
+    len = Routed_Device_Service_Approval(
+        SERVICE_SUPPORTED_DEVICE_COMMUNICATION_CONTROL, 0, NULL, 0);
+    zassert_not_equal(len, 0, NULL);
+
+    len = Routed_Device_Service_Approval(
+        SERVICE_SUPPORTED_DEVICE_COMMUNICATION_CONTROL, 0, apdu, 1);
+    zassert_true(len > 0, NULL);
+    status = Set_Routed_Device_Object_Index(0);
+    zassert_true(status, NULL);
+}
+#endif
+
 /**
  * @brief ReadProperty handler for this objects proprietary properties.
  * For the given ReadProperty data, the application_data is loaded
@@ -421,6 +464,190 @@ static void testDevice(void)
 
     return;
 }
+
+#if defined(BAC_ROUTING)
+static void test_Routed_Device_Reinitialize_Unsupported_State(
+    BACNET_REINITIALIZED_STATE state)
+{
+    bool status = false;
+    BACNET_REINITIALIZE_DEVICE_DATA rd_data = { 0 };
+
+    Device_Reinitialize_State_Set(BACNET_REINIT_IDLE);
+    Device_Reinitialize_Password_Set(NULL);
+    rd_data.error_class = ERROR_CLASS_DEVICE;
+    rd_data.error_code = ERROR_CODE_SUCCESS;
+    rd_data.state = state;
+    characterstring_init_ansi(&rd_data.password, NULL);
+
+    status = Device_Reinitialize(&rd_data);
+    zassert_false(status, NULL);
+    zassert_equal(
+        rd_data.error_class, ERROR_CLASS_SERVICES, "error-class=%s",
+        bactext_error_class_name(rd_data.error_class));
+    zassert_equal(
+        rd_data.error_code, ERROR_CODE_OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED,
+        "error-code=%s", bactext_error_code_name(rd_data.error_code));
+    zassert_equal(Device_Reinitialized_State(), BACNET_REINIT_IDLE, NULL);
+}
+
+#if defined(CONFIG_ZTEST_NEW_API)
+ZTEST(device_tests, test_Routed_Device_Reinitialize)
+#else
+static void test_Routed_Device_Reinitialize(void)
+#endif
+{
+    bool status = false;
+    BACNET_CHARACTER_STRING object_name = { 0 };
+    BACNET_REINITIALIZE_DEVICE_DATA rd_data = { 0 };
+
+    Device_Init(NULL);
+    Routing_Device_Init(100);
+    characterstring_init_ansi(&object_name, "VirtualDevice");
+    zassert_equal(Add_Routed_Device(101, &object_name, "Virtual"), 1, NULL);
+
+    status = Set_Routed_Device_Object_Index(0);
+    zassert_true(status, NULL);
+    zassert_equal(
+        Routed_Device_Service_Approval(
+            SERVICE_SUPPORTED_REINITIALIZE_DEVICE, 0, NULL, 0),
+        0, NULL);
+    zassert_equal(
+        Routed_Device_Service_Approval(
+            SERVICE_SUPPORTED_DEVICE_COMMUNICATION_CONTROL, 0, NULL, 0),
+        0, NULL);
+    Device_Reinitialize_State_Set(BACNET_REINIT_IDLE);
+    Device_Reinitialize_Password_Set(NULL);
+    rd_data.error_class = ERROR_CLASS_DEVICE;
+    rd_data.error_code = ERROR_CODE_SUCCESS;
+    rd_data.state = BACNET_REINIT_COLDSTART;
+    characterstring_init_ansi(&rd_data.password, NULL);
+    status = Device_Reinitialize(&rd_data);
+    zassert_true(status, NULL);
+    zassert_equal(Device_Reinitialized_State(), BACNET_REINIT_COLDSTART, NULL);
+
+    status = Set_Routed_Device_Object_Index(1);
+    zassert_true(status, NULL);
+    zassert_equal(
+        Routed_Device_Service_Approval(
+            SERVICE_SUPPORTED_REINITIALIZE_DEVICE, 0, NULL, 0),
+        0, NULL);
+    zassert_not_equal(
+        Routed_Device_Service_Approval(
+            SERVICE_SUPPORTED_DEVICE_COMMUNICATION_CONTROL, 0, NULL, 0),
+        0, NULL);
+    test_Routed_Device_Reinitialize_Unsupported_State(BACNET_REINIT_COLDSTART);
+    test_Routed_Device_Reinitialize_Unsupported_State(BACNET_REINIT_WARMSTART);
+    test_Routed_Device_Reinitialize_Unsupported_State(
+        BACNET_REINIT_ACTIVATE_CHANGES);
+}
+#endif
+
+#if defined(BAC_ROUTING) && defined(BACNET_BACKUP_RESTORE)
+#if defined(CONFIG_ZTEST_NEW_API)
+ZTEST(device_tests, test_Routed_Device_Backup_Restore_Independence)
+#else
+static void test_Routed_Device_Backup_Restore_Independence(void)
+#endif
+{
+    bool status = false;
+    BACNET_CHARACTER_STRING object_name = { 0 };
+    BACNET_REINITIALIZE_DEVICE_DATA rd_data = { 0 };
+
+    Device_Init(NULL);
+    Routing_Device_Init(200);
+    characterstring_init_ansi(&object_name, "VirtualDevice1");
+    zassert_equal(Add_Routed_Device(201, &object_name, "Virtual1"), 1, NULL);
+    characterstring_init_ansi(&object_name, "VirtualDevice2");
+    zassert_equal(Add_Routed_Device(202, &object_name, "Virtual2"), 2, NULL);
+
+    rd_data.error_class = ERROR_CLASS_DEVICE;
+    rd_data.error_code = ERROR_CODE_SUCCESS;
+    rd_data.state = BACNET_REINIT_STARTRESTORE;
+    characterstring_init_ansi(&rd_data.password, NULL);
+
+    Set_Routed_Device_Object_Index(1);
+    Device_Reinitialize_Password_Set(NULL);
+    status = Device_Reinitialize(&rd_data);
+    zassert_true(status, NULL);
+    zassert_equal(
+        Device_Backup_And_Restore_State(), BACKUP_STATE_PERFORMING_A_RESTORE,
+        NULL);
+
+    rd_data.error_class = ERROR_CLASS_DEVICE;
+    rd_data.error_code = ERROR_CODE_SUCCESS;
+    status = Device_Reinitialize(&rd_data);
+    zassert_false(status, NULL);
+    zassert_equal(rd_data.error_class, ERROR_CLASS_DEVICE, NULL);
+    zassert_equal(
+        rd_data.error_code, ERROR_CODE_CONFIGURATION_IN_PROGRESS, NULL);
+
+    Set_Routed_Device_Object_Index(0);
+    zassert_equal(Device_Backup_And_Restore_State(), BACKUP_STATE_IDLE, NULL);
+    Set_Routed_Device_Object_Index(2);
+    Device_Reinitialize_Password_Set(NULL);
+    zassert_equal(Device_Backup_And_Restore_State(), BACKUP_STATE_IDLE, NULL);
+    status = Device_Reinitialize(&rd_data);
+    zassert_true(status, NULL);
+    zassert_equal(
+        Device_Backup_And_Restore_State(), BACKUP_STATE_PERFORMING_A_RESTORE,
+        NULL);
+
+    Set_Routed_Device_Object_Index(1);
+    rd_data.error_class = ERROR_CLASS_DEVICE;
+    rd_data.error_code = ERROR_CODE_SUCCESS;
+    rd_data.state = BACNET_REINIT_ABORTRESTORE;
+    status = Device_Reinitialize(&rd_data);
+    zassert_true(status, NULL);
+    zassert_equal(Device_Backup_And_Restore_State(), BACKUP_STATE_IDLE, NULL);
+
+    Set_Routed_Device_Object_Index(2);
+    zassert_equal(
+        Device_Backup_And_Restore_State(), BACKUP_STATE_PERFORMING_A_RESTORE,
+        NULL);
+}
+
+#if defined(CONFIG_ZTEST_NEW_API)
+ZTEST(device_tests, test_Routed_Device_Backup_Countdown_Per_Device)
+#else
+static void test_Routed_Device_Backup_Countdown_Per_Device(void)
+#endif
+{
+    bool status = false;
+    BACNET_CHARACTER_STRING object_name = { 0 };
+
+    Device_Init(NULL);
+    Routing_Device_Init(300);
+    characterstring_init_ansi(&object_name, "VirtualDevice1");
+    zassert_equal(Add_Routed_Device(301, &object_name, "Virtual1"), 1, NULL);
+    characterstring_init_ansi(&object_name, "VirtualDevice2");
+    zassert_equal(Add_Routed_Device(302, &object_name, "Virtual2"), 2, NULL);
+
+    status = Set_Routed_Device_Object_Index(1);
+    zassert_true(status, NULL);
+    Device_Backup_Failure_Timeout_Set(1);
+    Device_Backup_And_Restore_State_Set(BACKUP_STATE_PERFORMING_A_BACKUP);
+    Device_Backup_Failure_Timeout_Restart();
+
+    status = Set_Routed_Device_Object_Index(2);
+    zassert_true(status, NULL);
+    zassert_equal(Device_Backup_And_Restore_State(), BACKUP_STATE_IDLE, NULL);
+
+    status = Set_Routed_Device_Object_Index(1);
+    zassert_true(status, NULL);
+    Device_Timer(500);
+    zassert_equal(
+        Device_Backup_And_Restore_State(), BACKUP_STATE_PERFORMING_A_BACKUP,
+        NULL);
+
+    Device_Timer(500);
+    zassert_equal(
+        Device_Backup_And_Restore_State(), BACKUP_STATE_BACKUP_FAILURE, NULL);
+
+    status = Set_Routed_Device_Object_Index(2);
+    zassert_true(status, NULL);
+    zassert_equal(Device_Backup_And_Restore_State(), BACKUP_STATE_IDLE, NULL);
+}
+#endif
 /**
  * @}
  */
@@ -430,9 +657,25 @@ ZTEST_SUITE(device_tests, NULL, NULL, NULL, NULL, NULL);
 #else
 void test_main(void)
 {
+#if defined(BAC_ROUTING) && defined(BACNET_BACKUP_RESTORE)
+    ztest_test_suite(
+        device_tests, ztest_unit_test(testDevice),
+        ztest_unit_test(test_Device_Data_Sharing),
+        ztest_unit_test(test_Routed_Device_DCC_Remains_Blocked),
+        ztest_unit_test(test_Routed_Device_Reinitialize),
+        ztest_unit_test(test_Routed_Device_Backup_Restore_Independence),
+        ztest_unit_test(test_Routed_Device_Backup_Countdown_Per_Device));
+#elif defined(BAC_ROUTING)
+    ztest_test_suite(
+        device_tests, ztest_unit_test(testDevice),
+        ztest_unit_test(test_Device_Data_Sharing),
+        ztest_unit_test(test_Routed_Device_DCC_Remains_Blocked),
+        ztest_unit_test(test_Routed_Device_Reinitialize));
+#else
     ztest_test_suite(
         device_tests, ztest_unit_test(testDevice),
         ztest_unit_test(test_Device_Data_Sharing));
+#endif
 
     ztest_run_test_suite(device_tests);
 }


### PR DESCRIPTION
## Summary

Related to #1287.

This updates routed device reinitialization handling so virtual devices can participate in Backup/Restore flows without changing the existing gateway-device behavior.

## Key changes

- Keep existing behavior when `BAC_ROUTING` is disabled.
- Keep existing gateway-device behavior when `BAC_ROUTING` is enabled.
- Allow routed virtual devices to receive ReinitializeDevice service requests, but only handle Backup/Restore related states.
- Return `ERROR_CLASS_SERVICES` / `ERROR_CODE_OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED` for routed virtual-device `COLDSTART`, `WARMSTART`, and `ACTIVATE_CHANGES` instead of sending a Simple ACK.
- Keep DCC blocked for routed virtual devices.
- Keep `Reinit_Password` as `const char *` with the existing default value.
- Add per-device routing state only under `BAC_ROUTING`.
- Add Backup/Restore fields only under `BAC_ROUTING && BACNET_BACKUP_RESTORE`.

## Tests

Added device test variants that reuse the same test source across the macro matrix:

- `test_device`: `BAC_ROUTING` off, `BACNET_BACKUP_RESTORE` off
- `test_device_backup_restore`: `BAC_ROUTING` off, `BACNET_BACKUP_RESTORE` on
- `test_device_bac_routing`: `BAC_ROUTING` on, `BACNET_BACKUP_RESTORE` off
- `test_device_bac_routing_backup_restore`: `BAC_ROUTING` on, `BACNET_BACKUP_RESTORE` on

Additional coverage verifies that routed virtual devices reject unsupported ReinitializeDevice states:

- `COLDSTART`
- `WARMSTART`
- `ACTIVATE_CHANGES`

Verification performed:

- Built and ran all four device test variants successfully.
- Ran the full top-level CTest suite successfully: `274/274` tests passed.

## Follow-up note

The device-object handler direction in `feature/refactor-device-object-handling` looks useful for a future refactor, but this PR intentionally keeps that broader `device_h` / per-device object-handler restructuring out of scope. The current change keeps the Issue #1287 behavior focused and limited to routed device Backup/Restore handling plus the related unit-test matrix.
