### PR TITLE
platform.h: move and sanitize min and max helpers

### DIFF
--- a/apps/mstpcrc/main.c
+++ b/apps/mstpcrc/main.c
@@ -23,11 +23,6 @@
 /* OS specific include*/
 #include "bacport.h"
 
-#ifndef max
-#define max(a, b) (((a)(b)) ? (a) : (b))
-#define min(a, b) (((a) < (b)) ? (a) : (b))
-#endif
-
 /* buffer needed by CRC functions */
 static uint8_t CRC_Buffer[1512];
 static unsigned CRC_Buffer_Len = 0;

--- a/ports/linux/mstpsnap.c
+++ b/ports/linux/mstpsnap.c
@@ -14,8 +14,9 @@
 #/* BACnet Stack defines - first */
 #include "bacnet/bacdef.h"
 /* BACnet Stack API */
-#include "bacnet/basic/sys/mstimer.h"
 #include "bacnet/basic/sys/bytes.h"
+#include "bacnet/basic/sys/compare.h"
+#include "bacnet/basic/sys/mstimer.h"
 #include "bacnet/datalink/crc.h"
 #include "bacnet/datalink/mstp.h"
 #include "bacnet/datalink/dlmstp.h"
@@ -28,11 +29,6 @@
 
 /** @file linux/mstpsnap.c  Example application testing BACnet MS/TP on Linux.
  */
-
-#ifndef max
-#define max(a, b) (((a)(b)) ? (a) : (b))
-#define min(a, b) (((a) < (b)) ? (a) : (b))
-#endif
 
 /* local port data - shared with RS-485 */
 static struct mstp_port_struct_t MSTP_Port;
@@ -177,7 +173,8 @@ snap_received_packet(const struct mstp_port_struct_t *mstp_port, int sockfd)
     mtu[30] = mstp_port->HeaderCRCActual;
     mtu_len = 31;
     if (mstp_port->DataLength) {
-        max_data = min(mstp_port->InputBufferSize, mstp_port->DataLength);
+        max_data =
+            BACNET_MIN(mstp_port->InputBufferSize, mstp_port->DataLength);
         for (i = 0; i < max_data; i++) {
             mtu[31 + i] = mstp_port->InputBuffer[i];
         }

--- a/ports/win32/dlmstp-mm.c
+++ b/ports/win32/dlmstp-mm.c
@@ -19,6 +19,7 @@
 #include "bacnet/datalink/mstp.h"
 #include "bacnet/datalink/dlmstp.h"
 #include "bacnet/npdu.h"
+#include "bacnet/basic/sys/compare.h"
 /* port specific */
 #include "rs485.h"
 
@@ -533,7 +534,8 @@ bool dlmstp_init(const char *ifname)
     if (timeGetDevCaps(&tc, sizeof(TIMECAPS)) != TIMERR_NOERROR) {
         fprintf(stderr, "Failed to set timer resolution\n");
     }
-    TimeBeginPeriod = min(max(tc.wPeriodMin, TARGET_RESOLUTION), tc.wPeriodMax);
+    TimeBeginPeriod =
+        BACNET_CLAMP(tc.wPeriodMin, TARGET_RESOLUTION, tc.wPeriodMax);
     timeBeginPeriod(TimeBeginPeriod);
 
     /* start the threads */

--- a/ports/win32/mstimer-init.c
+++ b/ports/win32/mstimer-init.c
@@ -13,6 +13,7 @@
 #include <limits.h>
 #include <time.h>
 #include "bacport.h"
+#include "bacnet/basic/sys/compare.h"
 #include "bacnet/basic/sys/mstimer.h"
 
 /* Windows timer period - in milliseconds */
@@ -47,7 +48,7 @@ void mstimer_init(void)
         fprintf(stderr, "Failed to get timer resolution parameters\n");
     }
     /* configure for 1ms resolution - if possible */
-    Timer_Period = min(max(tc.wPeriodMin, 1L), tc.wPeriodMax);
+    Timer_Period = BACNET_CLAMP(tc.wPeriodMin, 1L, tc.wPeriodMax);
     if (Timer_Period != 1L) {
         fprintf(
             stderr,

--- a/src/bacnet/bacaddr.c
+++ b/src/bacnet/bacaddr.c
@@ -16,6 +16,7 @@
 #include "bacnet/bacdcode.h"
 #include "bacnet/bacint.h"
 #include "bacnet/bactext.h"
+#include "bacnet/basic/sys/compare.h"
 #include "bacnet/bacaddr.h"
 
 /**
@@ -542,11 +543,12 @@ int encode_bacnet_address(uint8_t *apdu, const BACNET_ADDRESS *destination)
         }
         /* encode mac address as an octet-string */
         if (destination->len > 0) {
-            adr_len = min(destination->len, sizeof(destination->adr));
+            adr_len = BACNET_MIN(destination->len, sizeof(destination->adr));
             len = encode_application_octet_string_buffer(
                 apdu, destination->adr, adr_len);
         } else {
-            mac_len = min(destination->mac_len, sizeof(destination->mac));
+            mac_len =
+                BACNET_MIN(destination->mac_len, sizeof(destination->mac));
             len = encode_application_octet_string_buffer(
                 apdu, destination->mac, mac_len);
         }

--- a/src/bacnet/bacstr.c
+++ b/src/bacnet/bacstr.c
@@ -20,6 +20,7 @@
 /* BACnet Stack defines - first */
 #include "bacnet/bacdef.h"
 /* BACnet Stack API */
+#include "bacnet/basic/sys/compare.h"
 #include "bacnet/bacstr.h"
 
 #ifndef BACNET_USE_OCTETSTRING /* Do we need any octet strings? */
@@ -246,7 +247,7 @@ bool bitstring_set_bits_used(
 unsigned bitstring_bits_capacity(const BACNET_BIT_STRING *bit_string)
 {
     if (bit_string) {
-        return min((MAX_BITSTRING_BYTES * 8), (UINT8_MAX + 1));
+        return BACNET_MIN((MAX_BITSTRING_BYTES * 8), (UINT8_MAX + 1));
     } else {
         return 0;
     }

--- a/src/bacnet/basic/object/bacfile.c
+++ b/src/bacnet/basic/object/bacfile.c
@@ -26,6 +26,7 @@
 #include "bacnet/basic/binding/address.h"
 #include "bacnet/basic/object/bacfile.h"
 #include "bacnet/basic/services.h"
+#include "bacnet/basic/sys/compare.h"
 #include "bacnet/basic/sys/keylist.h"
 #include "bacnet/basic/tsm/tsm.h"
 /* BACnet Stack Objects */
@@ -1098,7 +1099,7 @@ bool bacfile_read_record_data(BACNET_ATOMIC_READ_FILE_DATA *data)
         return false;
     }
     max_records =
-        min(data->type.record.RecordCount, ARRAY_SIZE(data->fileData));
+        BACNET_MIN(data->type.record.RecordCount, ARRAY_SIZE(data->fileData));
     pathname = bacfile_pathname(data->object_instance);
     if (pathname) {
         found = true;
@@ -1192,8 +1193,8 @@ bool bacfile_write_record_data(const BACNET_ATOMIC_WRITE_FILE_DATA *data)
         /* if the file is read-only, then we cannot write to it */
         return false;
     }
-    max_records =
-        min(data->type.record.returnedRecordCount, ARRAY_SIZE(data->fileData));
+    max_records = BACNET_MIN(
+        data->type.record.returnedRecordCount, ARRAY_SIZE(data->fileData));
     pathname = bacfile_pathname(data->object_instance);
     if (pathname) {
         found = true;

--- a/src/bacnet/basic/object/gateway/gw_device.c
+++ b/src/bacnet/basic/object/gateway/gw_device.c
@@ -39,8 +39,9 @@
 #include "bacnet/basic/object/trendlog.h"
 #include "bacnet/basic/object/bacfile.h"
 /* os specific includes */
-#include "bacnet/basic/sys/mstimer.h"
+#include "bacnet/basic/sys/compare.h"
 #include "bacnet/basic/sys/debug.h"
+#include "bacnet/basic/sys/mstimer.h"
 
 /* forward prototypes */
 int Routed_Device_Read_Property_Local(BACNET_READ_PROPERTY_DATA *rpdata);
@@ -187,7 +188,8 @@ DEVICE_OBJECT_DATA *Get_Routed_Device_Object(int idx)
     if (idx == -1) {
         return &Devices[iCurrent_Device_Idx];
     } else if (
-        (idx >= 0) && (idx < min(MAX_NUM_DEVICES, Num_Managed_Devices))) {
+        (idx >= 0) &&
+        (idx < BACNET_MIN(MAX_NUM_DEVICES, Num_Managed_Devices))) {
         iCurrent_Device_Idx = idx;
         return &Devices[idx];
     } else {
@@ -209,7 +211,8 @@ BACNET_ADDRESS *Get_Routed_Device_Address(int idx)
     if (idx == -1) {
         return &Devices[iCurrent_Device_Idx].bacDevAddr;
     } else if (
-        (idx >= 0) && (idx < min(MAX_NUM_DEVICES, Num_Managed_Devices))) {
+        (idx >= 0) &&
+        (idx < BACNET_MIN(MAX_NUM_DEVICES, Num_Managed_Devices))) {
         iCurrent_Device_Idx = idx;
         return &Devices[idx].bacDevAddr;
     } else {
@@ -256,7 +259,8 @@ bool Routed_Device_Address_Lookup(int idx, uint8_t dlen, const uint8_t *dadr)
     DEVICE_OBJECT_DATA *pDev;
     int i;
 
-    if ((idx >= 0) && (idx < min(MAX_NUM_DEVICES, Num_Managed_Devices))) {
+    if ((idx >= 0) &&
+        (idx < BACNET_MIN(MAX_NUM_DEVICES, Num_Managed_Devices))) {
         pDev = &Devices[idx];
         if (dlen == 0) {
             /* Automatic match */
@@ -310,7 +314,8 @@ bool Routed_Device_GetNext(
     int idx = *cursor;
     bool bSuccess = false;
 
-    if ((idx < 0) || (idx >= min(MAX_NUM_DEVICES, Num_Managed_Devices))) {
+    if ((idx < 0) ||
+        (idx >= BACNET_MIN(MAX_NUM_DEVICES, Num_Managed_Devices))) {
         /* The next index will be out of range.
            Eg, last call to GetNext may have been the last successful one.*/
         idx = -1;
@@ -336,7 +341,7 @@ bool Routed_Device_GetNext(
             /* Step over this case (starting point) */
             idx = 1;
         }
-        while (idx < min(MAX_NUM_DEVICES, Num_Managed_Devices)) {
+        while (idx < BACNET_MIN(MAX_NUM_DEVICES, Num_Managed_Devices)) {
             bSuccess =
                 Routed_Device_Address_Lookup(idx++, dest->len, dest->adr);
             if (bSuccess) {
@@ -347,7 +352,7 @@ bool Routed_Device_GetNext(
     }
     if (!bSuccess) {
         *cursor = -1;
-    } else if (idx == min(MAX_NUM_DEVICES, Num_Managed_Devices)) {
+    } else if (idx == BACNET_MIN(MAX_NUM_DEVICES, Num_Managed_Devices)) {
         /* No more to GetNext */
         *cursor = -1;
     } else {
@@ -408,7 +413,7 @@ static uint32_t Routed_Device_Instance_To_Index(uint32_t Instance_Number)
 {
     int i;
 
-    for (i = 0; i < min(MAX_NUM_DEVICES, Num_Managed_Devices); i++) {
+    for (i = 0; i < BACNET_MIN(MAX_NUM_DEVICES, Num_Managed_Devices); i++) {
         if (Devices[i].bacObj.Object_Instance_Number == Instance_Number) {
             /* Found Instance, so return the Device Index Number */
             return i;

--- a/src/bacnet/basic/object/schedule.c
+++ b/src/bacnet/basic/object/schedule.c
@@ -15,6 +15,7 @@
 #include "bacnet/proplist.h"
 #include "bacnet/timestamp.h"
 #include "bacnet/basic/services.h"
+#include "bacnet/basic/sys/compare.h"
 #include "bacnet/basic/sys/debug.h"
 #include "bacnet/basic/object/device.h" /* me */
 #include "bacnet/basic/object/schedule.h"
@@ -655,7 +656,7 @@ int Schedule_Read_Property(BACNET_READ_PROPERTY_DATA *rpdata)
                 bacapp_encode_data(&apdu[0], &CurrentSC->Schedule_Default);
             break;
         case PROP_LIST_OF_OBJECT_PROPERTY_REFERENCES:
-            imax = min(
+            imax = BACNET_MIN(
                 CurrentSC->obj_prop_ref_cnt, BACNET_SCHEDULE_OBJ_PROP_REF_SIZE);
             for (i = 0; i < imax; i++) {
                 apdu_len += bacapp_encode_device_obj_property_ref(
@@ -729,9 +730,9 @@ static BACNET_ERROR_CODE Schedule_Weekly_Schedule_Element_Write(
             len = bacnet_dailyschedule_context_decode(
                 application_data, application_data_len, 0, &daily_schedule);
             if (len > 0) {
-                tv_size =
-                    min(daily_schedule.TV_Count,
-                        BACNET_DAILY_SCHEDULE_TIME_VALUES_SIZE);
+                tv_size = BACNET_MIN(
+                    daily_schedule.TV_Count,
+                    BACNET_DAILY_SCHEDULE_TIME_VALUES_SIZE);
                 for (tv = 0; tv < tv_size; tv++) {
                     /* copy the time value */
                     memcpy(

--- a/src/bacnet/basic/sys/bramfs.c
+++ b/src/bacnet/basic/sys/bramfs.c
@@ -13,6 +13,7 @@
 #include <string.h>
 /* BACnet Stack defines - first */
 #include "bacnet/bacdef.h"
+#include "bacnet/basic/sys/compare.h"
 #include "bacnet/basic/sys/keylist.h"
 #include "bacnet/basic/object/bacfile.h"
 #include "bacnet/datalink/cobs.h"
@@ -385,7 +386,7 @@ bool bacfile_ramfs_write_record_data(
             return false;
         }
         /* sanitize the incoming record; assume from an octetstring */
-        fileDataStrLen = min(fileDataLen, MAX_OCTET_STRING_BYTES);
+        fileDataStrLen = BACNET_MIN(fileDataLen, MAX_OCTET_STRING_BYTES);
         memcpy(fileDataStr, fileData, fileDataStrLen);
         fileDataStr[fileDataStrLen] = 0; /* null-terminate */
         if (fileDataStrLen == 0) {

--- a/src/bacnet/basic/sys/compare.h
+++ b/src/bacnet/basic/sys/compare.h
@@ -1,0 +1,41 @@
+/**
+ * @file
+ * @brief This file contains some value comparison and bounds helpers
+ * @author Anthony Loiseau <anthony.loiseau@allcircuits.com>
+ * @date 2026
+ * @copyright SPDX-License-Identifier: MIT
+ */
+#ifndef BACNET_SYS_COMPARE_H
+#define BACNET_SYS_COMPARE_H
+
+/**
+ * @brief Return the maximum of two values
+ * @param a First value
+ * @param b Second value
+ * @return a or b, whichever is the bigger one
+ * @attention Arguments can be evaluated more than once
+ */
+#define BACNET_MAX(a, b) (((a) > (b)) ? (a) : (b))
+
+/**
+ * @brief Return the minimum of two values
+ * @param a First value
+ * @param b Second value
+ * @return a or b, whichever is the smaller one
+ * @attention Arguments can be evaluated more than once
+ */
+#define BACNET_MIN(a, b) (((a) < (b)) ? (a) : (b))
+
+/**
+ * @brief Clamp a value to a specified inclusive range
+ * @param min Minimum value for the result
+ * @param value Value to clamp within min and max inclusive
+ * @param max Maximum value for the result
+ * @return min, value or max depending on value
+ * @note Given value is not modified by this call
+ * @attention Arguments can be evaluated more than once
+ */
+#define BACNET_CLAMP(min, value, max) \
+    BACNET_MIN(BACNET_MAX((value), (min)), (max))
+
+#endif /* BACNET_SYS_COMPARE_H */

--- a/src/bacnet/basic/sys/platform.h
+++ b/src/bacnet/basic/sys/platform.h
@@ -84,16 +84,6 @@ __inline int c99_snprintf(char *outBuf, size_t size, const char *format, ...)
 #endif
 #endif
 
-/* some common min/max as defined in windef.h */
-#ifndef NOMINMAX
-#ifndef max
-#define max(a, b) (((a) > (b)) ? (a) : (b))
-#endif
-#ifndef min
-#define min(a, b) (((a) < (b)) ? (a) : (b))
-#endif
-#endif /* NOMINMAX */
-
 #if defined(__MINGW32__)
 #define BACNET_STACK_FALLTHROUGH() /* fall through */
 #elif defined(__GNUC__)

--- a/src/bacnet/hostnport.c
+++ b/src/bacnet/hostnport.c
@@ -13,6 +13,7 @@
 #include <ctype.h>
 #include "bacnet/hostnport.h"
 #include "bacnet/bacdcode.h"
+#include "bacnet/basic/sys/compare.h"
 
 /**
  * @brief Encode the BACnetHostAddress CHOICE
@@ -726,7 +727,7 @@ void host_n_port_minimal_ip_init(
 
     if (host) {
         host->tag = BACNET_HOST_ADDRESS_TAG_IP_ADDRESS;
-        imax = min(address_len, sizeof(host->host.ip_address.address));
+        imax = BACNET_MIN(address_len, sizeof(host->host.ip_address.address));
         host->host.ip_address.length = imax;
         if (address) {
             for (i = 0; i < imax; i++) {
@@ -872,7 +873,8 @@ bool host_n_port_to_minimal(
             dst->tag = BACNET_HOST_ADDRESS_TAG_IP_ADDRESS;
             dst->host.ip_address.length = octetstring_copy_value(
                 dst->host.ip_address.address,
-                min(sizeof(dst->host.ip_address.address),
+                BACNET_MIN(
+                    sizeof(dst->host.ip_address.address),
                     src->host.ip_address.length),
                 &src->host.ip_address);
         } else if (src->host_name) {


### PR DESCRIPTION
# What this PR does

`min` and `max` macros are move out of `platform.h` because `platform.h` is included by stack public API header files, and collides with quite many C++ apps methods.

They are moved to an internal `sys/compare.h` file, not meant to be publicly exposed, included by the few C files needing it.
By the way, I added a clamp macro for en min+max mix and remove the already-defined guards which now appears useless.

A few min/MIN/max/MAX defines still exists within app samples, untouched since in my opinion `sys/compare.h` is not meant to be included by those demo apps and since there is no chance they collide with another app of course.

Finally, new `sys/compare.h` `BACNET_MIN` and `BACNET_MAX` implementations are identical to legacy `platform.h` implementations, that is without non-standard brace and typeof, therefore with args being evaluated more than once. This has been chosen because implementing such non-standard variant implies the need of  keeping this standard-compliant implementation as fallback for some compilers, so arguments evaluation count would not be guaranteed anyway.

# Why

- `min` and `max` small case defines names collides with quite many C++ methods
- min and max helpers should not pollute library users
- Macros should be upper-cased
- BACNET_ prefix is preferred for such macros

This PR implements the fix discussed in #1414