### PR TITLE
CMake: add BACNET_DEFINES variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,17 @@ option(
   "enable intrinsic reporting"
   OFF)
 
+set(
+  BACNET_DEFINES
+  ""
+  CACHE STRING
+  "Extra compile definitions (e.g. MAX_NUM_DEVICES=30;MAX_TREND_LOGS=30)"
+)
+
+if(BACNET_DEFINES)
+  add_compile_definitions(${BACNET_DEFINES})
+endif()
+
 set(BACNET_PROTOCOL_REVISION 28)
 
 if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
Makefile already have a BACNET_DEFINES variable, through which developer can tweak almost all defines of the stack. CMake file misses it, it only provides explicit options for common choices.

Add this wildcard BACNET_DEFINES variable to CMake so caller can tweak stack internal behavior almost the same way he can do it using Makefile.

Examples of use through CLI:

```
cmake -DBACNET_DEFINES="MAX_NUM_DEVICES=30;MAX_TREND_LOGS=30" ..
```

Example of use when stack CMakeLists.txt is included in another project:

```
list(APPEND BACNET_DEFINES "MAX_NUM_DEVICES=30")
list(APPEND BACNET_DEFINES "MAX_TREND_LOGS=30")
add_subdirectory(bacnet-stack)
```