### PR TITLE
fix: accept empty GetAlarmSummary request

### DIFF
--- a/src/bacnet/basic/service/h_get_alarm_sum.c
+++ b/src/bacnet/basic/service/h_get_alarm_sum.c
@@ -59,14 +59,7 @@ void handler_get_alarm_summary(
     npdu_encode_npdu_data(&npdu_data, false, service_data->priority);
     pdu_len = npdu_encode_pdu(
         &Handler_Transmit_Buffer[0], src, &my_address, &npdu_data);
-    if (service_len == 0) {
-        apdu_len = reject_encode_apdu(
-            &Handler_Transmit_Buffer[pdu_len], service_data->invoke_id,
-            REJECT_REASON_MISSING_REQUIRED_PARAMETER);
-        debug_print("GetAlarmSummary: Missing Required Parameter. "
-                    "Sending Reject!\n");
-        goto GET_ALARM_SUMMARY_ABORT;
-    } else if (service_data->segmented_message) {
+    if (service_data->segmented_message) {
         /* we don't support segmentation - send an abort */
         apdu_len = abort_encode_apdu(
             &Handler_Transmit_Buffer[pdu_len], service_data->invoke_id,


### PR DESCRIPTION
This PR fixes the `GetAlarmSummary` handler so that it accepts a valid empty request instead of incorrectly rejecting it as missing required parameters.

According to BACnet service semantics, `GetAlarmSummary` is a confirmed service whose request carries no service parameters; only the ACK contains the returned alarm summary data. The current implementation is already consistent with this on the client/encoding side, since `get_alarm_summary_encode_apdu()` only emits the confirmed-service APDU header and does not append any request payload. However, on the server/handler side, `handler_get_alarm_summary()` previously treated `service_len == 0` as `REJECT_REASON_MISSING_REQUIRED_PARAMETER`, which means a standards-compliant empty request would always be rejected even though no parameters are actually defined for this service.

This change removes that incorrect empty-request rejection path from `handler_get_alarm_summary()`. After the change, an empty `GetAlarmSummary` request is processed normally, while the existing segmented-message rejection behavior remains unchanged.