### PR TITLE
Add a lighting command override ramp function.

### DIFF
--- a/src/bacnet/basic/sys/lighting_command.c
+++ b/src/bacnet/basic/sys/lighting_command.c
@@ -1012,6 +1012,7 @@ void lighting_command_fade_to(
     lighting_command_lock(data);
     if (data->Overridden) {
         if (data->Overridden_Momentary) {
+            data->Overridden_Momentary = false;
             data->Overridden = false;
         }
     }
@@ -1073,6 +1074,7 @@ void lighting_command_ramp_to(
     lighting_command_lock(data);
     if (data->Overridden) {
         if (data->Overridden_Momentary) {
+            data->Overridden_Momentary = false;
             data->Overridden = false;
         }
     }
@@ -1101,6 +1103,7 @@ void lighting_command_step(
     lighting_command_lock(data);
     if (data->Overridden) {
         if (data->Overridden_Momentary) {
+            data->Overridden_Momentary = false;
             data->Overridden = false;
         }
     }
@@ -1170,6 +1173,7 @@ void lighting_command_blink_warn(
     lighting_command_lock(data);
     if (data->Overridden) {
         if (data->Overridden_Momentary) {
+            data->Overridden_Momentary = false;
             data->Overridden = false;
         }
     }
@@ -1236,6 +1240,7 @@ void lighting_command_stop(struct bacnet_lighting_command_data *data)
     lighting_command_lock(data);
     if (data->Overridden) {
         if (data->Overridden_Momentary) {
+            data->Overridden_Momentary = false;
             data->Overridden = false;
         }
     }
@@ -1266,6 +1271,7 @@ void lighting_command_none(struct bacnet_lighting_command_data *data)
     lighting_command_lock(data);
     if (data->Overridden) {
         if (data->Overridden_Momentary) {
+            data->Overridden_Momentary = false;
             data->Overridden = false;
         }
     }
@@ -1293,6 +1299,7 @@ void lighting_command_restore_on(
     lighting_command_lock(data);
     if (data->Overridden) {
         if (data->Overridden_Momentary) {
+            data->Overridden_Momentary = false;
             data->Overridden = false;
         }
     }
@@ -1324,6 +1331,7 @@ void lighting_command_default_on(
     lighting_command_lock(data);
     if (data->Overridden) {
         if (data->Overridden_Momentary) {
+            data->Overridden_Momentary = false;
             data->Overridden = false;
         }
     }
@@ -1355,6 +1363,7 @@ void lighting_command_toggle_restore(
     lighting_command_lock(data);
     if (data->Overridden) {
         if (data->Overridden_Momentary) {
+            data->Overridden_Momentary = false;
             data->Overridden = false;
         }
     }
@@ -1392,6 +1401,7 @@ void lighting_command_toggle_default(
     lighting_command_lock(data);
     if (data->Overridden) {
         if (data->Overridden_Momentary) {
+            data->Overridden_Momentary = false;
             data->Overridden = false;
         }
     }

--- a/src/bacnet/basic/sys/lighting_command.c
+++ b/src/bacnet/basic/sys/lighting_command.c
@@ -528,13 +528,7 @@ static void lighting_command_tracking_value_event(
         data->Min_Actual_Value, data->Max_Actual_Value, tracking_value);
     old_physical_value = lighting_command_normalized_to_physical_value(
         data->Min_Actual_Value, data->Max_Actual_Value, old_value);
-    if (data->Overridden) {
-        lighting_command_notify(data, old_physical_value, physical_value);
-        if (data->Overridden_Momentary) {
-            data->Overridden = false;
-        }
-    } else if (!data->Out_Of_Service) {
-        data->Overridden_Momentary = false;
+    if (!data->Out_Of_Service) {
         lighting_command_notify(data, old_physical_value, physical_value);
     } else {
         debug_printf(
@@ -919,82 +913,15 @@ static void lighting_command_override_nolock(
 {
     float old_value;
 
+    data->Lighting_Operation = BACNET_LIGHTS_STOP;
+    if (isgreaterequal(value, 1.0)) {
+        /* the last value that was greater than or equal to 1.0%.*/
+        data->Last_On_Value = value;
+    }
     old_value = data->Tracking_Value;
     data->Tracking_Value = lighting_command_normalized_range_clamp(value);
     lighting_command_tracking_value_event(
         data, old_value, data->Tracking_Value);
-}
-
-/**
- * @brief Overrides the current lighting command with the provided value
- * @param data [in] dimmer data
- */
-void lighting_command_override(
-    struct bacnet_lighting_command_data *data, float value)
-{
-    if (!data) {
-        return;
-    }
-    lighting_command_lock(data);
-    lighting_command_override_nolock(data, value);
-    lighting_command_unlock(data);
-}
-
-/**
- * @brief Overrides the current lighting command with the provided value
- * @param data [in] dimmer data
- */
-void lighting_command_override_set(
-    struct bacnet_lighting_command_data *data, float value)
-{
-    if (!data) {
-        return;
-    }
-    lighting_command_lock(data);
-    data->Overridden = true;
-    data->Overridden_Momentary = false;
-    lighting_command_override_nolock(data, value);
-    lighting_command_unlock(data);
-}
-
-/**
- * @brief Clears the override of the current lighting command
- * @param data [in] dimmer data
- */
-void lighting_command_override_clear(
-    struct bacnet_lighting_command_data *data, float value)
-{
-    float old_value;
-
-    if (!data) {
-        return;
-    }
-    lighting_command_lock(data);
-    data->Overridden = false;
-    data->Overridden_Momentary = false;
-    old_value = data->Tracking_Value;
-    /* clamp Tracking value within the Normalized Range */
-    data->Tracking_Value = lighting_command_normalized_range_clamp(value);
-    lighting_command_tracking_value_event(
-        data, old_value, data->Tracking_Value);
-    lighting_command_unlock(data);
-}
-
-/**
- * @brief Overrides the current lighting command with the provided value
- * @param data [in] dimmer data
- */
-void lighting_command_override_momentary(
-    struct bacnet_lighting_command_data *data, float value)
-{
-    if (!data) {
-        return;
-    }
-    lighting_command_lock(data);
-    data->Overridden = true;
-    data->Overridden_Momentary = true;
-    lighting_command_override_nolock(data, value);
-    lighting_command_unlock(data);
 }
 
 /**
@@ -1027,9 +954,6 @@ void lighting_command_timer(
         return;
     }
     lighting_command_lock(data);
-    if (data->Overridden) {
-        data->Lighting_Operation = BACNET_LIGHTS_NONE;
-    }
     switch (data->Lighting_Operation) {
         case BACNET_LIGHTS_NONE:
             data->In_Progress = BACNET_LIGHTING_IDLE;
@@ -1086,19 +1010,52 @@ void lighting_command_fade_to(
         return;
     }
     lighting_command_lock(data);
+    if (data->Overridden) {
+        if (data->Overridden_Momentary) {
+            data->Overridden = false;
+        }
+    }
+    if (!data->Overridden) {
+        /* possibly interrupting a blink warn, so notify */
+        lighting_command_blink_stop_notify_nolock(data);
+        /* configure the lighting operation */
+        data->Fade_Time = fade_time;
+        data->Lighting_Operation = BACNET_LIGHTS_FADE_TO;
+        data->Target_Level = value;
+        if (isgreaterequal(value, 1.0)) {
+            /* the last value that was greater than or equal to 1.0%.*/
+            data->Last_On_Value = value;
+        }
+        lighting_command_event_notify(
+            data, BACNET_LIGHTS_FADE_TO, value, fade_time);
+    }
+    lighting_command_unlock(data);
+}
+
+/**
+ * @brief Execute a ramp to command without locking the data structure
+ * @param data - dimmer data structure
+ * @param value - target value for the ramp to command
+ * @param ramp_rate - ramp rate for the ramp to command
+ */
+static void lighting_command_ramp_to_nolock(
+    struct bacnet_lighting_command_data *data, float value, float ramp_rate)
+{
+    if (!data) {
+        return;
+    }
     /* possibly interrupting a blink warn, so notify */
     lighting_command_blink_stop_notify_nolock(data);
     /* configure the lighting operation */
-    data->Fade_Time = fade_time;
-    data->Lighting_Operation = BACNET_LIGHTS_FADE_TO;
+    data->Ramp_Rate = lighting_command_ramp_rate_clamp(ramp_rate);
+    data->Lighting_Operation = BACNET_LIGHTS_RAMP_TO;
     data->Target_Level = value;
     if (isgreaterequal(value, 1.0)) {
         /* the last value that was greater than or equal to 1.0%.*/
         data->Last_On_Value = value;
     }
     lighting_command_event_notify(
-        data, BACNET_LIGHTS_FADE_TO, value, fade_time);
-    lighting_command_unlock(data);
+        data, BACNET_LIGHTS_RAMP_TO, value, data->Ramp_Rate);
 }
 
 /**
@@ -1114,18 +1071,14 @@ void lighting_command_ramp_to(
         return;
     }
     lighting_command_lock(data);
-    /* possibly interrupting a blink warn, so notify */
-    lighting_command_blink_stop_notify_nolock(data);
-    /* configure the lighting operation */
-    data->Ramp_Rate = lighting_command_ramp_rate_clamp(ramp_rate);
-    data->Lighting_Operation = BACNET_LIGHTS_RAMP_TO;
-    data->Target_Level = value;
-    if (isgreaterequal(value, 1.0)) {
-        /* the last value that was greater than or equal to 1.0%.*/
-        data->Last_On_Value = value;
+    if (data->Overridden) {
+        if (data->Overridden_Momentary) {
+            data->Overridden = false;
+        }
     }
-    lighting_command_event_notify(
-        data, BACNET_LIGHTS_RAMP_TO, value, data->Ramp_Rate);
+    if (!data->Overridden) {
+        lighting_command_ramp_to_nolock(data, value, ramp_rate);
+    }
     lighting_command_unlock(data);
 }
 
@@ -1146,45 +1099,56 @@ void lighting_command_step(
         return;
     }
     lighting_command_lock(data);
-    /* possibly interrupting a blink warn, so notify */
-    lighting_command_blink_stop_notify_nolock(data);
-    /* configure the lighting operation */
-    if (((operation == BACNET_LIGHTS_STEP_UP) ||
-         (operation == BACNET_LIGHTS_STEP_DOWN)) &&
-        (is_float_equal(data->Tracking_Value, 0.0))) {
-        /* If the starting level of Tracking_Value is 0.0%,
-        then this operation is ignored. */
-        goto done;
+    if (data->Overridden) {
+        if (data->Overridden_Momentary) {
+            data->Overridden = false;
+        }
     }
-    data->Lighting_Operation = operation;
-    data->Fade_Time = 0;
-    data->Step_Increment = step_increment;
-    /* determine the last-on-value for the given step operation */
-    if (operation == BACNET_LIGHTS_STEP_UP) {
-        target_value = lighting_command_step_up_target_value(
-            data->Tracking_Value, data->Step_Increment);
-        target_value = lighting_command_normalized_on_range_clamp(target_value);
-    } else if (operation == BACNET_LIGHTS_STEP_DOWN) {
-        target_value = lighting_command_step_down_target_value(
-            data->Tracking_Value, data->Step_Increment);
-        target_value = lighting_command_normalized_on_range_clamp(target_value);
-    } else if (operation == BACNET_LIGHTS_STEP_ON) {
-        target_value = lighting_command_step_up_target_value(
-            data->Tracking_Value, data->Step_Increment);
-        target_value = lighting_command_normalized_range_clamp(target_value);
-    } else if (operation == BACNET_LIGHTS_STEP_OFF) {
-        target_value = lighting_command_step_down_target_value(
-            data->Tracking_Value, data->Step_Increment);
-        target_value = lighting_command_normalized_range_clamp(target_value);
-    } else {
-        goto done;
+    if (!data->Overridden) {
+        /* possibly interrupting a blink warn, so notify */
+        lighting_command_blink_stop_notify_nolock(data);
+        /* configure the lighting operation */
+        if (((operation == BACNET_LIGHTS_STEP_UP) ||
+             (operation == BACNET_LIGHTS_STEP_DOWN)) &&
+            (is_float_equal(data->Tracking_Value, 0.0))) {
+            /* If the starting level of Tracking_Value is 0.0%,
+            then this operation is ignored. */
+            goto done;
+        }
+        data->Lighting_Operation = operation;
+        data->Fade_Time = 0;
+        data->Step_Increment = step_increment;
+        /* determine the last-on-value for the given step operation */
+        if (operation == BACNET_LIGHTS_STEP_UP) {
+            target_value = lighting_command_step_up_target_value(
+                data->Tracking_Value, data->Step_Increment);
+            target_value =
+                lighting_command_normalized_on_range_clamp(target_value);
+        } else if (operation == BACNET_LIGHTS_STEP_DOWN) {
+            target_value = lighting_command_step_down_target_value(
+                data->Tracking_Value, data->Step_Increment);
+            target_value =
+                lighting_command_normalized_on_range_clamp(target_value);
+        } else if (operation == BACNET_LIGHTS_STEP_ON) {
+            target_value = lighting_command_step_up_target_value(
+                data->Tracking_Value, data->Step_Increment);
+            target_value =
+                lighting_command_normalized_range_clamp(target_value);
+        } else if (operation == BACNET_LIGHTS_STEP_OFF) {
+            target_value = lighting_command_step_down_target_value(
+                data->Tracking_Value, data->Step_Increment);
+            target_value =
+                lighting_command_normalized_range_clamp(target_value);
+        } else {
+            goto done;
+        }
+        if (isgreaterequal(target_value, 1.0)) {
+            /* the last value that was greater than or equal to 1.0%.*/
+            data->Last_On_Value = target_value;
+        }
+        lighting_command_event_notify(
+            data, operation, data->Step_Increment, data->Fade_Time);
     }
-    if (isgreaterequal(target_value, 1.0)) {
-        /* the last value that was greater than or equal to 1.0%.*/
-        data->Last_On_Value = target_value;
-    }
-    lighting_command_event_notify(
-        data, operation, data->Step_Increment, data->Fade_Time);
 done:
     lighting_command_unlock(data);
 }
@@ -1204,25 +1168,32 @@ void lighting_command_blink_warn(
         return;
     }
     lighting_command_lock(data);
-    /* possibly interrupting a blink warn, so notify */
-    lighting_command_blink_stop_notify_nolock(data);
-    /* configure the new warning */
-    data->Lighting_Operation = operation;
-    data->Blink.Target_Interval = blink->Interval;
-    data->Blink.Duration = blink->Duration;
-    data->Blink.Priority = blink->Priority;
-    data->Blink.Callback = blink->Callback;
-    data->Blink.Count = blink->Count;
-    data->Blink.On_Value = blink->On_Value;
-    data->Blink.Off_Value = blink->Off_Value;
-    data->Blink.End_Value = blink->End_Value;
-    /* start blinking */
-    data->In_Progress = BACNET_LIGHTING_OTHER;
-    /* configure next interval */
-    data->Blink.State = false;
-    data->Blink.Interval = blink->Interval;
-    lighting_command_event_notify(
-        data, operation, blink->Interval, blink->Duration);
+    if (data->Overridden) {
+        if (data->Overridden_Momentary) {
+            data->Overridden = false;
+        }
+    }
+    if (!data->Overridden) {
+        /* possibly interrupting a blink warn, so notify */
+        lighting_command_blink_stop_notify_nolock(data);
+        /* configure the new warning */
+        data->Lighting_Operation = operation;
+        data->Blink.Target_Interval = blink->Interval;
+        data->Blink.Duration = blink->Duration;
+        data->Blink.Priority = blink->Priority;
+        data->Blink.Callback = blink->Callback;
+        data->Blink.Count = blink->Count;
+        data->Blink.On_Value = blink->On_Value;
+        data->Blink.Off_Value = blink->Off_Value;
+        data->Blink.End_Value = blink->End_Value;
+        /* start blinking */
+        data->In_Progress = BACNET_LIGHTING_OTHER;
+        /* configure next interval */
+        data->Blink.State = false;
+        data->Blink.Interval = blink->Interval;
+        lighting_command_event_notify(
+            data, operation, blink->Interval, blink->Duration);
+    }
     lighting_command_unlock(data);
 }
 
@@ -1263,15 +1234,22 @@ void lighting_command_stop(struct bacnet_lighting_command_data *data)
         return;
     }
     lighting_command_lock(data);
-    /* possibly interrupting a blink warn, so notify */
-    lighting_command_blink_stop_notify_nolock(data);
-    /* configure the lighting operation */
-    data->Lighting_Operation = BACNET_LIGHTS_STOP;
-    if (isgreaterequal(data->Tracking_Value, 1.0)) {
-        /* the last value that was greater than or equal to 1.0%.*/
-        data->Last_On_Value = data->Tracking_Value;
+    if (data->Overridden) {
+        if (data->Overridden_Momentary) {
+            data->Overridden = false;
+        }
     }
-    lighting_command_event_notify(data, BACNET_LIGHTS_STOP, 0.0f, 0.0f);
+    if (!data->Overridden) {
+        /* possibly interrupting a blink warn, so notify */
+        lighting_command_blink_stop_notify_nolock(data);
+        /* configure the lighting operation */
+        data->Lighting_Operation = BACNET_LIGHTS_STOP;
+        if (isgreaterequal(data->Tracking_Value, 1.0)) {
+            /* the last value that was greater than or equal to 1.0%.*/
+            data->Last_On_Value = data->Tracking_Value;
+        }
+        lighting_command_event_notify(data, BACNET_LIGHTS_STOP, 0.0f, 0.0f);
+    }
     lighting_command_unlock(data);
 }
 
@@ -1286,11 +1264,18 @@ void lighting_command_none(struct bacnet_lighting_command_data *data)
         return;
     }
     lighting_command_lock(data);
-    /* possibly interrupting a blink warn, so notify */
-    lighting_command_blink_stop_notify_nolock(data);
-    /* configure the lighting operation */
-    data->Lighting_Operation = BACNET_LIGHTS_NONE;
-    lighting_command_event_notify(data, BACNET_LIGHTS_NONE, 0.0f, 0.0f);
+    if (data->Overridden) {
+        if (data->Overridden_Momentary) {
+            data->Overridden = false;
+        }
+    }
+    if (!data->Overridden) {
+        /* possibly interrupting a blink warn, so notify */
+        lighting_command_blink_stop_notify_nolock(data);
+        /* configure the lighting operation */
+        data->Lighting_Operation = BACNET_LIGHTS_NONE;
+        lighting_command_event_notify(data, BACNET_LIGHTS_NONE, 0.0f, 0.0f);
+    }
     lighting_command_unlock(data);
 }
 
@@ -1306,14 +1291,22 @@ void lighting_command_restore_on(
         return;
     }
     lighting_command_lock(data);
-    /* possibly interrupting a blink warn, so notify */
-    lighting_command_blink_stop_notify_nolock(data);
-    /* configure the lighting operation */
-    data->Fade_Time = fade_time;
-    data->Lighting_Operation = BACNET_LIGHTS_RESTORE_ON;
-    data->Target_Level = data->Last_On_Value;
-    lighting_command_event_notify(
-        data, BACNET_LIGHTS_RESTORE_ON, data->Last_On_Value, data->Fade_Time);
+    if (data->Overridden) {
+        if (data->Overridden_Momentary) {
+            data->Overridden = false;
+        }
+    }
+    if (!data->Overridden) {
+        /* possibly interrupting a blink warn, so notify */
+        lighting_command_blink_stop_notify_nolock(data);
+        /* configure the lighting operation */
+        data->Fade_Time = fade_time;
+        data->Lighting_Operation = BACNET_LIGHTS_RESTORE_ON;
+        data->Target_Level = data->Last_On_Value;
+        lighting_command_event_notify(
+            data, BACNET_LIGHTS_RESTORE_ON, data->Last_On_Value,
+            data->Fade_Time);
+    }
     lighting_command_unlock(data);
 }
 
@@ -1329,15 +1322,22 @@ void lighting_command_default_on(
         return;
     }
     lighting_command_lock(data);
-    /* possibly interrupting a blink warn, so notify */
-    lighting_command_blink_stop_notify_nolock(data);
-    /* configure the lighting operation */
-    data->Fade_Time = fade_time;
-    data->Lighting_Operation = BACNET_LIGHTS_DEFAULT_ON;
-    data->Target_Level = data->Default_On_Value;
-    lighting_command_event_notify(
-        data, BACNET_LIGHTS_DEFAULT_ON, data->Default_On_Value,
-        data->Fade_Time);
+    if (data->Overridden) {
+        if (data->Overridden_Momentary) {
+            data->Overridden = false;
+        }
+    }
+    if (!data->Overridden) {
+        /* possibly interrupting a blink warn, so notify */
+        lighting_command_blink_stop_notify_nolock(data);
+        /* configure the lighting operation */
+        data->Fade_Time = fade_time;
+        data->Lighting_Operation = BACNET_LIGHTS_DEFAULT_ON;
+        data->Target_Level = data->Default_On_Value;
+        lighting_command_event_notify(
+            data, BACNET_LIGHTS_DEFAULT_ON, data->Default_On_Value,
+            data->Fade_Time);
+    }
     lighting_command_unlock(data);
 }
 
@@ -1353,21 +1353,28 @@ void lighting_command_toggle_restore(
         return;
     }
     lighting_command_lock(data);
-    /* possibly interrupting a blink warn, so notify */
-    lighting_command_blink_stop_notify_nolock(data);
-    /* configure the lighting operation */
-    data->Fade_Time = fade_time;
-    data->Lighting_Operation = BACNET_LIGHTS_TOGGLE_RESTORE;
-    if (isless(data->Tracking_Value, 1.0f)) {
-        /* OFF: write the Last_On_Value */
-        data->Target_Level = data->Last_On_Value;
-    } else {
-        /* not OFF, write 0.0% */
-        data->Target_Level = 0.0f;
+    if (data->Overridden) {
+        if (data->Overridden_Momentary) {
+            data->Overridden = false;
+        }
     }
-    lighting_command_event_notify(
-        data, BACNET_LIGHTS_TOGGLE_RESTORE, data->Target_Level,
-        data->Fade_Time);
+    if (!data->Overridden) {
+        /* possibly interrupting a blink warn, so notify */
+        lighting_command_blink_stop_notify_nolock(data);
+        /* configure the lighting operation */
+        data->Fade_Time = fade_time;
+        data->Lighting_Operation = BACNET_LIGHTS_TOGGLE_RESTORE;
+        if (isless(data->Tracking_Value, 1.0f)) {
+            /* OFF: write the Last_On_Value */
+            data->Target_Level = data->Last_On_Value;
+        } else {
+            /* not OFF, write 0.0% */
+            data->Target_Level = 0.0f;
+        }
+        lighting_command_event_notify(
+            data, BACNET_LIGHTS_TOGGLE_RESTORE, data->Target_Level,
+            data->Fade_Time);
+    }
     lighting_command_unlock(data);
 }
 
@@ -1383,21 +1390,124 @@ void lighting_command_toggle_default(
         return;
     }
     lighting_command_lock(data);
-    /* possibly interrupting a blink warn, so notify */
-    lighting_command_blink_stop_notify_nolock(data);
-    /* configure the lighting operation */
-    data->Fade_Time = fade_time;
-    data->Lighting_Operation = BACNET_LIGHTS_TOGGLE_DEFAULT;
-    if (isless(data->Tracking_Value, 1.0f)) {
-        /* OFF: write the Default_On_Value */
-        data->Target_Level = data->Default_On_Value;
-    } else {
-        /* not OFF, write 0.0% */
-        data->Target_Level = 0.0f;
+    if (data->Overridden) {
+        if (data->Overridden_Momentary) {
+            data->Overridden = false;
+        }
     }
-    lighting_command_event_notify(
-        data, BACNET_LIGHTS_TOGGLE_DEFAULT, data->Target_Level,
-        data->Fade_Time);
+    if (!data->Overridden) {
+        /* possibly interrupting a blink warn, so notify */
+        lighting_command_blink_stop_notify_nolock(data);
+        /* configure the lighting operation */
+        data->Fade_Time = fade_time;
+        data->Lighting_Operation = BACNET_LIGHTS_TOGGLE_DEFAULT;
+        if (isless(data->Tracking_Value, 1.0f)) {
+            /* OFF: write the Default_On_Value */
+            data->Target_Level = data->Default_On_Value;
+        } else {
+            /* not OFF, write 0.0% */
+            data->Target_Level = 0.0f;
+        }
+        lighting_command_event_notify(
+            data, BACNET_LIGHTS_TOGGLE_DEFAULT, data->Target_Level,
+            data->Fade_Time);
+    }
+    lighting_command_unlock(data);
+}
+
+/**
+ * @brief Overrides the current lighting command with the provided value
+ * @param data [in] dimmer data
+ */
+void lighting_command_override(
+    struct bacnet_lighting_command_data *data, float value)
+{
+    if (!data) {
+        return;
+    }
+    lighting_command_lock(data);
+    lighting_command_override_nolock(data, value);
+    lighting_command_unlock(data);
+}
+
+/**
+ * @brief Overrides the current lighting command with the provided value
+ * @param data [in] dimmer data
+ */
+void lighting_command_override_set(
+    struct bacnet_lighting_command_data *data, float value)
+{
+    if (!data) {
+        return;
+    }
+    lighting_command_lock(data);
+    data->Overridden = true;
+    data->Overridden_Momentary = false;
+    lighting_command_override_nolock(data, value);
+    lighting_command_unlock(data);
+}
+
+/**
+ * @brief Overrides the current lighting command with the provided value and
+ * ramp rate
+ * @param data [in] dimmer data
+ * @param value [in] target value for the ramp to command
+ * @param ramp_rate [in] ramp rate value
+ */
+void lighting_command_override_ramp(
+    struct bacnet_lighting_command_data *data, float value, float ramp_rate)
+{
+    if (!data) {
+        return;
+    }
+    lighting_command_lock(data);
+    data->Overridden = true;
+    data->Overridden_Momentary = false;
+    lighting_command_ramp_to_nolock(data, value, ramp_rate);
+    lighting_command_unlock(data);
+}
+
+/**
+ * @brief Clears the override of the current lighting command
+ * @param data [in] dimmer data
+ * @param value [in] value to set the tracking value to when clearing the
+ * override
+ */
+void lighting_command_override_clear(
+    struct bacnet_lighting_command_data *data, float value)
+{
+    float old_value;
+
+    if (!data) {
+        return;
+    }
+    lighting_command_lock(data);
+    data->Overridden = false;
+    data->Overridden_Momentary = false;
+    data->Lighting_Operation = BACNET_LIGHTS_STOP;
+    /* notify */
+    old_value = data->Tracking_Value;
+    /* clamp Tracking value within the Normalized Range */
+    data->Tracking_Value = lighting_command_normalized_range_clamp(value);
+    lighting_command_tracking_value_event(
+        data, old_value, data->Tracking_Value);
+    lighting_command_unlock(data);
+}
+
+/**
+ * @brief Overrides the current lighting command with the provided value
+ * @param data [in] dimmer data
+ */
+void lighting_command_override_momentary(
+    struct bacnet_lighting_command_data *data, float value)
+{
+    if (!data) {
+        return;
+    }
+    lighting_command_lock(data);
+    data->Overridden = true;
+    data->Overridden_Momentary = true;
+    lighting_command_override_nolock(data, value);
     lighting_command_unlock(data);
 }
 

--- a/src/bacnet/basic/sys/lighting_command.h
+++ b/src/bacnet/basic/sys/lighting_command.h
@@ -181,6 +181,9 @@ void lighting_command_override_clear(
 BACNET_STACK_EXPORT
 void lighting_command_override_momentary(
     struct bacnet_lighting_command_data *data, float value);
+BACNET_STACK_EXPORT
+void lighting_command_override_ramp(
+    struct bacnet_lighting_command_data *data, float value, float ramp_rate);
 
 BACNET_STACK_EXPORT
 float lighting_command_ramp_rate_clamp(float ramp_rate);

--- a/test/bacnet/basic/sys/lighting_command/src/main.c
+++ b/test/bacnet/basic/sys/lighting_command/src/main.c
@@ -469,22 +469,65 @@ static void test_lighting_command_unit(void)
     lighting_command_timer(&data, milliseconds);
     zassert_true(is_float_equal(Tracking_Value, target_level), NULL);
     zassert_true(data.In_Progress == BACNET_LIGHTING_IDLE, NULL);
-    /* momentary override - self clearing flags */
+    /* momentary override - Overridden and Overridden_Momentary are both set;
+       the next lighting command self-clears Overridden because
+       Overridden_Momentary is still set (tracking_value_event no longer
+       clears it) */
     override_level = 42.0f;
     target_level = 100.0f;
     milliseconds = 10;
     lighting_command_override_momentary(&data, override_level);
+    zassert_true(data.Overridden, NULL);
+    zassert_true(data.Overridden_Momentary, NULL);
     lighting_command_timer(&data, milliseconds);
     zassert_true(is_float_equal(Tracking_Value, override_level), NULL);
     zassert_true(data.In_Progress == BACNET_LIGHTING_IDLE, NULL);
-    zassert_false(data.Overridden, NULL);
+    zassert_true(data.Overridden, NULL);
     zassert_true(data.Overridden_Momentary, NULL);
+    /* fade_to sees Overridden_Momentary, self-clears Overridden, then runs */
     lighting_command_fade_to(&data, target_level, 0);
+    zassert_false(data.Overridden, NULL);
     lighting_command_timer(&data, milliseconds);
     zassert_true(is_float_equal(Tracking_Value, target_level), NULL);
     zassert_true(data.In_Progress == BACNET_LIGHTING_IDLE, NULL);
     zassert_false(data.Overridden, NULL);
+    zassert_true(data.Overridden_Momentary, NULL);
+
+    /* override_ramp - overrides and ramps to target; the timer is not
+       blocked by Overridden, so the ramp operates normally */
+    target_level = 0.0f;
+    override_level = data.Max_Actual_Value;
+    ramp_rate = 100.0f;
+    milliseconds = 1000;
+    lighting_command_fade_to(&data, target_level, 0);
+    lighting_command_timer(&data, milliseconds);
+    zassert_true(is_float_equal(Tracking_Value, target_level), NULL);
+    zassert_true(data.In_Progress == BACNET_LIGHTING_IDLE, NULL);
+    lighting_event_clear();
+    lighting_command_override_ramp(&data, override_level, ramp_rate);
+    zassert_true(data.Overridden, NULL);
     zassert_false(data.Overridden_Momentary, NULL);
+    zassert_equal(data.Lighting_Operation, BACNET_LIGHTS_RAMP_TO, NULL);
+    lighting_event_assert(
+        &data, BACNET_LIGHTS_RAMP_TO, override_level,
+        lighting_command_ramp_rate_clamp(ramp_rate));
+    /* timer advances the ramp even though Overridden is set */
+    do {
+        lighting_command_timer(&data, milliseconds);
+    } while (data.Lighting_Operation == BACNET_LIGHTS_RAMP_TO);
+    zassert_true(is_float_equal(Tracking_Value, override_level), NULL);
+    zassert_true(data.In_Progress == BACNET_LIGHTING_IDLE, NULL);
+    zassert_true(data.Overridden, NULL);
+    /* regular ramp commands are blocked while Overridden */
+    lighting_command_ramp_to(&data, data.Max_Actual_Value, ramp_rate);
+    lighting_command_timer(&data, milliseconds);
+    zassert_true(is_float_equal(Tracking_Value, override_level), NULL);
+    /* clear the override */
+    lighting_command_override_clear(&data, 0.0f);
+    zassert_false(data.Overridden, NULL);
+    lighting_command_timer(&data, milliseconds);
+    zassert_true(is_float_equal(Tracking_Value, 0.0f), NULL);
+    zassert_true(data.In_Progress == BACNET_LIGHTING_IDLE, NULL);
 
     /* step clamping */
     target_step = lighting_command_step_increment_clamp(0.0f);
@@ -894,6 +937,7 @@ static void test_lighting_command_unit(void)
     lighting_command_override_set(NULL, override_level);
     lighting_command_override_clear(NULL, override_level);
     lighting_command_override_momentary(NULL, override_level);
+    lighting_command_override_ramp(NULL, override_level, ramp_rate);
     lighting_command_fade_to(NULL, 0.0f, 0);
     lighting_command_ramp_to(NULL, 0.0f, 0.0f);
     lighting_command_step(NULL, BACNET_LIGHTS_STEP_OFF, 0.0f);

--- a/test/bacnet/basic/sys/lighting_command/src/main.c
+++ b/test/bacnet/basic/sys/lighting_command/src/main.c
@@ -470,9 +470,8 @@ static void test_lighting_command_unit(void)
     zassert_true(is_float_equal(Tracking_Value, target_level), NULL);
     zassert_true(data.In_Progress == BACNET_LIGHTING_IDLE, NULL);
     /* momentary override - Overridden and Overridden_Momentary are both set;
-       the next lighting command self-clears Overridden because
-       Overridden_Momentary is still set (tracking_value_event no longer
-       clears it) */
+       the next lighting command self-clears both Overridden and
+       Overridden_Momentary, then runs normally */
     override_level = 42.0f;
     target_level = 100.0f;
     milliseconds = 10;
@@ -484,14 +483,16 @@ static void test_lighting_command_unit(void)
     zassert_true(data.In_Progress == BACNET_LIGHTING_IDLE, NULL);
     zassert_true(data.Overridden, NULL);
     zassert_true(data.Overridden_Momentary, NULL);
-    /* fade_to sees Overridden_Momentary, self-clears Overridden, then runs */
+    /* fade_to sees Overridden_Momentary, clears both Overridden flags, then
+     * runs */
     lighting_command_fade_to(&data, target_level, 0);
     zassert_false(data.Overridden, NULL);
+    zassert_false(data.Overridden_Momentary, NULL);
     lighting_command_timer(&data, milliseconds);
     zassert_true(is_float_equal(Tracking_Value, target_level), NULL);
     zassert_true(data.In_Progress == BACNET_LIGHTING_IDLE, NULL);
     zassert_false(data.Overridden, NULL);
-    zassert_true(data.Overridden_Momentary, NULL);
+    zassert_false(data.Overridden_Momentary, NULL);
 
     /* override_ramp - overrides and ramps to target; the timer is not
        blocked by Overridden, so the ramp operates normally */


### PR DESCRIPTION
Add a lighting command override ramp function. 
Prevent any lighting commands from meddling with tracking values and lighting operations while the light is overridden.