### PR TITLE
Bugfix/atomic read file out of bounds write

### DIFF
--- a/src/bacnet/bacerror.c
+++ b/src/bacnet/bacerror.c
@@ -11,6 +11,8 @@
 /* BACnet Stack API */
 #include "bacnet/bacdcode.h"
 #include "bacnet/bacerror.h"
+#include "bacnet/abort.h"
+#include "bacnet/reject.h"
 
 /** @file bacerror.c  Encode/Decode BACnet Errors */
 
@@ -406,4 +408,36 @@ BACNET_ERROR_CLASS bacerror_code_class(BACNET_ERROR_CODE error_code)
     }
 
     return error_class;
+}
+
+/**
+ * @brief Encode an APDU for a BACnet error, abort, or reject message
+ * @param apdu - buffer for the data to be encoded, or NULL for length
+ * @param invoke_id - invokeID to be encoded
+ * @param service - BACnet service to be encoded (ignored for abort or reject)
+ * @param error_code - Error, Abort, or Reject value to be encoded
+ * @return number of bytes encoded
+ */
+int bacnet_error_encode_apdu(
+    uint8_t *apdu,
+    uint8_t invoke_id,
+    BACNET_CONFIRMED_SERVICE service,
+    BACNET_ERROR_CODE error_code)
+{
+    int apdu_len = 0;
+    BACNET_ERROR_CLASS error_class = ERROR_CLASS_DEVICE;
+
+    if (abort_valid_error_code(error_code)) {
+        apdu_len = abort_encode_apdu(
+            apdu, invoke_id, abort_convert_error_code(error_code), true);
+    } else if (reject_valid_error_code(error_code)) {
+        apdu_len = reject_encode_apdu(
+            apdu, invoke_id, reject_convert_error_code(error_code));
+    } else {
+        error_class = bacerror_code_class(error_code);
+        apdu_len = bacerror_encode_apdu(
+            apdu, invoke_id, service, error_class, error_code);
+    }
+
+    return apdu_len;
 }

--- a/src/bacnet/bacerror.h
+++ b/src/bacnet/bacerror.h
@@ -44,6 +44,13 @@ int bacerror_decode_error_class_and_code(
 BACNET_STACK_EXPORT
 BACNET_ERROR_CLASS bacerror_code_class(BACNET_ERROR_CODE error_code);
 
+BACNET_STACK_EXPORT
+int bacnet_error_encode_apdu(
+    uint8_t *apdu,
+    uint8_t invoke_id,
+    BACNET_CONFIRMED_SERVICE service,
+    BACNET_ERROR_CODE error_code);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/src/bacnet/basic/object/bacfile.c
+++ b/src/bacnet/basic/object/bacfile.c
@@ -1067,20 +1067,28 @@ bool bacfile_read_record_data(BACNET_ATOMIC_READ_FILE_DATA *data)
     bool found = false;
     bool status = false;
     uint32_t i = 0;
+    size_t max_records = 0;
 
+    if (!data) {
+        return false;
+    }
+    max_records =
+        min(data->type.record.RecordCount, ARRAY_SIZE(data->fileData));
     pathname = bacfile_pathname(data->object_instance);
     if (pathname) {
         found = true;
-        data->endOfFile = false;
-        for (i = 0; i < data->type.record.RecordCount; i++) {
-            status = bacfile_read_record_data_callback(
-                pathname, data->type.record.fileStartRecord, i,
-                octetstring_value(&data->fileData[i]),
-                octetstring_capacity(&data->fileData[i]));
-            if (!status) {
-                data->endOfFile = true;
-                data->type.record.RecordCount = i;
-                break;
+        if (max_records > 0) {
+            data->endOfFile = false;
+            for (i = 0; i < max_records; i++) {
+                status = bacfile_read_record_data_callback(
+                    pathname, data->type.record.fileStartRecord, i,
+                    octetstring_value(&data->fileData[i]),
+                    octetstring_capacity(&data->fileData[i]));
+                if (!status) {
+                    data->endOfFile = true;
+                    data->type.record.RecordCount = i;
+                    break;
+                }
             }
         }
     }

--- a/src/bacnet/basic/service/h_arf.c
+++ b/src/bacnet/basic/service/h_arf.c
@@ -83,107 +83,106 @@ void handler_atomic_read_file(
     BACNET_ADDRESS *src,
     BACNET_CONFIRMED_SERVICE_DATA *service_data)
 {
-    BACNET_ATOMIC_READ_FILE_DATA data;
+    BACNET_ATOMIC_READ_FILE_DATA data = { 0 };
     int len = 0;
     int pdu_len = 0;
     bool error = false;
     int bytes_sent = 0;
     BACNET_NPDU_DATA npdu_data;
     BACNET_ADDRESS my_address;
-    BACNET_ERROR_CLASS error_class = ERROR_CLASS_OBJECT;
     BACNET_ERROR_CODE error_code = ERROR_CODE_UNKNOWN_OBJECT;
 
-#if PRINT_ENABLED
-    fprintf(stderr, "Received Atomic-Read-File Request!\n");
-#endif
+    debug_printf_stderr("Received Atomic-Read-File Request!\n");
     /* encode the NPDU portion of the packet */
     datalink_get_my_address(&my_address);
     npdu_encode_npdu_data(&npdu_data, false, service_data->priority);
     pdu_len = npdu_encode_pdu(
         &Handler_Transmit_Buffer[0], src, &my_address, &npdu_data);
     if (service_len == 0) {
-        len = reject_encode_apdu(
-            &Handler_Transmit_Buffer[pdu_len], service_data->invoke_id,
-            REJECT_REASON_MISSING_REQUIRED_PARAMETER);
-        debug_print("ARF: Missing Required Parameter. Sending Reject!\n");
-        goto ARF_ABORT;
+        error_code = ERROR_CODE_REJECT_MISSING_REQUIRED_PARAMETER;
+        error = true;
+        debug_printf_stderr(
+            "ARF: Missing Required Parameter. Sending Reject!\n");
     } else if (service_data->segmented_message) {
-        len = abort_encode_apdu(
-            &Handler_Transmit_Buffer[pdu_len], service_data->invoke_id,
-            ABORT_REASON_SEGMENTATION_NOT_SUPPORTED, true);
-        debug_print("ARF: Segmented Message. Sending Abort!\n");
-        goto ARF_ABORT;
+        error_code = ERROR_CODE_ABORT_SEGMENTATION_NOT_SUPPORTED;
+        error = true;
     }
-    len = arf_decode_service_request(service_request, service_len, &data);
+    if (!error) {
+        len = arf_decode_service_request(service_request, service_len, &data);
+    }
     /* bad decoding - send an abort */
     if (len < 0) {
-        len = abort_encode_apdu(
-            &Handler_Transmit_Buffer[pdu_len], service_data->invoke_id,
-            ABORT_REASON_OTHER, true);
-        debug_print("ARF: Bad Encoding. Sending Abort!\n");
-        goto ARF_ABORT;
-    }
-    if (data.object_type == OBJECT_FILE) {
+        debug_printf_stderr("ARF: Bad Encoding. Sending Abort!\n");
+        error_code = ERROR_CODE_ABORT_OTHER;
+        error = true;
+    } else if (data.object_type == OBJECT_FILE) {
         if (!bacfile_valid_instance(data.object_instance)) {
             error = true;
         } else if (data.access == FILE_STREAM_ACCESS) {
             if (data.type.stream.requestedOctetCount <=
                 octetstring_capacity(&data.fileData[0])) {
                 bacfile_read_stream_data(&data);
-                debug_fprintf(
-                    stderr, "ARF: Stream offset %d, %d octets.\n",
+                debug_printf_stderr(
+                    "ARF: Stream offset %d, %d octets.\n",
                     (int)data.type.stream.fileStartPosition,
                     (int)data.type.stream.requestedOctetCount);
                 len = arf_ack_encode_apdu(
                     &Handler_Transmit_Buffer[pdu_len], service_data->invoke_id,
                     &data);
             } else {
-                len = abort_encode_apdu(
-                    &Handler_Transmit_Buffer[pdu_len], service_data->invoke_id,
-                    ABORT_REASON_SEGMENTATION_NOT_SUPPORTED, true);
-                debug_fprintf(
-                    stderr,
+                error_code = ERROR_CODE_ABORT_SEGMENTATION_NOT_SUPPORTED;
+                error = true;
+                debug_printf_stderr(
                     "ARF: Too Big To Send (%d >= %d). "
                     "Sending Abort!\n",
                     (int)data.type.stream.requestedOctetCount,
                     (int)octetstring_capacity(&data.fileData[0]));
             }
         } else if (data.access == FILE_RECORD_ACCESS) {
-            if (data.type.record.fileStartRecord >=
-                BACNET_READ_FILE_RECORD_COUNT) {
-                error_class = ERROR_CLASS_SERVICES;
+            if (data.type.record.RecordCount > ARRAY_SIZE(data.fileData)) {
+                debug_printf_stderr(
+                    "ARF: RecordCount %u > %u. Sending Reject!\n",
+                    (unsigned)data.type.record.RecordCount,
+                    (unsigned)ARRAY_SIZE(data.fileData));
+                error_code = ERROR_CODE_REJECT_PARAMETER_OUT_OF_RANGE;
+                error = true;
+            } else if (
+                data.type.record.fileStartRecord >= ARRAY_SIZE(data.fileData)) {
+                debug_printf_stderr(
+                    "ARF: fileStartRecord %d >= %u. Sending Error!\n",
+                    (int)data.type.record.fileStartRecord,
+                    (unsigned)ARRAY_SIZE(data.fileData));
                 error_code = ERROR_CODE_INVALID_FILE_START_POSITION;
                 error = true;
             } else if (bacfile_read_record_data(&data)) {
-                debug_fprintf(
-                    stderr, "ARF: fileStartRecord %d, %u RecordCount.\n",
+                debug_printf_stderr(
+                    "ARF: fileStartRecord %d, %u RecordCount.\n",
                     (int)data.type.record.fileStartRecord,
                     (unsigned)data.type.record.RecordCount);
                 len = arf_ack_encode_apdu(
                     &Handler_Transmit_Buffer[pdu_len], service_data->invoke_id,
                     &data);
             } else {
+                debug_printf_stderr("ARF: file_access_denied! Sending Error!");
                 error = true;
-                error_class = ERROR_CLASS_OBJECT;
                 error_code = ERROR_CODE_FILE_ACCESS_DENIED;
             }
         } else {
+            debug_printf_stderr(
+                "ARF: Invalid File Access Method. Sending Error!\n");
             error = true;
-            error_class = ERROR_CLASS_SERVICES;
             error_code = ERROR_CODE_INVALID_FILE_ACCESS_METHOD;
-            debug_print("ARF: Record Access Requested. Sending Error!\n");
         }
     } else {
+        debug_printf_stderr("ARF: Inconsistent Object Type. Sending Error!\n");
         error = true;
-        error_class = ERROR_CLASS_SERVICES;
         error_code = ERROR_CODE_INCONSISTENT_OBJECT_TYPE;
     }
     if (error) {
-        len = bacerror_encode_apdu(
+        len = bacnet_error_encode_apdu(
             &Handler_Transmit_Buffer[pdu_len], service_data->invoke_id,
-            SERVICE_CONFIRMED_ATOMIC_READ_FILE, error_class, error_code);
+            SERVICE_CONFIRMED_ATOMIC_READ_FILE, error_code);
     }
-ARF_ABORT:
     pdu_len += len;
     bytes_sent = datalink_send_pdu(
         src, &npdu_data, &Handler_Transmit_Buffer[0], pdu_len);

--- a/src/bacnet/basic/service/h_arf.c
+++ b/src/bacnet/basic/service/h_arf.c
@@ -150,9 +150,6 @@ int handler_atomic_read_file_encode(
                     len = arf_ack_encode_apdu(
                         apdu, service_data->invoke_id, &data);
                     pdu_len += len;
-                    if (apdu) {
-                        apdu += len;
-                    }
                 } else {
                     error_code = ERROR_CODE_ABORT_SEGMENTATION_NOT_SUPPORTED;
                     error = true;
@@ -187,9 +184,6 @@ int handler_atomic_read_file_encode(
                     len = arf_ack_encode_apdu(
                         apdu, service_data->invoke_id, &data);
                     pdu_len += len;
-                    if (apdu) {
-                        apdu += len;
-                    }
                 } else {
                     DEBUG_PRINTF("ARF: file_access_denied! Sending Error!");
                     error = true;

--- a/src/bacnet/basic/service/h_arf.c
+++ b/src/bacnet/basic/service/h_arf.c
@@ -77,32 +77,52 @@ last octet or record of the file, then the 'End Of File' parameter
 shall be TRUE, otherwise FALSE.
 */
 
-void handler_atomic_read_file(
+/**
+ * @brief Encode an AtomicReadFile ACK or Error response based on the
+ *       provided request and service data.
+ * @param service_request The APDU portion of the request, starting with the
+ * service choice.
+ * @param service_len The length of the service_request buffer.
+ * @param apdu The buffer to encode the response APDU into.
+ * @param apdu_size The size of the apdu buffer.
+ * @param src The source address to send the response to.
+ * @param npdu_data The NPDU data to use for encoding the response.
+ * @param service_data The confirmed service data from the request, used for
+ * encoding the response.
+ * @return The number of bytes encoded into the apdu buffer, or a negative value
+ * on encoding error.
+ */
+int handler_atomic_read_file_encode(
+    uint8_t *apdu,
     uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
+    BACNET_NPDU_DATA *npdu_data,
     BACNET_CONFIRMED_SERVICE_DATA *service_data)
 {
     BACNET_ATOMIC_READ_FILE_DATA data = { 0 };
     int len = 0;
     int pdu_len = 0;
     bool error = false;
-    int bytes_sent = 0;
-    BACNET_NPDU_DATA npdu_data;
     BACNET_ADDRESS my_address;
     BACNET_ERROR_CODE error_code = ERROR_CODE_UNKNOWN_OBJECT;
+    uint8_t *apdu_start;
 
-    debug_printf_stderr("Received Atomic-Read-File Request!\n");
+    DEBUG_PRINTF("Received Atomic-Read-File Request!\n");
     /* encode the NPDU portion of the packet */
     datalink_get_my_address(&my_address);
-    npdu_encode_npdu_data(&npdu_data, false, service_data->priority);
-    pdu_len = npdu_encode_pdu(
-        &Handler_Transmit_Buffer[0], src, &my_address, &npdu_data);
+    npdu_encode_npdu_data(npdu_data, false, service_data->priority);
+    len = npdu_encode_pdu(apdu, src, &my_address, npdu_data);
+    pdu_len += len;
+    if (apdu) {
+        apdu += len;
+    }
+    /* APDU starts after the NPDU portion */
+    apdu_start = apdu;
     if (service_len == 0) {
         error_code = ERROR_CODE_REJECT_MISSING_REQUIRED_PARAMETER;
         error = true;
-        debug_printf_stderr(
-            "ARF: Missing Required Parameter. Sending Reject!\n");
+        DEBUG_PRINTF("ARF: Missing Required Parameter. Sending Reject!\n");
     } else if (service_data->segmented_message) {
         error_code = ERROR_CODE_ABORT_SEGMENTATION_NOT_SUPPORTED;
         error = true;
@@ -111,84 +131,123 @@ void handler_atomic_read_file(
         len = arf_decode_service_request(service_request, service_len, &data);
     }
     /* bad decoding - send an abort */
-    if (len < 0) {
-        debug_printf_stderr("ARF: Bad Encoding. Sending Abort!\n");
-        error_code = ERROR_CODE_ABORT_OTHER;
-        error = true;
-    } else if (data.object_type == OBJECT_FILE) {
-        if (!bacfile_valid_instance(data.object_instance)) {
+    if (!error) {
+        if (len < 0) {
+            DEBUG_PRINTF("ARF: Bad Encoding. Sending Abort!\n");
+            error_code = ERROR_CODE_ABORT_OTHER;
             error = true;
-        } else if (data.access == FILE_STREAM_ACCESS) {
-            if (data.type.stream.requestedOctetCount <=
-                octetstring_capacity(&data.fileData[0])) {
-                bacfile_read_stream_data(&data);
-                debug_printf_stderr(
-                    "ARF: Stream offset %d, %d octets.\n",
-                    (int)data.type.stream.fileStartPosition,
-                    (int)data.type.stream.requestedOctetCount);
-                len = arf_ack_encode_apdu(
-                    &Handler_Transmit_Buffer[pdu_len], service_data->invoke_id,
-                    &data);
+        } else if (data.object_type == OBJECT_FILE) {
+            if (!bacfile_valid_instance(data.object_instance)) {
+                error = true;
+            } else if (data.access == FILE_STREAM_ACCESS) {
+                if (data.type.stream.requestedOctetCount <=
+                    octetstring_capacity(&data.fileData[0])) {
+                    bacfile_read_stream_data(&data);
+                    DEBUG_PRINTF(
+                        "ARF: Stream offset %d, %d octets.\n",
+                        (int)data.type.stream.fileStartPosition,
+                        (int)data.type.stream.requestedOctetCount);
+                    len = arf_ack_encode_apdu(
+                        apdu, service_data->invoke_id, &data);
+                    pdu_len += len;
+                    if (apdu) {
+                        apdu += len;
+                    }
+                } else {
+                    error_code = ERROR_CODE_ABORT_SEGMENTATION_NOT_SUPPORTED;
+                    error = true;
+                    DEBUG_PRINTF(
+                        "ARF: Too Big To Send (%d >= %d). "
+                        "Sending Abort!\n",
+                        (int)data.type.stream.requestedOctetCount,
+                        (int)octetstring_capacity(&data.fileData[0]));
+                }
+            } else if (data.access == FILE_RECORD_ACCESS) {
+                if (data.type.record.RecordCount > ARRAY_SIZE(data.fileData)) {
+                    DEBUG_PRINTF(
+                        "ARF: RecordCount %u > %u. Sending Reject!\n",
+                        (unsigned)data.type.record.RecordCount,
+                        (unsigned)ARRAY_SIZE(data.fileData));
+                    error_code = ERROR_CODE_REJECT_PARAMETER_OUT_OF_RANGE;
+                    error = true;
+                } else if (
+                    data.type.record.fileStartRecord >=
+                    ARRAY_SIZE(data.fileData)) {
+                    DEBUG_PRINTF(
+                        "ARF: fileStartRecord %d >= %u. Sending Error!\n",
+                        (int)data.type.record.fileStartRecord,
+                        (unsigned)ARRAY_SIZE(data.fileData));
+                    error_code = ERROR_CODE_INVALID_FILE_START_POSITION;
+                    error = true;
+                } else if (bacfile_read_record_data(&data)) {
+                    DEBUG_PRINTF(
+                        "ARF: fileStartRecord %d, %u RecordCount.\n",
+                        (int)data.type.record.fileStartRecord,
+                        (unsigned)data.type.record.RecordCount);
+                    len = arf_ack_encode_apdu(
+                        apdu, service_data->invoke_id, &data);
+                    pdu_len += len;
+                    if (apdu) {
+                        apdu += len;
+                    }
+                } else {
+                    DEBUG_PRINTF("ARF: file_access_denied! Sending Error!");
+                    error = true;
+                    error_code = ERROR_CODE_FILE_ACCESS_DENIED;
+                }
             } else {
-                error_code = ERROR_CODE_ABORT_SEGMENTATION_NOT_SUPPORTED;
+                DEBUG_PRINTF(
+                    "ARF: Invalid File Access Method. Sending Error!\n");
                 error = true;
-                debug_printf_stderr(
-                    "ARF: Too Big To Send (%d >= %d). "
-                    "Sending Abort!\n",
-                    (int)data.type.stream.requestedOctetCount,
-                    (int)octetstring_capacity(&data.fileData[0]));
-            }
-        } else if (data.access == FILE_RECORD_ACCESS) {
-            if (data.type.record.RecordCount > ARRAY_SIZE(data.fileData)) {
-                debug_printf_stderr(
-                    "ARF: RecordCount %u > %u. Sending Reject!\n",
-                    (unsigned)data.type.record.RecordCount,
-                    (unsigned)ARRAY_SIZE(data.fileData));
-                error_code = ERROR_CODE_REJECT_PARAMETER_OUT_OF_RANGE;
-                error = true;
-            } else if (
-                data.type.record.fileStartRecord >= ARRAY_SIZE(data.fileData)) {
-                debug_printf_stderr(
-                    "ARF: fileStartRecord %d >= %u. Sending Error!\n",
-                    (int)data.type.record.fileStartRecord,
-                    (unsigned)ARRAY_SIZE(data.fileData));
-                error_code = ERROR_CODE_INVALID_FILE_START_POSITION;
-                error = true;
-            } else if (bacfile_read_record_data(&data)) {
-                debug_printf_stderr(
-                    "ARF: fileStartRecord %d, %u RecordCount.\n",
-                    (int)data.type.record.fileStartRecord,
-                    (unsigned)data.type.record.RecordCount);
-                len = arf_ack_encode_apdu(
-                    &Handler_Transmit_Buffer[pdu_len], service_data->invoke_id,
-                    &data);
-            } else {
-                debug_printf_stderr("ARF: file_access_denied! Sending Error!");
-                error = true;
-                error_code = ERROR_CODE_FILE_ACCESS_DENIED;
+                error_code = ERROR_CODE_INVALID_FILE_ACCESS_METHOD;
             }
         } else {
-            debug_printf_stderr(
-                "ARF: Invalid File Access Method. Sending Error!\n");
+            DEBUG_PRINTF("ARF: Inconsistent Object Type. Sending Error!\n");
             error = true;
-            error_code = ERROR_CODE_INVALID_FILE_ACCESS_METHOD;
+            error_code = ERROR_CODE_INCONSISTENT_OBJECT_TYPE;
         }
-    } else {
-        debug_printf_stderr("ARF: Inconsistent Object Type. Sending Error!\n");
-        error = true;
-        error_code = ERROR_CODE_INCONSISTENT_OBJECT_TYPE;
     }
     if (error) {
         len = bacnet_error_encode_apdu(
-            &Handler_Transmit_Buffer[pdu_len], service_data->invoke_id,
+            apdu_start, service_data->invoke_id,
             SERVICE_CONFIRMED_ATOMIC_READ_FILE, error_code);
-    }
-    pdu_len += len;
-    bytes_sent = datalink_send_pdu(
-        src, &npdu_data, &Handler_Transmit_Buffer[0], pdu_len);
-    if (bytes_sent <= 0) {
-        debug_perror("ARF: Failed to send PDU");
+        pdu_len += len;
     }
 
-    return;
+    return pdu_len;
+}
+
+/**
+ * @brief Handler for the AtomicReadFile service. Encodes and sends an ACK or
+ * Error response based on the provided request and service data.
+ * @param service_request The APDU portion of the request, starting with the
+ * service choice.
+ * @param service_len The length of the service_request buffer.
+ * @param src The source address to send the response to.
+ * @param service_data The confirmed service data from the request, used for
+ * encoding the response.
+ */
+void handler_atomic_read_file(
+    uint8_t *service_request,
+    uint16_t service_len,
+    BACNET_ADDRESS *src,
+    BACNET_CONFIRMED_SERVICE_DATA *service_data)
+{
+    int pdu_len = 0, bytes_sent = 0;
+    BACNET_NPDU_DATA npdu_data = { 0 };
+
+    pdu_len = handler_atomic_read_file_encode(
+        NULL, service_request, service_len, src, &npdu_data, service_data);
+    if (pdu_len > sizeof(Handler_Transmit_Buffer)) {
+        debug_perror("ARF: Encoded PDU length exceeds transmit buffer size");
+    } else {
+        pdu_len = handler_atomic_read_file_encode(
+            Handler_Transmit_Buffer, service_request, service_len, src,
+            &npdu_data, service_data);
+        bytes_sent = datalink_send_pdu(
+            src, &npdu_data, &Handler_Transmit_Buffer[0], pdu_len);
+        if (bytes_sent <= 0) {
+            debug_perror("ARF: Failed to send PDU");
+        }
+    }
 }

--- a/src/bacnet/basic/service/h_arf.h
+++ b/src/bacnet/basic/service/h_arf.h
@@ -15,10 +15,20 @@
 #include "bacnet/bacdef.h"
 /* BACnet Stack API */
 #include "bacnet/apdu.h"
+#include "bacnet/npdu.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
+
+BACNET_STACK_EXPORT
+int handler_atomic_read_file_encode(
+    uint8_t *apdu,
+    uint8_t *service_request,
+    uint16_t service_len,
+    BACNET_ADDRESS *src,
+    BACNET_NPDU_DATA *npdu_data,
+    BACNET_CONFIRMED_SERVICE_DATA *service_data);
 
 BACNET_STACK_EXPORT
 void handler_atomic_read_file(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -194,6 +194,7 @@ list(APPEND testdirs
   # basic/program
   bacnet/basic/program/ubasic
   # basic/service
+  bacnet/basic/service/h_arf
   bacnet/basic/service/h_cov
   # basic/server
   bacnet/basic/server/bacnet_device

--- a/test/bacnet/bacaudit/CMakeLists.txt
+++ b/test/bacnet/bacaudit/CMakeLists.txt
@@ -45,7 +45,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdest.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/bacreal.c
     ${SRC_DIR}/bacnet/bacstr.c

--- a/test/bacnet/bacdest/CMakeLists.txt
+++ b/test/bacnet/bacdest/CMakeLists.txt
@@ -44,7 +44,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacapp.c
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/baclog.c
     ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/bacerror/CMakeLists.txt
+++ b/test/bacnet/bacerror/CMakeLists.txt
@@ -34,11 +34,13 @@ add_executable(${PROJECT_NAME}
     # File(s) under test
     ${SRC_DIR}/bacnet/bacerror.c
     # Support files and stubs (pathname alphabetical)
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/bacreal.c
     ${SRC_DIR}/bacnet/bacstr.c
     ${SRC_DIR}/bacnet/basic/sys/bigend.c
+    ${SRC_DIR}/bacnet/reject.c
     # Test and test library files
     ./src/main.c
     ${ZTST_DIR}/ztest_mock.c

--- a/test/bacnet/bacerror/src/main.c
+++ b/test/bacnet/bacerror/src/main.c
@@ -5,9 +5,12 @@
  * @date 2007
  * @copyright SPDX-License-Identifier: MIT
  */
+#include <string.h>
 #include <zephyr/ztest.h>
 #include <bacnet/bacdef.h>
 #include <bacnet/bacerror.h>
+#include <bacnet/abort.h>
+#include <bacnet/reject.h>
 
 /**
  * @addtogroup bacnet_tests
@@ -139,6 +142,84 @@ static void testBACError(void)
     zassert_equal(test_error_code, error_code, NULL);
 }
 /**
+ * @brief Test bacnet_error_encode_apdu dispatch - abort, reject, and error
+ * paths
+ *
+ * The new function bacnet_error_encode_apdu() dispatches to
+ * abort_encode_apdu(), reject_encode_apdu(), or bacerror_encode_apdu() based on
+ * the error code. Verify all three paths produce the correct PDU type byte.
+ * Note: abort_encode_apdu() and reject_encode_apdu() return 0 for NULL apdu
+ * (no length-only mode); only bacerror_encode_apdu() supports NULL apdu.
+ */
+#if defined(CONFIG_ZTEST_NEW_API)
+ZTEST(bacerror_tests, testBACNetErrorEncodeAPDU)
+#else
+static void testBACNetErrorEncodeAPDU(void)
+#endif
+{
+    uint8_t apdu[480] = { 0 };
+    int len = 0;
+    int null_len = 0;
+    uint8_t invoke_id = 5;
+    BACNET_CONFIRMED_SERVICE service = SERVICE_CONFIRMED_ATOMIC_READ_FILE;
+
+    /* --- abort path --- */
+    /* ERROR_CODE_ABORT_APDU_TOO_LONG is an abort-valid error code.
+     * abort_encode_apdu() returns 0 for NULL apdu (no length-only mode). */
+    null_len = bacnet_error_encode_apdu(
+        NULL, invoke_id, service, ERROR_CODE_ABORT_APDU_TOO_LONG);
+    zassert_equal(null_len, 0, "abort null_len=%d", null_len);
+    len = bacnet_error_encode_apdu(
+        &apdu[0], invoke_id, service, ERROR_CODE_ABORT_APDU_TOO_LONG);
+    zassert_true(len > 0, "abort len=%d", len);
+    zassert_equal(apdu[0] & 0xFEU, PDU_TYPE_ABORT, "apdu[0]=0x%02x", apdu[0]);
+    zassert_equal(apdu[1], invoke_id, NULL);
+
+    /* --- reject path --- */
+    /* ERROR_CODE_REJECT_BUFFER_OVERFLOW is a reject-valid error code.
+     * reject_encode_apdu() returns 0 for NULL apdu (no length-only mode). */
+    memset(apdu, 0, sizeof(apdu));
+    null_len = bacnet_error_encode_apdu(
+        NULL, invoke_id, service, ERROR_CODE_REJECT_BUFFER_OVERFLOW);
+    zassert_equal(null_len, 0, "reject null_len=%d", null_len);
+    len = bacnet_error_encode_apdu(
+        &apdu[0], invoke_id, service, ERROR_CODE_REJECT_BUFFER_OVERFLOW);
+    zassert_true(len > 0, "reject len=%d", len);
+    zassert_equal(apdu[0], PDU_TYPE_REJECT, "apdu[0]=0x%02x", apdu[0]);
+    zassert_equal(apdu[1], invoke_id, NULL);
+
+    /* --- regular error path --- */
+    /* ERROR_CODE_UNKNOWN_OBJECT maps to a normal BACnet error.
+     * bacerror_encode_apdu() supports NULL apdu (length-only mode). */
+    memset(apdu, 0, sizeof(apdu));
+    null_len = bacnet_error_encode_apdu(
+        NULL, invoke_id, service, ERROR_CODE_UNKNOWN_OBJECT);
+    zassert_true(null_len > 0, "error null_len=%d", null_len);
+    len = bacnet_error_encode_apdu(
+        &apdu[0], invoke_id, service, ERROR_CODE_UNKNOWN_OBJECT);
+    zassert_equal(len, null_len, NULL);
+    zassert_true(len > 0, "error len=%d", len);
+    zassert_equal(apdu[0], PDU_TYPE_ERROR, "apdu[0]=0x%02x", apdu[0]);
+    zassert_equal(apdu[1], invoke_id, NULL);
+    zassert_equal(apdu[2], (uint8_t)service, NULL);
+
+    /* --- reject path from h_arf.c bounds checks --- */
+    /* ERROR_CODE_REJECT_PARAMETER_OUT_OF_RANGE triggers reject */
+    memset(apdu, 0, sizeof(apdu));
+    len = bacnet_error_encode_apdu(
+        &apdu[0], invoke_id, service, ERROR_CODE_REJECT_PARAMETER_OUT_OF_RANGE);
+    zassert_true(len > 0, "len=%d", len);
+    zassert_equal(apdu[0], PDU_TYPE_REJECT, "apdu[0]=0x%02x", apdu[0]);
+
+    /* --- reject path for missing required parameter --- */
+    memset(apdu, 0, sizeof(apdu));
+    len = bacnet_error_encode_apdu(
+        &apdu[0], invoke_id, service,
+        ERROR_CODE_REJECT_MISSING_REQUIRED_PARAMETER);
+    zassert_true(len > 0, "len=%d", len);
+    zassert_equal(apdu[0], PDU_TYPE_REJECT, "apdu[0]=0x%02x", apdu[0]);
+}
+/**
  * @}
  */
 
@@ -147,7 +228,9 @@ ZTEST_SUITE(bacerror_tests, NULL, NULL, NULL, NULL, NULL);
 #else
 void test_main(void)
 {
-    ztest_test_suite(bacerror_tests, ztest_unit_test(testBACError));
+    ztest_test_suite(
+        bacerror_tests, ztest_unit_test(testBACError),
+        ztest_unit_test(testBACNetErrorEncodeAPDU));
 
     ztest_run_test_suite(bacerror_tests);
 }

--- a/test/bacnet/baclog/CMakeLists.txt
+++ b/test/bacnet/baclog/CMakeLists.txt
@@ -44,7 +44,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdest.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/baclog.c
     ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/basic/object/auditlog/CMakeLists.txt
+++ b/test/bacnet/basic/object/auditlog/CMakeLists.txt
@@ -45,7 +45,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdest.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/bacreal.c
     ${SRC_DIR}/bacnet/bacstr.c

--- a/test/bacnet/basic/object/blo/CMakeLists.txt
+++ b/test/bacnet/basic/object/blo/CMakeLists.txt
@@ -43,7 +43,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdest.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/baclog.c
     ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/basic/object/lc/CMakeLists.txt
+++ b/test/bacnet/basic/object/lc/CMakeLists.txt
@@ -47,7 +47,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdest.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/baclog.c
     ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/basic/object/lo/CMakeLists.txt
+++ b/test/bacnet/basic/object/lo/CMakeLists.txt
@@ -45,7 +45,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdest.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/baclog.c
     ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/basic/object/lsp/CMakeLists.txt
+++ b/test/bacnet/basic/object/lsp/CMakeLists.txt
@@ -42,7 +42,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdest.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/baclog.c
     ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/basic/object/lsz/CMakeLists.txt
+++ b/test/bacnet/basic/object/lsz/CMakeLists.txt
@@ -43,7 +43,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdest.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/baclog.c
     ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/basic/object/nc/CMakeLists.txt
+++ b/test/bacnet/basic/object/nc/CMakeLists.txt
@@ -44,7 +44,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdest.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/baclog.c
     ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/basic/object/netport/CMakeLists.txt
+++ b/test/bacnet/basic/object/netport/CMakeLists.txt
@@ -61,7 +61,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdest.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/baclog.c
     ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/basic/service/h_arf/CMakeLists.txt
+++ b/test/bacnet/basic/service/h_arf/CMakeLists.txt
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: MIT
+
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+
+get_filename_component(basename ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(test_${basename}
+    VERSION 1.0.0
+    LANGUAGES C)
+
+string(REGEX REPLACE
+    "/test/bacnet/[a-zA-Z0-9_/-]*$"
+    "/src"
+    SRC_DIR
+    ${CMAKE_CURRENT_SOURCE_DIR})
+string(REGEX REPLACE
+    "/test/bacnet/[a-zA-Z0-9_/-]*$"
+    "/test"
+    TST_DIR
+    ${CMAKE_CURRENT_SOURCE_DIR})
+
+set(ZTST_DIR "${TST_DIR}/ztest/src")
+
+add_compile_definitions(
+    BACNET_BIG_ENDIAN=0
+    CONFIG_ZTEST=1
+    BACDL_NONE=1
+    )
+
+include_directories(
+    ${SRC_DIR}
+    ${TST_DIR}/ztest/include
+    )
+
+add_executable(${PROJECT_NAME}
+    # File(s) under test
+    ${SRC_DIR}/bacnet/basic/service/h_arf.c
+    # Support files and stubs (pathname alphabetical)
+    ${SRC_DIR}/bacnet/abort.c
+    ${SRC_DIR}/bacnet/arf.c
+    ${SRC_DIR}/bacnet/bacaddr.c
+    ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/bacdcode.c
+    ${SRC_DIR}/bacnet/bacint.c
+    ${SRC_DIR}/bacnet/bacreal.c
+    ${SRC_DIR}/bacnet/bacstr.c
+    ${SRC_DIR}/bacnet/bactext.c
+    ${SRC_DIR}/bacnet/basic/sys/bigend.c
+    ${SRC_DIR}/bacnet/indtext.c
+    ${SRC_DIR}/bacnet/basic/sys/debug.c
+    ${SRC_DIR}/bacnet/basic/tsm/tsm.c
+    ${SRC_DIR}/bacnet/datalink/datalink.c
+    ${SRC_DIR}/bacnet/npdu.c
+    ${SRC_DIR}/bacnet/reject.c
+    # Test and test library files
+    ./src/bacfile_stub.c
+    ./src/main.c
+    ${TST_DIR}/bacnet/basic/object/test/apdu_mock.c
+    ${ZTST_DIR}/ztest_mock.c
+    ${ZTST_DIR}/ztest.c
+    )

--- a/test/bacnet/basic/service/h_arf/src/bacfile_stub.c
+++ b/test/bacnet/basic/service/h_arf/src/bacfile_stub.c
@@ -1,0 +1,47 @@
+/**
+ * @file
+ * @brief Stubs for BACnet File object functions used by
+ * handler_atomic_read_file
+ * @author Steve Karg <skarg@users.sourceforge.net>
+ * @date 2026
+ * @copyright SPDX-License-Identifier: MIT
+ */
+#include <stdbool.h>
+#include <stdint.h>
+/* BACnet Stack defines - first */
+#include "bacnet/bacdef.h"
+/* BACnet Stack API */
+#include "bacnet/basic/object/bacfile.h"
+
+/** Control variable: set true to make bacfile_valid_instance() return true */
+bool Bacfile_Valid_Instance_Result = false;
+
+/**
+ * @brief Stub: report whether the file instance is valid
+ */
+bool bacfile_valid_instance(uint32_t object_instance)
+{
+    (void)object_instance;
+    return Bacfile_Valid_Instance_Result;
+}
+
+/** Control variable: set true to make bacfile_read_record_data() succeed */
+bool Bacfile_Read_Record_Data_Result = false;
+
+/**
+ * @brief Stub: simulate reading record data from a file
+ */
+bool bacfile_read_record_data(BACNET_ATOMIC_READ_FILE_DATA *data)
+{
+    (void)data;
+    return Bacfile_Read_Record_Data_Result;
+}
+
+/**
+ * @brief Stub: simulate reading stream data from a file (always succeeds)
+ */
+bool bacfile_read_stream_data(BACNET_ATOMIC_READ_FILE_DATA *data)
+{
+    (void)data;
+    return true;
+}

--- a/test/bacnet/basic/service/h_arf/src/main.c
+++ b/test/bacnet/basic/service/h_arf/src/main.c
@@ -1,0 +1,236 @@
+/**
+ * @file
+ * @brief Functional tests for handler_atomic_read_file bounds checks
+ * @author Steve Karg <skarg@users.sourceforge.net>
+ * @date 2026
+ * @copyright SPDX-License-Identifier: MIT
+ *
+ * Tests exercise the two out-of-bounds guards added to
+ * handler_atomic_read_file:
+ *   1. RecordCount > ARRAY_SIZE(data.fileData)  -> PDU_TYPE_REJECT
+ *   2. fileStartRecord >= ARRAY_SIZE(data.fileData) -> PDU_TYPE_ERROR
+ */
+#include <string.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <zephyr/ztest.h>
+/* BACnet Stack defines - first */
+#include "bacnet/bacdef.h"
+/* BACnet Stack API */
+#include "bacnet/bacenum.h"
+#include "bacnet/apdu.h"
+#include "bacnet/npdu.h"
+#include "bacnet/arf.h"
+#include "bacnet/basic/services.h"
+#include "bacnet/basic/tsm/tsm.h"
+
+/* Stub control variables defined in bacfile_stub.c */
+extern bool Bacfile_Valid_Instance_Result;
+extern bool Bacfile_Read_Record_Data_Result;
+
+/**
+ * @brief Build a minimal BACNET_CONFIRMED_SERVICE_DATA for use as the
+ *        service_data argument.
+ */
+static void
+make_service_data(BACNET_CONFIRMED_SERVICE_DATA *sd, uint8_t invoke_id)
+{
+    memset(sd, 0, sizeof(BACNET_CONFIRMED_SERVICE_DATA));
+    sd->invoke_id = invoke_id;
+    sd->priority = MESSAGE_PRIORITY_NORMAL;
+    sd->segmented_message = false;
+}
+
+/* -------------------------------------------------------------------------
+ * Test 1: service_len == 0  -> REJECT (missing required parameter)
+ * ------------------------------------------------------------------------- */
+#if defined(CONFIG_ZTEST_NEW_API)
+ZTEST(h_arf_tests, testHandlerARF_EmptyRequest)
+#else
+static void testHandlerARF_EmptyRequest(void)
+#endif
+{
+    BACNET_ADDRESS src = { 0 };
+    BACNET_CONFIRMED_SERVICE_DATA service_data = { 0 };
+    BACNET_NPDU_DATA npdu_data = { 0 };
+    uint8_t test_pdu_type, pdu_type;
+    uint8_t transmit_buffer[480] = { 0 };
+    int pdu_len, apdu_offset;
+
+    make_service_data(&service_data, 1);
+    Bacfile_Valid_Instance_Result = false;
+    Bacfile_Read_Record_Data_Result = false;
+    pdu_len = handler_atomic_read_file_encode(
+        transmit_buffer, NULL, 0, &src, &npdu_data, &service_data);
+    zassert_true(pdu_len > 0, "encoding failed: len=%d", pdu_len);
+    /* ERROR_CODE_REJECT_MISSING_REQUIRED_PARAMETER */
+    apdu_offset = npdu_decode(transmit_buffer, NULL, NULL, &npdu_data);
+    pdu_type = PDU_TYPE_REJECT;
+    test_pdu_type = transmit_buffer[apdu_offset];
+    zassert_equal(
+        pdu_type, test_pdu_type,
+        "Expected PDU_TYPE_REJECT (0x%02x), got 0x%02x", (unsigned)pdu_type,
+        (unsigned)test_pdu_type);
+}
+
+/* -------------------------------------------------------------------------
+ * Test 2: RecordCount > ARRAY_SIZE(data.fileData)  -> REJECT
+ *
+ * BACNET_READ_FILE_RECORD_COUNT defaults to 1, so ARRAY_SIZE(data.fileData)
+ * is 1.  Requesting RecordCount=2 must trigger the new bounds guard and
+ * return a Reject PDU.
+ * ------------------------------------------------------------------------- */
+#if defined(CONFIG_ZTEST_NEW_API)
+ZTEST(h_arf_tests, testHandlerARF_RecordCountOutOfBounds)
+#else
+static void testHandlerARF_RecordCountOutOfBounds(void)
+#endif
+{
+    BACNET_ATOMIC_READ_FILE_DATA req = { 0 };
+    uint8_t service_request[480] = { 0 };
+    uint8_t transmit_buffer[480] = { 0 };
+    BACNET_ADDRESS src = { 0 };
+    BACNET_CONFIRMED_SERVICE_DATA service_data = { 0 };
+    BACNET_NPDU_DATA npdu_data = { 0 };
+    int apdu_offset, len, service_len;
+
+    /* Build a FILE_RECORD_ACCESS request with RecordCount=2 (out of bounds) */
+    req.object_type = OBJECT_FILE;
+    req.object_instance = 0;
+    req.access = FILE_RECORD_ACCESS;
+    req.type.record.fileStartRecord = 0;
+    req.type.record.RecordCount = 2; /* > ARRAY_SIZE(data.fileData) == 1 */
+
+    service_len = arf_service_encode_apdu(service_request, &req);
+    zassert_true(service_len > 0, "encoding failed: len=%d", service_len);
+
+    make_service_data(&service_data, 2);
+    Bacfile_Valid_Instance_Result = true;
+    Bacfile_Read_Record_Data_Result = false;
+
+    len = handler_atomic_read_file_encode(
+        transmit_buffer, service_request, (uint16_t)service_len, &src,
+        &npdu_data, &service_data);
+    zassert_true(len > 0, "encoding failed: len=%d", len);
+
+    /* RecordCount exceeds the buffer size: handler must send a Reject */
+    apdu_offset = npdu_decode(transmit_buffer, NULL, NULL, &npdu_data);
+    zassert_equal(
+        transmit_buffer[apdu_offset], (uint8_t)PDU_TYPE_REJECT,
+        "Expected PDU_TYPE_REJECT (0x%02x) for RecordCount=2, got 0x%02x",
+        (unsigned)PDU_TYPE_REJECT, (unsigned)transmit_buffer[apdu_offset]);
+}
+
+/* -------------------------------------------------------------------------
+ * Test 3: fileStartRecord >= ARRAY_SIZE(data.fileData)  -> ERROR
+ *
+ * RecordCount=1 is within bounds, but fileStartRecord=1 equals
+ * ARRAY_SIZE(data.fileData) and must trigger the second new guard.
+ * The error code is ERROR_CODE_INVALID_FILE_START_POSITION which maps to
+ * ERROR_CLASS_SERVICES and is encoded as a regular Error PDU.
+ * ------------------------------------------------------------------------- */
+#if defined(CONFIG_ZTEST_NEW_API)
+ZTEST(h_arf_tests, testHandlerARF_FileStartRecordOutOfBounds)
+#else
+static void testHandlerARF_FileStartRecordOutOfBounds(void)
+#endif
+{
+    BACNET_ATOMIC_READ_FILE_DATA req = { 0 };
+    uint8_t service_request[480] = { 0 };
+    uint8_t transmit_buffer[480] = { 0 };
+    BACNET_ADDRESS src = { 0 };
+    BACNET_CONFIRMED_SERVICE_DATA service_data = { 0 };
+    BACNET_NPDU_DATA npdu_data = { 0 };
+    int apdu_offset, len, service_len;
+
+    /* Build a FILE_RECORD_ACCESS request with fileStartRecord=1 (out of
+     * bounds) */
+    req.object_type = OBJECT_FILE;
+    req.object_instance = 0;
+    req.access = FILE_RECORD_ACCESS;
+    req.type.record.fileStartRecord = 1; /* >= ARRAY_SIZE(data.fileData) == 1 */
+    req.type.record.RecordCount = 1; /* within bounds */
+
+    service_len = arf_service_encode_apdu(service_request, &req);
+    zassert_true(service_len > 0, "encoding failed: len=%d", service_len);
+
+    make_service_data(&service_data, 3);
+    Bacfile_Valid_Instance_Result = true;
+    Bacfile_Read_Record_Data_Result = false;
+
+    len = handler_atomic_read_file_encode(
+        transmit_buffer, service_request, (uint16_t)service_len, &src,
+        &npdu_data, &service_data);
+    zassert_true(len > 0, "encoding failed: len=%d", len);
+    /* fileStartRecord out of bounds: handler must send a regular Error PDU */
+    apdu_offset = npdu_decode(transmit_buffer, NULL, NULL, &npdu_data);
+    zassert_equal(
+        transmit_buffer[apdu_offset], (uint8_t)PDU_TYPE_ERROR,
+        "Expected PDU_TYPE_ERROR (0x%02x) for fileStartRecord=1, got 0x%02x",
+        (unsigned)PDU_TYPE_ERROR, (unsigned)transmit_buffer[apdu_offset]);
+}
+
+/* -------------------------------------------------------------------------
+ * Test 4: Valid record request with RecordCount=1, fileStartRecord=0  -> ACK
+ *
+ * Verify the normal success path still works after the bounds checks.
+ * ------------------------------------------------------------------------- */
+#if defined(CONFIG_ZTEST_NEW_API)
+ZTEST(h_arf_tests, testHandlerARF_ValidRecordRequest)
+#else
+static void testHandlerARF_ValidRecordRequest(void)
+#endif
+{
+    BACNET_ATOMIC_READ_FILE_DATA req = { 0 };
+    uint8_t service_request[480] = { 0 };
+    uint8_t transmit_buffer[480] = { 0 };
+    BACNET_ADDRESS src = { 0 };
+    BACNET_CONFIRMED_SERVICE_DATA service_data = { 0 };
+    BACNET_NPDU_DATA npdu_data = { 0 };
+    int apdu_offset, len, service_len;
+
+    /* Build a FILE_RECORD_ACCESS request within bounds */
+    req.object_type = OBJECT_FILE;
+    req.object_instance = 0;
+    req.access = FILE_RECORD_ACCESS;
+    req.type.record.fileStartRecord = 0;
+    req.type.record.RecordCount = 1;
+
+    service_len = arf_service_encode_apdu(service_request, &req);
+    zassert_true(service_len > 0, "encoding failed: len=%d", service_len);
+
+    make_service_data(&service_data, 4);
+    /* Both the instance check and the read succeed */
+    Bacfile_Valid_Instance_Result = true;
+    Bacfile_Read_Record_Data_Result = true;
+
+    len = handler_atomic_read_file_encode(
+        transmit_buffer, service_request, (uint16_t)service_len, &src,
+        &npdu_data, &service_data);
+    zassert_true(len > 0, "encoding failed: len=%d", len);
+    /* Successful read: handler must send a ComplexACK */
+    apdu_offset = npdu_decode(transmit_buffer, NULL, NULL, &npdu_data);
+    zassert_equal(
+        transmit_buffer[apdu_offset], (uint8_t)PDU_TYPE_COMPLEX_ACK,
+        "Expected PDU_TYPE_COMPLEX_ACK (0x%02x), got 0x%02x",
+        (unsigned)PDU_TYPE_COMPLEX_ACK, (unsigned)transmit_buffer[apdu_offset]);
+}
+
+/**
+ * @}
+ */
+
+#if defined(CONFIG_ZTEST_NEW_API)
+ZTEST_SUITE(h_arf_tests, NULL, NULL, NULL, NULL, NULL);
+#else
+void test_main(void)
+{
+    ztest_test_suite(
+        h_arf_tests, ztest_unit_test(testHandlerARF_EmptyRequest),
+        ztest_unit_test(testHandlerARF_RecordCountOutOfBounds),
+        ztest_unit_test(testHandlerARF_FileStartRecordOutOfBounds),
+        ztest_unit_test(testHandlerARF_ValidRecordRequest));
+
+    ztest_run_test_suite(h_arf_tests);
+}
+#endif

--- a/test/bacnet/create_object/CMakeLists.txt
+++ b/test/bacnet/create_object/CMakeLists.txt
@@ -43,7 +43,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdest.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/baclog.c
     ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/datalink/bsc-datalink/CMakeLists.txt
+++ b/test/bacnet/datalink/bsc-datalink/CMakeLists.txt
@@ -180,7 +180,9 @@ target_sources(${PROJECT_NAME} PRIVATE
   ${SRC_DIR}/bacnet/bacdcode.c
   ${SRC_DIR}/bacnet/bacdest.c
   ${SRC_DIR}/bacnet/bacdevobjpropref.c
+  ${SRC_DIR}/bacnet/abort.c
   ${SRC_DIR}/bacnet/bacerror.c
+  ${SRC_DIR}/bacnet/reject.c
   ${SRC_DIR}/bacnet/bacint.c
   ${SRC_DIR}/bacnet/baclog.c
   ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/datalink/bsc-node/CMakeLists.txt
+++ b/test/bacnet/datalink/bsc-node/CMakeLists.txt
@@ -169,7 +169,9 @@ target_sources(${PROJECT_NAME} PRIVATE
   ${SRC_DIR}/bacnet/bacdcode.c
   ${SRC_DIR}/bacnet/bacdest.c
   ${SRC_DIR}/bacnet/bacdevobjpropref.c
+  ${SRC_DIR}/bacnet/abort.c
   ${SRC_DIR}/bacnet/bacerror.c
+  ${SRC_DIR}/bacnet/reject.c
   ${SRC_DIR}/bacnet/bacint.c
   ${SRC_DIR}/bacnet/baclog.c
   ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/datalink/bsc-socket/CMakeLists.txt
+++ b/test/bacnet/datalink/bsc-socket/CMakeLists.txt
@@ -167,7 +167,9 @@ target_sources(${PROJECT_NAME} PRIVATE
   ${SRC_DIR}/bacnet/bacdcode.c
   ${SRC_DIR}/bacnet/bacdest.c
   ${SRC_DIR}/bacnet/bacdevobjpropref.c
+  ${SRC_DIR}/bacnet/abort.c
   ${SRC_DIR}/bacnet/bacerror.c
+  ${SRC_DIR}/bacnet/reject.c
   ${SRC_DIR}/bacnet/bacint.c
   ${SRC_DIR}/bacnet/baclog.c
   ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/datalink/hub-sc/CMakeLists.txt
+++ b/test/bacnet/datalink/hub-sc/CMakeLists.txt
@@ -172,7 +172,9 @@ target_sources(${PROJECT_NAME} PRIVATE
   ${SRC_DIR}/bacnet/bacdcode.c
   ${SRC_DIR}/bacnet/bacdest.c
   ${SRC_DIR}/bacnet/bacdevobjpropref.c
+  ${SRC_DIR}/bacnet/abort.c
   ${SRC_DIR}/bacnet/bacerror.c
+  ${SRC_DIR}/bacnet/reject.c
   ${SRC_DIR}/bacnet/bacint.c
   ${SRC_DIR}/bacnet/baclog.c
   ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/delete_object/CMakeLists.txt
+++ b/test/bacnet/delete_object/CMakeLists.txt
@@ -43,7 +43,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdest.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/baclog.c
     ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/hostnport/CMakeLists.txt
+++ b/test/bacnet/hostnport/CMakeLists.txt
@@ -43,7 +43,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdest.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/baclog.c
     ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/list_element/CMakeLists.txt
+++ b/test/bacnet/list_element/CMakeLists.txt
@@ -43,7 +43,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdest.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/baclog.c
     ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/lso/CMakeLists.txt
+++ b/test/bacnet/lso/CMakeLists.txt
@@ -43,7 +43,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdest.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/baclog.c
     ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/rpm/CMakeLists.txt
+++ b/test/bacnet/rpm/CMakeLists.txt
@@ -44,7 +44,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdest.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/baclog.c
     ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/timesync/CMakeLists.txt
+++ b/test/bacnet/timesync/CMakeLists.txt
@@ -44,7 +44,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdest.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/baclog.c
     ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/wpm/CMakeLists.txt
+++ b/test/bacnet/wpm/CMakeLists.txt
@@ -44,7 +44,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdest.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/baclog.c
     ${SRC_DIR}/bacnet/bacreal.c

--- a/test/bacnet/write_group/CMakeLists.txt
+++ b/test/bacnet/write_group/CMakeLists.txt
@@ -43,7 +43,9 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/bacnet/bacdcode.c
     ${SRC_DIR}/bacnet/bacdest.c
     ${SRC_DIR}/bacnet/bacdevobjpropref.c
+    ${SRC_DIR}/bacnet/abort.c
     ${SRC_DIR}/bacnet/bacerror.c
+    ${SRC_DIR}/bacnet/reject.c
     ${SRC_DIR}/bacnet/bacint.c
     ${SRC_DIR}/bacnet/baclog.c
     ${SRC_DIR}/bacnet/bacreal.c

--- a/test/unit/bacnet/bacerror/CMakeLists.txt
+++ b/test/unit/bacnet/bacerror/CMakeLists.txt
@@ -33,7 +33,9 @@ include_directories(
 
 add_executable(${PROJECT_NAME}
     # File(s) under test
+        ${SRC_DIR}/bacnet/abort.c
         ${SRC_DIR}/bacnet/bacerror.c
+        ${SRC_DIR}/bacnet/reject.c
     # Support files and stubs (pathname alphabetical)
     # Test and test library files
     ./src/main.c


### PR DESCRIPTION
A crafted request can set an excessively large RecordCount, which is later used as the loop bound for writing record data into a stack-allocated BACNET_ATOMIC_READ_FILE_DATA data structure. However, the stack object only has space for one fileData element. When the loop reaches i = 1, the code computes &data->fileData[1], which is already out of bounds, and the resulting invalid pointer is passed down to memmove(), causing a stack-buffer-overflow.