### PR TITLE
fix: advance device object property value codec cursor

### DIFF
--- a/src/bacnet/bacapp.c
+++ b/src/bacnet/bacapp.c
@@ -6162,6 +6162,9 @@ int bacapp_device_object_property_value_encode(
     if (value->property_array_index != BACNET_ARRAY_ALL) {
         len = encode_context_unsigned(apdu, 3, value->property_array_index);
         apdu_len += len;
+        if (apdu) {
+            apdu += len;
+        }
     }
     len = encode_opening_tag(apdu, 4);
     apdu_len += len;
@@ -6263,7 +6266,8 @@ int bacapp_device_object_property_value_decode(
             value->property_array_index = BACNET_ARRAY_ALL;
         }
     }
-    if (bacnet_is_opening_tag_number(apdu, apdu_size, 4, &len)) {
+    if (bacnet_is_opening_tag_number(
+            &apdu[apdu_len], apdu_size - apdu_len, 4, &len)) {
         /* property-value [4] ABSTRACT-SYNTAX.&Type */
         apdu_len += len;
         if (value) {
@@ -6276,11 +6280,14 @@ int bacapp_device_object_property_value_decode(
         } else {
             return BACNET_STATUS_ERROR;
         }
-        if (bacnet_is_closing_tag_number(apdu, apdu_size, 4, &len)) {
+        if (bacnet_is_closing_tag_number(
+                &apdu[apdu_len], apdu_size - apdu_len, 4, &len)) {
             apdu_len += len;
         } else {
             return BACNET_STATUS_ERROR;
         }
+    } else {
+        return BACNET_STATUS_ERROR;
     }
 
     return apdu_len;


### PR DESCRIPTION
### Summary

This PR fixes cursor handling in the `BACnetDeviceObjectPropertyValue` encoder and decoder so the optional `property-array-index` and required `property-value` fields are processed in the correct sequence.

### The Bug 

According to the BACnet specification, `BACnetDeviceObjectPropertyValue` is encoded and decoded in order as `device-identifier [0]`, `object-identifier [1]`, `property-identifier [2]`, optional `property-array-index [3]`, and required `property-value [4]`. In the previous implementation, the encoder wrote `property-array-index [3]` but did not advance the output pointer before writing `property-value [4]`, which could corrupt the encoded layout when the optional array index was present. The decoder had a related cursor bug: after consuming the preceding fields, it checked the opening and closing tags for `property-value [4]` from the beginning of the buffer instead of from the current parse offset. As a result, valid payloads could be misparsed and malformed payloads missing the required `property-value [4]` field could be accepted instead of rejected.

### Changes

This change advances the output pointer after encoding the optional `property-array-index [3]`, changes the decoder to validate the `property-value [4]` opening and closing tags at the current cursor position, and returns `BACNET_STATUS_ERROR` when the required `property-value [4]` field is not present.