### PR TITLE
fix: mark AV COV change on out-of-service writes

### DIFF
--- a/src/bacnet/basic/object/av.c
+++ b/src/bacnet/basic/object/av.c
@@ -993,7 +993,8 @@ bool Analog_Value_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
             status = write_property_type_valid(
                 wp_data, &value, BACNET_APPLICATION_TAG_BOOLEAN);
             if (status) {
-                CurrentAV->Out_Of_Service = value.type.Boolean;
+                Analog_Value_Out_Of_Service_Set(
+                    wp_data->object_instance, value.type.Boolean);
             }
             break;
         case PROP_UNITS:


### PR DESCRIPTION
### Summary

This PR fixes `Analog Value` `Out_Of_Service` writes so they correctly set the COV change flag.

### The Bug

According to the BACnet specification, a change that affects the COV value list should be reflected in subsequent COV processing and notifications. In the previous implementation, the `PROP_OUT_OF_SERVICE` branch in `Analog_Value_Write_Property()` wrote `CurrentAV->Out_Of_Service` directly instead of using `Analog_Value_Out_Of_Service_Set()`. Because the setter is responsible for marking the object as changed when the value actually changes, remote `WriteProperty` requests could update `Out_Of_Service` without setting the `Changed` flag. As a result, subscribers could miss the corresponding COV update.

### Changes

This change updates the `PROP_OUT_OF_SERVICE` handling in `Analog_Value_Write_Property()` to call `Analog_Value_Out_Of_Service_Set()` instead of writing the field directly, so `Changed` is set consistently when the property value changes.