### PR TITLE
Fix write property error code to indicate success in decode functions

### DIFF
--- a/src/bacnet/wp.c
+++ b/src/bacnet/wp.c
@@ -204,7 +204,7 @@ int wp_decode_service_request(
         return BACNET_STATUS_ERROR;
     }
     if (wpdata) {
-        wpdata->error_code = ERROR_CODE_OTHER;
+        wpdata->error_code = ERROR_CODE_SUCCESS;
         wpdata->array_index = BACNET_ARRAY_ALL;
         wpdata->priority = BACNET_MAX_PRIORITY;
         wpdata->application_data_len = 0;

--- a/src/bacnet/wpm.c
+++ b/src/bacnet/wpm.c
@@ -123,7 +123,7 @@ int wpm_decode_object_property(
         return BACNET_STATUS_REJECT;
     }
     if (wp_data) {
-        wp_data->error_code = ERROR_CODE_OTHER;
+        wp_data->error_code = ERROR_CODE_SUCCESS;
         wp_data->array_index = BACNET_ARRAY_ALL;
         wp_data->priority = BACNET_MAX_PRIORITY;
         wp_data->application_data_len = 0;


### PR DESCRIPTION
Fix write property error code to indicate success in decode functions. In wp_decode_service_request(), wpdata->error_code was set to ERROR_CODE_OTHER at decode start. On success the function does not update it, so error_code stays OTHER even when decode returns a positive length.