### PR TITLE
fix: reject Max_Master below local MSTP address

### DIFF
--- a/src/bacnet/basic/object/device.c
+++ b/src/bacnet/basic/object/device.c
@@ -3648,7 +3648,14 @@ bool Device_Write_Property_Local(BACNET_WRITE_PROPERTY_DATA *wp_data)
             if (status) {
                 if ((value.type.Unsigned_Int > 0) &&
                     (value.type.Unsigned_Int <= 127)) {
-                    dlmstp_set_max_master((uint8_t)value.type.Unsigned_Int);
+                    if ((dlmstp_mac_address() <= 127) &&
+                        (value.type.Unsigned_Int < dlmstp_mac_address())) {
+                        status = false;
+                        wp_data->error_class = ERROR_CLASS_PROPERTY;
+                        wp_data->error_code = ERROR_CODE_VALUE_OUT_OF_RANGE;
+                    } else {
+                        dlmstp_set_max_master((uint8_t)value.type.Unsigned_Int);
+                    }
                 } else {
                     status = false;
                     wp_data->error_class = ERROR_CLASS_PROPERTY;

--- a/src/bacnet/basic/object/netport.c
+++ b/src/bacnet/basic/object/netport.c
@@ -1446,11 +1446,14 @@ bool Network_Port_MSTP_Max_Master_Set(uint32_t object_instance, uint8_t value)
 {
     bool status = false;
     unsigned index = 0;
+    uint8_t mac_address = 0;
 
     index = Network_Port_Instance_To_Index(object_instance);
     if (index < BACNET_NETWORK_PORTS_MAX) {
         if (Object_List[index].Network_Type == PORT_TYPE_MSTP) {
-            if (value <= 127) {
+            mac_address = Object_List[index].Network.MSTP.MAC_Address;
+            if ((value <= 127) &&
+                ((mac_address > 127) || (mac_address <= value))) {
                 if (Object_List[index].Network.MSTP.Max_Master != value) {
                     Object_List[index].Changes_Pending = true;
                 }

--- a/src/bacnet/basic/server/bacnet_device.c
+++ b/src/bacnet/basic/server/bacnet_device.c
@@ -3336,7 +3336,14 @@ bool Device_Write_Property_Local(BACNET_WRITE_PROPERTY_DATA *wp_data)
             if (status) {
                 if ((value.type.Unsigned_Int > 0) &&
                     (value.type.Unsigned_Int <= 127)) {
-                    dlmstp_set_max_master((uint8_t)value.type.Unsigned_Int);
+                    if ((dlmstp_mac_address() <= 127) &&
+                        (value.type.Unsigned_Int < dlmstp_mac_address())) {
+                        status = false;
+                        wp_data->error_class = ERROR_CLASS_PROPERTY;
+                        wp_data->error_code = ERROR_CODE_VALUE_OUT_OF_RANGE;
+                    } else {
+                        dlmstp_set_max_master((uint8_t)value.type.Unsigned_Int);
+                    }
                 } else {
                     status = false;
                     wp_data->error_class = ERROR_CLASS_PROPERTY;

--- a/src/bacnet/datalink/dlmstp.c
+++ b/src/bacnet/datalink/dlmstp.c
@@ -484,7 +484,9 @@ uint8_t dlmstp_max_info_frames(void)
  */
 void dlmstp_set_max_master(uint8_t max_master)
 {
-    if (max_master <= 127) {
+    if (MSTP_Port && (max_master <= 127) &&
+        ((MSTP_Port->This_Station > 127) ||
+            (MSTP_Port->This_Station <= max_master))) {
         MSTP_Port->Nmax_master = max_master;
     }
 


### PR DESCRIPTION
This PR fixes `Max_Master` validation so that MS/TP configurations can no longer be written into an invalid state where `Max_Master` is smaller than the local station address.

For an MS/TP master node, `Max_Master` defines the highest allowable master address on the link, so it must remain consistent with the local node address. In the previous implementation, the `WriteProperty` paths for `PROP_MAX_MASTER` only checked that the value was within the numeric range and then passed it to `dlmstp_set_max_master()`. The generic `dlmstp_set_max_master()` implementation also only checked `max_master <= 127`, without preserving the required invariant that the local station address must not be greater than `Nmax_master`. Once `This_Station > Nmax_master` is allowed, later MS/TP state-machine logic uses `This_Station`, `Next_Station`, and `Poll_Station` in modulo operations based on `Nmax_master + 1`, which breaks the intended token-passing and polling semantics. The repository already contains port-specific implementations that reject this condition, which confirms that the generic path was missing necessary validation.

This change adds explicit rejection of `Max_Master` values below the local MS/TP MAC address in the `Device` and basic server `WriteProperty` handlers, applies the same constraint to the MSTP `Network Port` setter, and also adds a defensive guard in the generic `dlmstp_set_max_master()` implementation so the datalink layer will not accept a value that violates the `This_Station <= Nmax_master` invariant.