### PR TITLE
fix: advance Recipient_List decode cursor for list elements

### DIFF
--- a/src/bacnet/basic/object/nc.c
+++ b/src/bacnet/basic/object/nc.c
@@ -927,6 +927,7 @@ int Notification_Class_Add_List_Element(BACNET_LIST_ELEMENT_DATA *list_element)
             &recipient_list[new_element_count]);
         if (len > 0) {
             new_element_count++;
+            application_data += len;
             application_data_len -= len;
             if (new_element_count >= NC_MAX_RECIPIENTS) {
                 list_element->first_failed_element_number = new_element_count;
@@ -1097,6 +1098,7 @@ int Notification_Class_Remove_List_Element(
             &recipient_list[remove_element_count]);
         if (len > 0) {
             remove_element_count++;
+            application_data += len;
             application_data_len -= len;
             if (remove_element_count >= NC_MAX_RECIPIENTS) {
                 list_element->first_failed_element_number =


### PR DESCRIPTION
This PR fixes multi-element `AddListElement` and `RemoveListElement` handling for `Notification Class.Recipient_List`.

According to the BACnet list-element service procedure, when a request carries multiple list elements, the server should decode and process them sequentially in order. In the current implementation, the `Notification_Class_Add_List_Element()` and `Notification_Class_Remove_List_Element()` loops decode one `BACNET_DESTINATION` at a time from `application_data`, but after a successful decode they only subtract `len` from `application_data_len` and never advance the `application_data` pointer itself. As a result, each iteration re-decodes the first element instead of moving to the next one, so later elements in the request are never actually processed. This can lead to incorrect outcomes such as false "list full", false "element not found", or incorrect `first_failed_element_number` reporting.

This change updates both decode loops in `src/bacnet/basic/object/nc.c` to advance the input pointer (`application_data += len`) after each successfully decoded recipient entry. With that fix, multi-element add/remove requests are decoded in sequence as intended, and each element participates in the operation exactly once.