### PR TITLE
Fix buffer overflows in bsc_node_parse_urls()

### DIFF
--- a/src/bacnet/datalink/bsc/bsc-node.c
+++ b/src/bacnet/datalink/bsc/bsc-node.c
@@ -405,22 +405,28 @@ static void bsc_node_parse_urls(
                  .utf8_websocket_uri_string_len;
          i++) {
         if (url[i] == 0x20) {
-            if (i > BSC_CONF_NODE_MAX_URI_SIZE_IN_ADDRESS_RESOLUTION_ACK ||
+            if ((i - start) >
+                    BSC_CONF_NODE_MAX_URI_SIZE_IN_ADDRESS_RESOLUTION_ACK ||
                 (i - start) == 0) {
                 start = i + 1;
                 continue;
-            } else {
+            } else if (j <
+                BSC_CONF_NODE_MAX_URIS_NUM_IN_ADDRESS_RESOLUTION_ACK) {
                 memcpy(&r->utf8_urls[j][0], &url[start], i - start);
-                r->utf8_urls[j][i] = 0;
+                r->utf8_urls[j][i - start] = 0;
                 j++;
                 start = i + 1;
+            } else {
+                break;
             }
         }
     }
     if (i - start > 0 &&
-        i <= BSC_CONF_NODE_MAX_URI_SIZE_IN_ADDRESS_RESOLUTION_ACK) {
+        (i - start) <=
+            BSC_CONF_NODE_MAX_URI_SIZE_IN_ADDRESS_RESOLUTION_ACK &&
+        j < BSC_CONF_NODE_MAX_URIS_NUM_IN_ADDRESS_RESOLUTION_ACK) {
         memcpy(&r->utf8_urls[j][0], &url[start], i - start);
-        r->utf8_urls[j][i] = 0;
+        r->utf8_urls[j][i - start] = 0;
         j++;
     }
     r->urls_num = j;

--- a/src/bacnet/datalink/bsc/bsc-node.c
+++ b/src/bacnet/datalink/bsc/bsc-node.c
@@ -410,8 +410,8 @@ static void bsc_node_parse_urls(
                 (i - start) == 0) {
                 start = i + 1;
                 continue;
-            } else if (j <
-                BSC_CONF_NODE_MAX_URIS_NUM_IN_ADDRESS_RESOLUTION_ACK) {
+            } else if (
+                j < BSC_CONF_NODE_MAX_URIS_NUM_IN_ADDRESS_RESOLUTION_ACK) {
                 memcpy(&r->utf8_urls[j][0], &url[start], i - start);
                 r->utf8_urls[j][i - start] = 0;
                 j++;
@@ -422,8 +422,7 @@ static void bsc_node_parse_urls(
         }
     }
     if (i - start > 0 &&
-        (i - start) <=
-            BSC_CONF_NODE_MAX_URI_SIZE_IN_ADDRESS_RESOLUTION_ACK &&
+        (i - start) <= BSC_CONF_NODE_MAX_URI_SIZE_IN_ADDRESS_RESOLUTION_ACK &&
         j < BSC_CONF_NODE_MAX_URIS_NUM_IN_ADDRESS_RESOLUTION_ACK) {
         memcpy(&r->utf8_urls[j][0], &url[start], i - start);
         r->utf8_urls[j][i - start] = 0;


### PR DESCRIPTION
## Summary

Three buffer overflow bugs in the BACnet/SC Address Resolution ACK URL parser (`bsc_node_parse_urls()` in `src/bacnet/datalink/bsc/bsc-node.c`):

**Bug 1 -- NUL byte write past buffer (CWE-787):** The NUL terminator at lines 414/423 uses the absolute string position `i` as an array index (`r->utf8_urls[j][i] = 0`) instead of the relative URL length `i - start`. For URLs starting past byte 128 in the URI string, `i` exceeds the 129-byte `utf8_urls[j]` buffer, writing a zero byte up to ~1389 bytes out of bounds.

**Bug 2 -- Unbounded URL count (CWE-787):** The URL index `j` is never checked against `BSC_CONF_NODE_MAX_URIS_NUM_IN_ADDRESS_RESOLUTION_ACK`. With 11+ space-separated short URLs in a single Address Resolution ACK, both `memcpy` and the NUL write access past the 10-element `utf8_urls` array, corrupting `urls_num`, `fresh_timer`, and adjacent `BSC_ADDRESS_RESOLUTION` entries in the static array.

**Bug 3 -- Incorrect length comparison:** The skip check at line 408 compares the absolute position `i` against the max URI size instead of the actual URL length `(i - start)`. This causes valid short URLs at high string offsets to be incorrectly rejected.

## Fix

- Use `(i - start)` for URL length in both the skip check and NUL terminator index
- Add `j < BSC_CONF_NODE_MAX_URIS_NUM_IN_ADDRESS_RESOLUTION_ACK` bounds check before every array write
- Break out of the loop when the URL count limit is reached

## Impact

An authenticated BACnet/SC peer can send a crafted Address Resolution ACK message to trigger out-of-bounds writes, corrupting static data structures. Bug 2 is the most exploitable -- a 21-byte URI string with 11 single-character URLs is sufficient.