### PR TITLE
Uninitialized Value Use in AtomicReadFile-ACK

### DIFF
--- a/apps/perl/perl_bindings.c
+++ b/apps/perl/perl_bindings.c
@@ -245,7 +245,7 @@ static void AtomicReadFileAckHandler(
     BACNET_CONFIRMED_SERVICE_ACK_DATA *service_data)
 {
     int len = 0;
-    BACNET_ATOMIC_READ_FILE_DATA data;
+    BACNET_ATOMIC_READ_FILE_DATA data = { 0 };
 
     if (address_match(&Target_Address, src) &&
         (service_data->invoke_id == Request_Invoke_ID)) {
@@ -295,7 +295,7 @@ static void My_Read_Property_Ack_Handler(
     BACNET_CONFIRMED_SERVICE_ACK_DATA *service_data)
 {
     int len = 0;
-    BACNET_READ_PROPERTY_DATA data;
+    BACNET_READ_PROPERTY_DATA data = { 0 };
 
     if (address_match(&Target_Address, src) &&
         (service_data->invoke_id == Request_Invoke_ID)) {

--- a/apps/piface/device.c
+++ b/apps/piface/device.c
@@ -1687,7 +1687,7 @@ static bool Device_Write_Property_Object_Name(
 {
     bool status = false; /* return value */
     int len = 0;
-    BACNET_CHARACTER_STRING value;
+    BACNET_CHARACTER_STRING value = { 0 };
     BACNET_OBJECT_TYPE object_type = OBJECT_NONE;
     uint32_t object_instance = 0;
     int apdu_size = 0;

--- a/apps/readfile/main.c
+++ b/apps/readfile/main.c
@@ -97,7 +97,7 @@ static void AtomicReadFileAckHandler(
 {
     int len = 0;
     int result = 0;
-    BACNET_ATOMIC_READ_FILE_DATA data;
+    BACNET_ATOMIC_READ_FILE_DATA data = { 0 };
     FILE *pFile = NULL; /* stream pointer */
     size_t octets_written = 0;
     size_t octet_count = 0;

--- a/ports/at91sam7s/device.c
+++ b/ports/at91sam7s/device.c
@@ -205,7 +205,7 @@ static bool Device_Write_Property_Object_Name(
 {
     bool status = false; /* return value */
     int len = 0;
-    BACNET_CHARACTER_STRING value;
+    BACNET_CHARACTER_STRING value = { 0 };
     BACNET_OBJECT_TYPE object_type = OBJECT_NONE;
     uint32_t object_instance = 0;
     int apdu_size = 0;

--- a/ports/bdk-atxx4-mstp/device.c
+++ b/ports/bdk-atxx4-mstp/device.c
@@ -172,7 +172,7 @@ static bool Device_Write_Property_Object_Name(
 {
     bool status = false; /* return value */
     int len = 0;
-    BACNET_CHARACTER_STRING value;
+    BACNET_CHARACTER_STRING value = { 0 };
     BACNET_OBJECT_TYPE object_type = OBJECT_NONE;
     uint32_t object_instance = 0;
     int apdu_size = 0;

--- a/ports/stm32f4xx/device.c
+++ b/ports/stm32f4xx/device.c
@@ -1206,7 +1206,7 @@ static bool Device_Write_Property_Object_Name(
 {
     bool status = false; /* return value */
     int len = 0;
-    BACNET_CHARACTER_STRING value;
+    BACNET_CHARACTER_STRING value = { 0 };
     BACNET_OBJECT_TYPE object_type = OBJECT_NONE;
     uint32_t object_instance = 0;
     int apdu_size = 0;

--- a/src/bacnet/arf.c
+++ b/src/bacnet/arf.c
@@ -334,6 +334,7 @@ int arf_ack_service_encode_apdu(
     int apdu_len = 0; /* total length of the apdu, return value */
     int len = 0;
     uint32_t i = 0;
+    BACNET_UNSIGNED_INTEGER record_count = 0;
 
     /* endOfFile */
     len = encode_application_boolean(apdu, data->endOfFile);
@@ -374,13 +375,17 @@ int arf_ack_service_encode_apdu(
             if (apdu) {
                 apdu += len;
             }
-            len = encode_application_unsigned(
-                apdu, data->type.record.RecordCount);
+            /* restrict the record count to the size of the fileData array */
+            record_count = data->type.record.RecordCount;
+            if (record_count > ARRAY_SIZE(data->fileData)) {
+                record_count = ARRAY_SIZE(data->fileData);
+            }
+            len = encode_application_unsigned(apdu, record_count);
             apdu_len += len;
             if (apdu) {
                 apdu += len;
             }
-            for (i = 0; i < data->type.record.RecordCount; i++) {
+            for (i = 0; i < record_count; i++) {
                 len = encode_application_octet_string(apdu, &data->fileData[i]);
                 apdu_len += len;
                 if (apdu) {
@@ -520,6 +525,9 @@ int arf_ack_decode_service_request(
         len = bacnet_unsigned_application_decode(
             &apdu[apdu_len], apdu_size - apdu_len, &record_count);
         if (len <= 0) {
+            return BACNET_STATUS_ERROR;
+        }
+        if (record_count > BACNET_READ_FILE_RECORD_COUNT) {
             return BACNET_STATUS_ERROR;
         }
         if (data) {

--- a/src/bacnet/arf.c
+++ b/src/bacnet/arf.c
@@ -488,6 +488,7 @@ int arf_ack_decode_service_request(
         if (data) {
             octet_string = &data->fileData[0];
         }
+        octetstring_init(octet_string, NULL, 0);
         len = bacnet_octet_string_application_decode(
             &apdu[apdu_len], apdu_size - apdu_len, octet_string);
         if (len <= 0) {
@@ -534,6 +535,7 @@ int arf_ack_decode_service_request(
             } else {
                 octet_string = NULL;
             }
+            octetstring_init(octet_string, NULL, 0);
             len = bacnet_octet_string_application_decode(
                 &apdu[apdu_len], apdu_size - apdu_len, octet_string);
             if (len <= 0) {

--- a/src/bacnet/awf.c
+++ b/src/bacnet/awf.c
@@ -226,6 +226,7 @@ int awf_decode_service_request(
         if (data) {
             octet_string = &data->fileData[0];
         }
+        octetstring_init(octet_string, NULL, 0);
         len = bacnet_octet_string_application_decode(
             &apdu[apdu_len], apdu_size - apdu_len, octet_string);
         if (len <= 0) {
@@ -274,6 +275,7 @@ int awf_decode_service_request(
             } else {
                 octet_string = NULL;
             }
+            octetstring_init(octet_string, NULL, 0);
             len = bacnet_octet_string_application_decode(
                 &apdu[apdu_len], apdu_size - apdu_len, octet_string);
             if (len <= 0) {

--- a/src/bacnet/bacapp.c
+++ b/src/bacnet/bacapp.c
@@ -1352,6 +1352,7 @@ int bacapp_decode_application_tag_value(
 #endif
 #if defined(BACAPP_OCTET_STRING)
         case BACNET_APPLICATION_TAG_OCTET_STRING:
+            octetstring_init(&value->type.Octet_String, NULL, 0);
             apdu_len = bacnet_octet_string_application_decode(
                 apdu, apdu_size, &value->type.Octet_String);
             if (apdu_len == 0) {
@@ -1363,6 +1364,7 @@ int bacapp_decode_application_tag_value(
 #endif
 #if defined(BACAPP_CHARACTER_STRING)
         case BACNET_APPLICATION_TAG_CHARACTER_STRING:
+            characterstring_init_ansi(&value->type.Character_String, "");
             apdu_len = bacnet_character_string_application_decode(
                 apdu, apdu_size, &value->type.Character_String);
             if (apdu_len == 0) {
@@ -1374,6 +1376,7 @@ int bacapp_decode_application_tag_value(
 #endif
 #if defined(BACAPP_BIT_STRING)
         case BACNET_APPLICATION_TAG_BIT_STRING:
+            bitstring_init(&value->type.Bit_String);
             apdu_len = bacnet_bitstring_application_decode(
                 apdu, apdu_size, &value->type.Bit_String);
             if (apdu_len == 0) {

--- a/src/bacnet/basic/object/bacfile.c
+++ b/src/bacnet/basic/object/bacfile.c
@@ -1232,17 +1232,17 @@ bool bacfile_read_ack_record_data(
     bool found = false;
     const char *pathname = NULL;
     uint32_t i = 0;
-    size_t max_records = 0;
 
     if (!data) {
+        return false;
+    }
+    if (data->type.record.RecordCount > ARRAY_SIZE(data->fileData)) {
         return false;
     }
     pathname = bacfile_pathname(instance);
     if (pathname) {
         found = true;
-        max_records =
-            min(data->type.record.RecordCount, ARRAY_SIZE(data->fileData));
-        for (i = 0; i < max_records; i++) {
+        for (i = 0; i < data->type.record.RecordCount; i++) {
             bacfile_write_record_data_callback(
                 pathname, data->type.record.fileStartRecord, i,
                 octetstring_value((BACNET_OCTET_STRING *)&data->fileData[i]),

--- a/src/bacnet/basic/object/bacfile.c
+++ b/src/bacnet/basic/object/bacfile.c
@@ -1081,6 +1081,7 @@ bool bacfile_read_record_data(BACNET_ATOMIC_READ_FILE_DATA *data)
     const char *pathname = NULL;
     bool found = false;
     bool status = false;
+    size_t len = 0;
     uint32_t i = 0;
     size_t max_records = 0;
 
@@ -1099,7 +1100,14 @@ bool bacfile_read_record_data(BACNET_ATOMIC_READ_FILE_DATA *data)
                     pathname, data->type.record.fileStartRecord, i,
                     octetstring_value(&data->fileData[i]),
                     octetstring_capacity(&data->fileData[i]));
-                if (!status) {
+                if (status) {
+                    /* our records are NULL terminated C strings
+                       read with fgets() */
+                    len = bacnet_strnlen(
+                        (const char *)octetstring_value(&data->fileData[i]),
+                        octetstring_capacity(&data->fileData[i]));
+                    octetstring_truncate(&data->fileData[i], len);
+                } else {
                     data->endOfFile = true;
                     data->type.record.RecordCount = i;
                     break;

--- a/src/bacnet/basic/object/bacfile.c
+++ b/src/bacnet/basic/object/bacfile.c
@@ -1030,6 +1030,12 @@ uint32_t bacfile_instance_from_tsm(uint8_t invokeID)
 }
 #endif
 
+/**
+ * @brief Read stream data from a file
+ * @param data - pointer to the data structure to fill
+ * @return true - if successful
+ * @return false - if failed or file not found
+ */
 bool bacfile_read_stream_data(BACNET_ATOMIC_READ_FILE_DATA *data)
 {
     const char *pathname = NULL;
@@ -1037,6 +1043,9 @@ bool bacfile_read_stream_data(BACNET_ATOMIC_READ_FILE_DATA *data)
     size_t len = 0;
     size_t requestedOctetCount = 0;
 
+    if (!data) {
+        return false;
+    }
     pathname = bacfile_pathname(data->object_instance);
     if (pathname) {
         found = true;
@@ -1061,6 +1070,12 @@ bool bacfile_read_stream_data(BACNET_ATOMIC_READ_FILE_DATA *data)
     return found;
 }
 
+/**
+ * @brief Read record data from a file
+ * @param data - pointer to the data structure to fill
+ * @return true - if successful
+ * @return false - if failed or file not found
+ */
 bool bacfile_read_record_data(BACNET_ATOMIC_READ_FILE_DATA *data)
 {
     const char *pathname = NULL;
@@ -1108,6 +1123,9 @@ bool bacfile_write_stream_data(BACNET_ATOMIC_WRITE_FILE_DATA *data)
     bool status = false;
     size_t bytes_written = 0;
 
+    if (!data) {
+        return false;
+    }
     if (bacfile_read_only(data->object_instance)) {
         /* if the file is read-only, then we cannot write to it */
         return false;
@@ -1143,11 +1161,17 @@ bool bacfile_write_record_data(const BACNET_ATOMIC_WRITE_FILE_DATA *data)
     const char *pathname = NULL;
     bool found = false;
     size_t i = 0;
+    size_t max_records = 0;
 
+    if (!data) {
+        return false;
+    }
     if (bacfile_read_only(data->object_instance)) {
         /* if the file is read-only, then we cannot write to it */
         return false;
     }
+    max_records =
+        min(data->type.record.returnedRecordCount, ARRAY_SIZE(data->fileData));
     pathname = bacfile_pathname(data->object_instance);
     if (pathname) {
         found = true;
@@ -1156,7 +1180,7 @@ bool bacfile_write_record_data(const BACNET_ATOMIC_WRITE_FILE_DATA *data)
             as an append to the current end of file.
             If the 'File Start Record' parameter is 0,
             open the file as a clean slate. */
-        for (i = 0; i < data->type.record.returnedRecordCount; i++) {
+        for (i = 0; i < max_records; i++) {
             bacfile_write_record_data_callback(
                 pathname, data->type.record.fileStartRecord, i,
                 octetstring_value((BACNET_OCTET_STRING *)&data->fileData[i]),
@@ -1180,6 +1204,9 @@ bool bacfile_read_ack_stream_data(
     bool found = false;
     const char *pathname = NULL;
 
+    if (!data) {
+        return false;
+    }
     pathname = bacfile_pathname(instance);
     if (pathname) {
         found = true;
@@ -1205,11 +1232,17 @@ bool bacfile_read_ack_record_data(
     bool found = false;
     const char *pathname = NULL;
     uint32_t i = 0;
+    size_t max_records = 0;
 
+    if (!data) {
+        return false;
+    }
     pathname = bacfile_pathname(instance);
     if (pathname) {
         found = true;
-        for (i = 0; i < data->type.record.RecordCount; i++) {
+        max_records =
+            min(data->type.record.RecordCount, ARRAY_SIZE(data->fileData));
+        for (i = 0; i < max_records; i++) {
             bacfile_write_record_data_callback(
                 pathname, data->type.record.fileStartRecord, i,
                 octetstring_value((BACNET_OCTET_STRING *)&data->fileData[i]),

--- a/src/bacnet/basic/object/client/device-client.c
+++ b/src/bacnet/basic/object/client/device-client.c
@@ -1318,7 +1318,7 @@ static bool Device_Write_Property_Object_Name(
 {
     bool status = false; /* return value */
     int len = 0;
-    BACNET_CHARACTER_STRING value;
+    BACNET_CHARACTER_STRING value = { 0 };
     BACNET_OBJECT_TYPE object_type = OBJECT_NONE;
     uint32_t object_instance = 0;
     int apdu_size = 0;

--- a/src/bacnet/basic/object/device.c
+++ b/src/bacnet/basic/object/device.c
@@ -3619,7 +3619,7 @@ static bool Device_Write_Property_Object_Name(
 {
     bool status = false; /* return value */
     int len = 0;
-    BACNET_CHARACTER_STRING value;
+    BACNET_CHARACTER_STRING value = { 0 };
     BACNET_OBJECT_TYPE object_type = OBJECT_NONE;
     uint32_t object_instance = 0;
     int apdu_size = 0;

--- a/src/bacnet/basic/server/bacnet_device.c
+++ b/src/bacnet/basic/server/bacnet_device.c
@@ -3300,7 +3300,7 @@ static bool Device_Write_Property_Object_Name(
 {
     bool status = false; /* return value */
     int len = 0;
-    BACNET_CHARACTER_STRING value;
+    BACNET_CHARACTER_STRING value = { 0 };
     BACNET_OBJECT_TYPE object_type = OBJECT_NONE;
     uint32_t object_instance = 0;
     int apdu_size = 0;

--- a/src/bacnet/basic/service/h_arf_a.c
+++ b/src/bacnet/basic/service/h_arf_a.c
@@ -32,7 +32,7 @@ void handler_atomic_read_file_ack(
     BACNET_CONFIRMED_SERVICE_ACK_DATA *service_data)
 {
     int len = 0;
-    BACNET_ATOMIC_READ_FILE_DATA data;
+    BACNET_ATOMIC_READ_FILE_DATA data = { 0 };
     uint32_t instance = 0;
 
     (void)src;

--- a/src/bacnet/basic/service/s_arfs.c
+++ b/src/bacnet/basic/service/s_arfs.c
@@ -30,16 +30,16 @@ uint8_t Send_Atomic_Read_File_Stream(
     int fileStartPosition,
     unsigned requestedOctetCount)
 {
-    BACNET_ADDRESS dest;
-    BACNET_ADDRESS my_address;
-    BACNET_NPDU_DATA npdu_data;
+    BACNET_ADDRESS dest = { 0 };
+    BACNET_ADDRESS my_address = { 0 };
+    BACNET_NPDU_DATA npdu_data = { 0 };
     unsigned max_apdu = 0;
     uint8_t invoke_id = 0;
     bool status = false;
     int len = 0;
     int pdu_len = 0;
     int bytes_sent = 0;
-    BACNET_ATOMIC_READ_FILE_DATA data;
+    BACNET_ATOMIC_READ_FILE_DATA data = { 0 };
 
     /* if we are forbidden to send, don't send! */
     if (!dcc_communication_enabled()) {

--- a/src/bacnet/channel_value.c
+++ b/src/bacnet/channel_value.c
@@ -1290,18 +1290,21 @@ int bacnet_channel_value_no_coerce_decode(
 #endif
 #if defined(CHANNEL_OCTET_STRING)
         case BACNET_APPLICATION_TAG_OCTET_STRING:
+            octetstring_init(&value->type.Octet_String, NULL, 0);
             len = bacnet_octet_string_application_decode(
                 apdu, apdu_size, &value->type.Octet_String);
             break;
 #endif
 #if defined(CHANNEL_CHARACTER_STRING)
         case BACNET_APPLICATION_TAG_CHARACTER_STRING:
+            characterstring_init_ansi(&value->type.Character_String, "");
             len = bacnet_character_string_application_decode(
                 apdu, apdu_size, &value->type.Character_String);
             break;
 #endif
 #if defined(CHANNEL_BIT_STRING)
         case BACNET_APPLICATION_TAG_BIT_STRING:
+            bitstring_init(&value->type.Bit_String);
             len = bacnet_bitstring_application_decode(
                 apdu, apdu_size, &value->type.Bit_String);
             break;

--- a/src/bacnet/ihave.c
+++ b/src/bacnet/ihave.c
@@ -115,6 +115,7 @@ int ihave_decode_service_request(
     if (data) {
         decoded_string = &data->object_name;
     }
+    characterstring_init_ansi(decoded_string, "");
     len = bacnet_character_string_application_decode(
         &apdu[apdu_len], apdu_size - apdu_len, decoded_string);
     if (len <= 0) {

--- a/src/bacnet/whoami.c
+++ b/src/bacnet/whoami.c
@@ -134,6 +134,7 @@ int who_am_i_request_decode(
         return BACNET_STATUS_ERROR;
     }
     apdu_len += len;
+    characterstring_init_ansi(model_name, "");
     len = bacnet_character_string_application_decode(
         &apdu[apdu_len], apdu_size - apdu_len, model_name);
     if (len > 0) {
@@ -141,6 +142,7 @@ int who_am_i_request_decode(
     } else {
         return BACNET_STATUS_ERROR;
     }
+    characterstring_init_ansi(serial_number, "");
     len = bacnet_character_string_application_decode(
         &apdu[apdu_len], apdu_size - apdu_len, serial_number);
     if (len > 0) {

--- a/src/bacnet/youare.c
+++ b/src/bacnet/youare.c
@@ -171,6 +171,7 @@ int you_are_request_decode(
         return BACNET_STATUS_ERROR;
     }
     apdu_len += len;
+    characterstring_init_ansi(model_name, "");
     len = bacnet_character_string_application_decode(
         &apdu[apdu_len], apdu_size - apdu_len, model_name);
     if (len > 0) {
@@ -178,6 +179,7 @@ int you_are_request_decode(
     } else {
         return BACNET_STATUS_ERROR;
     }
+    characterstring_init_ansi(serial_number, "");
     len = bacnet_character_string_application_decode(
         &apdu[apdu_len], apdu_size - apdu_len, serial_number);
     if (len > 0) {
@@ -203,6 +205,7 @@ int you_are_request_decode(
     } else {
         return BACNET_STATUS_ERROR;
     }
+    octetstring_init(mac_address, NULL, 0);
     len = bacnet_octet_string_application_decode(
         &apdu[apdu_len], apdu_size - apdu_len, mac_address);
     if (len > 0) {

--- a/test/bacnet/arf/src/main.c
+++ b/test/bacnet/arf/src/main.c
@@ -6,6 +6,7 @@
  */
 #include <zephyr/ztest.h>
 #include <bacnet/arf.h>
+#include <string.h>
 
 /**
  * @addtogroup bacnet_tests
@@ -154,6 +155,19 @@ static void testAtomicReadFileAccess(const BACNET_ATOMIC_READ_FILE_DATA *data)
     }
 }
 
+static int
+encode_application_octet_string_with_raw_length(uint8_t *apdu, uint32_t length)
+{
+    int apdu_len = 0;
+
+    apdu_len =
+        encode_tag(apdu, BACNET_APPLICATION_TAG_OCTET_STRING, false, length);
+    memset(&apdu[apdu_len], 0xA5, length);
+    apdu_len += (int)length;
+
+    return apdu_len;
+}
+
 #if defined(CONFIG_ZTEST_NEW_API)
 ZTEST(arf_tests, testAtomicReadFile)
 #else
@@ -177,6 +191,61 @@ static void testAtomicReadFile(void)
     testAtomicReadFileAccess(&data);
 
     return;
+}
+
+#if defined(CONFIG_ZTEST_NEW_API)
+ZTEST(arf_tests, testAtomicReadFileAckOversizedOctetString)
+#else
+static void testAtomicReadFileAckOversizedOctetString(void)
+#endif
+{
+    BACNET_ATOMIC_READ_FILE_DATA data;
+    uint8_t apdu[2048] = { 0 };
+    uint32_t oversized_length = MAX_OCTET_STRING_BYTES + 1;
+    int apdu_len = 0;
+    int len = 0;
+
+    zassert_true((oversized_length + 16U) < sizeof(apdu), NULL);
+
+    memset(&data, 0xA5, sizeof(data));
+    apdu_len = 0;
+    len = encode_application_boolean(&apdu[apdu_len], true);
+    apdu_len += len;
+    len = encode_opening_tag(&apdu[apdu_len], 0);
+    apdu_len += len;
+    len = encode_application_signed(&apdu[apdu_len], 1234);
+    apdu_len += len;
+    len = encode_application_octet_string_with_raw_length(
+        &apdu[apdu_len], oversized_length);
+    apdu_len += len;
+    len = encode_closing_tag(&apdu[apdu_len], 0);
+    apdu_len += len;
+
+    len = arf_ack_decode_service_request(apdu, apdu_len, &data);
+    zassert_equal(len, apdu_len, NULL);
+    zassert_true(data.endOfFile, NULL);
+    zassert_equal(data.access, FILE_STREAM_ACCESS, NULL);
+    zassert_equal(data.type.stream.fileStartPosition, 1234, NULL);
+    zassert_equal(octetstring_length(&data.fileData[0]), 0, NULL);
+
+    apdu_len = 0;
+    len = encode_application_boolean(&apdu[apdu_len], false);
+    apdu_len += len;
+    len = encode_opening_tag(&apdu[apdu_len], 0);
+    apdu_len += len;
+    len = encode_application_signed(&apdu[apdu_len], -17);
+    apdu_len += len;
+    len = encode_application_octet_string_with_raw_length(&apdu[apdu_len], 3);
+    apdu_len += len;
+    len = encode_closing_tag(&apdu[apdu_len], 0);
+    apdu_len += len;
+
+    len = arf_ack_decode_service_request(apdu, apdu_len, &data);
+    zassert_equal(len, apdu_len, NULL);
+    zassert_false(data.endOfFile, NULL);
+    zassert_equal(data.access, FILE_STREAM_ACCESS, NULL);
+    zassert_equal(data.type.stream.fileStartPosition, -17, NULL);
+    zassert_equal(octetstring_length(&data.fileData[0]), 3, NULL);
 }
 
 #if defined(CONFIG_ZTEST_NEW_API)
@@ -226,6 +295,7 @@ void test_main(void)
     ztest_test_suite(
         arf_tests, ztest_unit_test(testAtomicReadFile),
         ztest_unit_test(testAtomicReadFileAck),
+        ztest_unit_test(testAtomicReadFileAckOversizedOctetString),
         ztest_unit_test(testAtomicReadFileMalformed));
 
     ztest_run_test_suite(arf_tests);

--- a/test/bacnet/awf/src/main.c
+++ b/test/bacnet/awf/src/main.c
@@ -7,6 +7,7 @@
  */
 #include <zephyr/ztest.h>
 #include <bacnet/awf.h>
+#include <string.h>
 
 /**
  * @addtogroup bacnet_tests
@@ -143,6 +144,19 @@ testAtomicWriteFileAckAccess(const BACNET_ATOMIC_WRITE_FILE_DATA *data)
     }
 }
 
+static int
+encode_application_octet_string_with_raw_length(uint8_t *apdu, uint32_t length)
+{
+    int apdu_len = 0;
+
+    apdu_len =
+        encode_tag(apdu, BACNET_APPLICATION_TAG_OCTET_STRING, false, length);
+    memset(&apdu[apdu_len], 0xA5, length);
+    apdu_len += (int)length;
+
+    return apdu_len;
+}
+
 #if defined(CONFIG_ZTEST_NEW_API)
 ZTEST(awf_tests, testAtomicWriteFileAck)
 #else
@@ -160,6 +174,63 @@ static void testAtomicWriteFileAck(void)
     testAtomicWriteFileAckAccess(&data);
 
     return;
+}
+
+#if defined(CONFIG_ZTEST_NEW_API)
+ZTEST(awf_tests, testAtomicWriteFileOversizedOctetString)
+#else
+static void testAtomicWriteFileOversizedOctetString(void)
+#endif
+{
+    BACNET_ATOMIC_WRITE_FILE_DATA data;
+    uint8_t apdu[2048] = { 0 };
+    uint32_t oversized_length = MAX_OCTET_STRING_BYTES + 1;
+    int apdu_len = 0;
+    int len = 0;
+
+    zassert_true((oversized_length + 24U) < sizeof(apdu), NULL);
+
+    memset(&data, 0xA5, sizeof(data));
+    apdu_len = 0;
+    len = encode_application_object_id(&apdu[apdu_len], OBJECT_FILE, 77);
+    apdu_len += len;
+    len = encode_opening_tag(&apdu[apdu_len], 0);
+    apdu_len += len;
+    len = encode_application_signed(&apdu[apdu_len], 321);
+    apdu_len += len;
+    len = encode_application_octet_string_with_raw_length(
+        &apdu[apdu_len], oversized_length);
+    apdu_len += len;
+    len = encode_closing_tag(&apdu[apdu_len], 0);
+    apdu_len += len;
+
+    len = awf_decode_service_request(apdu, apdu_len, &data);
+    zassert_equal(len, apdu_len, NULL);
+    zassert_equal(data.object_type, OBJECT_FILE, NULL);
+    zassert_equal(data.object_instance, 77, NULL);
+    zassert_equal(data.access, FILE_STREAM_ACCESS, NULL);
+    zassert_equal(data.type.stream.fileStartPosition, 321, NULL);
+    zassert_equal(octetstring_length(&data.fileData[0]), 0, NULL);
+
+    apdu_len = 0;
+    len = encode_application_object_id(&apdu[apdu_len], OBJECT_FILE, 99);
+    apdu_len += len;
+    len = encode_opening_tag(&apdu[apdu_len], 0);
+    apdu_len += len;
+    len = encode_application_signed(&apdu[apdu_len], -42);
+    apdu_len += len;
+    len = encode_application_octet_string_with_raw_length(&apdu[apdu_len], 3);
+    apdu_len += len;
+    len = encode_closing_tag(&apdu[apdu_len], 0);
+    apdu_len += len;
+
+    len = awf_decode_service_request(apdu, apdu_len, &data);
+    zassert_equal(len, apdu_len, NULL);
+    zassert_equal(data.object_type, OBJECT_FILE, NULL);
+    zassert_equal(data.object_instance, 99, NULL);
+    zassert_equal(data.access, FILE_STREAM_ACCESS, NULL);
+    zassert_equal(data.type.stream.fileStartPosition, -42, NULL);
+    zassert_equal(octetstring_length(&data.fileData[0]), 3, NULL);
 }
 
 #if defined(CONFIG_ZTEST_NEW_API)
@@ -212,6 +283,7 @@ void test_main(void)
     ztest_test_suite(
         awf_tests, ztest_unit_test(testAtomicWriteFile),
         ztest_unit_test(testAtomicWriteFileAck),
+        ztest_unit_test(testAtomicWriteFileOversizedOctetString),
         ztest_unit_test(testAtomicWriteFileMalformed));
 
     ztest_run_test_suite(awf_tests);

--- a/test/bacnet/bacdcode/src/main.c
+++ b/test/bacnet/bacdcode/src/main.c
@@ -1190,8 +1190,8 @@ static void testBACDCodeCharacterString(void)
 {
     uint8_t apdu[MAX_APDU] = { 0 };
     uint8_t encoded_apdu[MAX_APDU] = { 0 };
-    BACNET_CHARACTER_STRING value;
-    BACNET_CHARACTER_STRING test_value;
+    BACNET_CHARACTER_STRING value = { 0 };
+    BACNET_CHARACTER_STRING test_value = { 0 };
     char test_name[MAX_APDU] = { "" };
     int i; /* for loop counter */
     int apdu_len = 0, len = 0, null_len = 0, tag_len, test_len;


### PR DESCRIPTION
An uninitialized value use vulnerability in bacnet-stack's AtomicReadFile record-access ACK encoder allows unauthenticated remote attackers to corrupt the encoded OCTET STRING length and payload boundary in network responses by sending a crafted AtomicReadFile request that reaches a successful record-access path.

The vulnerability stems from a stack-allocated BACNET_ATOMIC_READ_FILE_DATA object being used as the source for response encoding without guaranteeing that each returned fileData[i] is a fully initialized BACNET_OCTET_STRING. In the verified 1.5.0 test case, the same uninitialized length value is consumed once to derive the encoded OCTET STRING length and again to determine how many bytes are copied into the ACK payload.

In the default POSIX-style example path, the observed effect is response corruption and zero-filled expansion of the encoded record item. On backends that only write a record prefix and do not fully initialize the remainder of the record buffer, the same flaw can additionally become a conditional information disclosure primitive.