### PR TITLE
bsc: reject short proprietary option headers in BVLC-SC decode

### DIFF
--- a/src/bacnet/datalink/bsc/bvlc-sc.c
+++ b/src/bacnet/datalink/bsc/bvlc-sc.c
@@ -23,6 +23,8 @@ static const char *s_invalid_header_2 =
     "'Secure Path' header option must not have header data";
 static const char *s_invalid_header_3 =
     "'Proprietary Header' option must have header data";
+static const char *s_invalid_header_4 =
+    "'Proprietary Header' option header data length must be at least 3";
 static const char *s_result_incomplete =
     "BVLC-Result message has incomplete payload";
 static const char *s_result_incorrect_bvlc_function =
@@ -187,6 +189,12 @@ static bool bvlc_sc_validate_options_headers(
                 return false;
             }
             memcpy(&hdr_len, &option_headers[options_len], 2);
+            if (hdr_len < 3) {
+                *error_code = ERROR_CODE_HEADER_ENCODING_ERROR;
+                *error_class = ERROR_CLASS_COMMUNICATION;
+                *error_desc_string = s_invalid_header_4;
+                return false;
+            }
             options_len +=
                 2 /* header length */ + hdr_len /* length of data header */;
         }
@@ -592,9 +600,14 @@ static void bvlc_sc_decode_proprietary_option(
 
     *out_proprietary_data = NULL;
     *out_proprietary_data_len = 0;
+    *out_vendor_id = 0;
+    *out_proprietary_option_type = 0;
     memcpy(&hdr_len, &in_options_list[1], sizeof(hdr_len));
-    memcpy(out_vendor_id, &in_options_list[3], sizeof(uint16_t));
-    *out_proprietary_option_type = in_options_list[5];
+
+    if (hdr_len >= 3) {
+        memcpy(out_vendor_id, &in_options_list[3], sizeof(uint16_t));
+        *out_proprietary_option_type = in_options_list[5];
+    }
 
     if (hdr_len > 3) {
         *out_proprietary_data = &in_options_list[6];

--- a/test/bacnet/datalink/bvlc-sc/src/main.c
+++ b/test/bacnet/datalink/bvlc-sc/src/main.c
@@ -4216,6 +4216,30 @@ static void test_BAD_HEADER_OPTIONS(void)
     len = bvlc_sc_add_option_to_data_options(
         buf, sizeof(buf), buf, 4, optbuf, optlen);
     zassert_equal(len, 0, NULL);
+
+    /* proprietary option with invalid hdr_len < 3 */
+    memset(buf, 0, sizeof(buf));
+    memset(&message, 0, sizeof(message));
+    npdu[0] = 0x01;
+    len = bvlc_sc_encode_encapsulated_npdu(
+        buf, sizeof(buf), message_id, NULL, NULL, npdu, 1);
+    zassert_not_equal(len, 0, NULL);
+
+    /* insert malformed data option before payload */
+    memmove(&buf[9], &buf[4], 1);
+    buf[1] |= BVLC_SC_CONTROL_DATA_OPTIONS;
+    buf[4] = BVLC_SC_OPTION_TYPE_PROPRIETARY | BVLC_SC_HEADER_DATA;
+    npdulen = 2;
+    memcpy(&buf[5], &npdulen, sizeof(npdulen));
+    buf[7] = 0x34;
+    buf[8] = 0x12;
+    len += 5;
+
+    ret = bvlc_sc_decode_message(
+        buf, len, &message, &error_code, &error_class, &err_desc);
+    zassert_equal(ret, false, NULL);
+    zassert_equal(error_code, ERROR_CODE_HEADER_ENCODING_ERROR, NULL);
+    zassert_equal(error_class, ERROR_CLASS_COMMUNICATION, NULL);
 }
 
 #if defined(CONFIG_ZTEST_NEW_API)


### PR DESCRIPTION
## Summary
- fix BACnet/SC proprietary header option validation to reject `hdr_len < 3`
- guard proprietary decode fixed-offset reads (`[3]`, `[4]`, `[5]`) behind `hdr_len >= 3`
- add regression test for malformed proprietary option (`hdr_len = 2`)

## Security impact
A remote BACnet/SC peer could trigger heap out-of-bounds reads in proprietary header option decode before auth. This change blocks malformed options earlier and avoids unsafe fixed-offset reads.

## Changes
- `src/bacnet/datalink/bsc/bvlc-sc.c`
  - add validation failure for proprietary option header data length smaller than vendor-id + option-type (3 bytes)
  - decode function initializes outputs and only reads vendor-id / option-type when `hdr_len >= 3`
- `test/bacnet/datalink/bvlc-sc/src/main.c`
  - add malformed packet case in `test_BAD_HEADER_OPTIONS` to verify decode rejects proprietary options with `hdr_len < 3`

## Validation
- targeted BVLC-SC unit tests:
  - `cmake -S test/bacnet/datalink/bvlc-sc -B test/build-bsc-bvlc`
  - `cmake --build test/build-bsc-bvlc`
  - `./test/build-bsc-bvlc/test_bvlc-sc`
  - result: pass
- pre-commit on changed files:
  - `pre-commit run --files src/bacnet/datalink/bsc/bvlc-sc.c test/bacnet/datalink/bvlc-sc/src/main.c`
  - result: pass