### PR TITLE
fix: use GetEventInformation service choice in error reply

### DIFF
--- a/src/bacnet/basic/service/h_getevent.c
+++ b/src/bacnet/basic/service/h_getevent.c
@@ -219,7 +219,8 @@ GET_EVENT_ERROR:
         } else {
             len = bacerror_encode_apdu(
                 &Handler_Transmit_Buffer[pdu_len], service_data->invoke_id,
-                SERVICE_CONFIRMED_READ_PROPERTY, error_class, error_code);
+                SERVICE_CONFIRMED_GET_EVENT_INFORMATION, error_class,
+                error_code);
             debug_print("GetEventInformation: Sending Error!\n");
         }
     }


### PR DESCRIPTION
### Summary

This PR fixes the `GetEventInformation` error path so that Error APDUs preserve the correct original confirmed service choice.

### Bug

According to the BACnet specification, when a confirmed service returns an Error APDU, the `original-service-choice` field should identify the service that actually failed. In the previous implementation, the error path in `handler_get_event_information()` encoded the response with `SERVICE_CONFIRMED_READ_PROPERTY` instead of `SERVICE_CONFIRMED_GET_EVENT_INFORMATION`. As a result, a client receiving that Error APDU could misclassify the failure as a `ReadProperty` error and dispatch it to the wrong service handler.

### Changes

This change updates the `bacerror_encode_apdu()` call in `handler_get_event_information()` so that the Error APDU now uses `SERVICE_CONFIRMED_GET_EVENT_INFORMATION` as the original confirmed service choice.