### PR TITLE
Fix typos in comments and docs

### DIFF
--- a/doc/README.faq
+++ b/doc/README.faq
@@ -25,7 +25,7 @@ A-3: Not really. The specific stuff is in the ports/ directory, and that is expe
 
 Q-4: Does the stack have some specific requirements regarding OS? What OS features are used (threads, timers, semaphors, events, mutexes...)?
 
-A-4: No, I did not use any OS features (except for the the ports to specific OS's: ports/win32/, ports/bsd and ports/linux/ which uses some tasks or threads for the MS/TP datalink layer or sockets for the BACnet/IP layers). Since my target was embedded microcontrollers, I kept the architecture single-threaded (but multithread safe except where noted) to keep it easy to follow and easy to implement in a microcontroller just running a main() loop.
+A-4: No, I did not use any OS features (except for the ports to specific OS's: ports/win32/, ports/bsd and ports/linux/ which uses some tasks or threads for the MS/TP datalink layer or sockets for the BACnet/IP layers). Since my target was embedded microcontrollers, I kept the architecture single-threaded (but multithread safe except where noted) to keep it easy to follow and easy to implement in a microcontroller just running a main() loop.
 
 Q-5: What is the difference between the two datalink layers BACnet/IP and BACnet Ethernet? In BACnet/IP, is the MAC address needed?
 
@@ -125,7 +125,7 @@ You can do one of the following:
    3. Write npdu router code to route from BACnet/IP to another datalink layer. Make server application on one datalink layer and make client applications on another datalink layer.
    4. Add external BACnet router or BACnet devices. Run a BACnet apps/server on another PC.
 
-Q-16: My Linux computer doesn't use eth0 for for the BACnet connection. My Windows computer has more than one network connnection. How can I choose the interface to use for the demo applications?
+Q-16: My Linux computer doesn't use eth0 for the BACnet connection. My Windows computer has more than one network connection. How can I choose the interface to use for the demo applications?
 
 A-16: Set the environment variable BACNET_IFACE. For Windows, set BACNET_IFACE=169.254.119.240 or whatever the address of the interface returned by ipconfig command. For Linux, use BACNET_IFACE=eth0 or whatever the name of the interface returned by the ifconfig command. Setting the environment variable under Windows can be done on the command line:
 

--- a/doc/htdocs/index.html
+++ b/doc/htdocs/index.html
@@ -289,7 +289,7 @@
   aptfile</code>
   <h2>BACnet services supported matrix</h2>
   <p>The BACnet stack currently implements the following services
-  listed in the the table. Services are added as needed for a
+  listed in the table. Services are added as needed for a
   variety of implemetations. With the services that are
   implemented, you could build a BACnet device that meets the
   standardized profile for a BACnet Smart Sensor, BACnet Smart

--- a/ports/bdk-atxx4-mstp/mstimer-init.c
+++ b/ports/bdk-atxx4-mstp/mstimer-init.c
@@ -40,7 +40,7 @@
 /* Timer counts up from count to TIMER_TICKS_MAX and then signals overflow */
 #define TIMER2_COUNT (TIMER_TICKS_MAX - TIMER2_TICKS)
 
-/* counter for the the timer which wraps every 49.7 days */
+/* counter for the timer which wraps every 49.7 days */
 static volatile uint32_t Millisecond_Counter;
 
 /*************************************************************************

--- a/ports/bsd/websocket-cli.c
+++ b/ports/bsd/websocket-cli.c
@@ -459,8 +459,8 @@ static void *bws_cli_worker(void *arg)
             DEBUG_PRINTF("bws_cli_worker() process disconnecting event\n");
             DEBUG_PRINTF("bws_cli_worker() destroy ctx %p\n", conn->ctx);
             /* TRICKY: Libwebsockets API is not designed to be used from
-                       multipe service threads, as a result
-               lws_context_destroy() is not thread safe. More over, on different
+                       multiple service threads, as a result
+               lws_context_destroy() is not thread safe. Moreover, on different
                platforms the function behaves in different ways. Call of
                        lws_context_destroy() leads to several calls of
                        bws_cli_websocket_event() callback (LWS_CALLBACK_CLOSED,
@@ -655,8 +655,8 @@ BSC_WEBSOCKET_RET bws_cli_connect(
 
     if (r) {
         /* TRICKY: Libwebsockets API is not designed to be used from
-                   multipe service threads, as a result lws_context_destroy()
-                   is not thread safe. More over, on different platforms the
+                   multiple service threads, as a result lws_context_destroy()
+                   is not thread safe. Moreover, on different platforms the
                    function behaves in different ways. Call of
                    lws_context_destroy() leads to several calls of
                    bws_cli_websocket_event() callback (LWS_CALLBACK_CLOSED,

--- a/ports/bsd/websocket-srv.c
+++ b/ports/bsd/websocket-srv.c
@@ -603,8 +603,8 @@ static void *bws_srv_worker(void *arg)
                 "user_param = %p\n",
                 ctx->wsctx, ctx, ctx->user_param);
             /* TRICKY: Libwebsockets API is not designed to be used from
-                       multipe service threads, as a result
-               lws_context_destroy() is not thread safe. More over, on different
+                       multiple service threads, as a result
+               lws_context_destroy() is not thread safe. Moreover, on different
                platforms the function behaves in different ways. Call of
                        lws_context_destroy() leads to several calls of
                        bws_srv_websocket_event() callback (LWS_CALLBACK_CLOSED,
@@ -790,8 +790,8 @@ BSC_WEBSOCKET_RET bws_srv_start(
 
     if (r) {
         /* TRICKY: Libwebsockets API is not designed to be used from
-                   multipe service threads, as a result lws_context_destroy()
-                   is not thread safe. More over, on different platforms the
+                   multiple service threads, as a result lws_context_destroy()
+                   is not thread safe. Moreover, on different platforms the
                    function behaves in different ways. Call of
                    lws_context_destroy() leads to several calls of
                    bws_srv_websocket_event() callback (LWS_CALLBACK_CLOSED,

--- a/ports/linux/websocket-cli.c
+++ b/ports/linux/websocket-cli.c
@@ -460,8 +460,8 @@ static void *bws_cli_worker(void *arg)
             DEBUG_PRINTF("bws_cli_worker() process disconnecting event\n");
             DEBUG_PRINTF("bws_cli_worker() destroy ctx %p\n", conn->ctx);
             /* TRICKY: Libwebsockets API is not designed to be used from
-                       multipe service threads, as a result
-               lws_context_destroy() is not thread safe.More over, on different
+                       multiple service threads, as a result
+               lws_context_destroy() is not thread safe. Moreover, on different
                platforms the function behaves in different ways. Call of
                        lws_context_destroy() leads to several calls of
                        bws_cli_websocket_event() callback (LWS_CALLBACK_CLOSED,
@@ -657,8 +657,8 @@ BSC_WEBSOCKET_RET bws_cli_connect(
 
     if (r) {
         /* TRICKY: Libwebsockets API is not designed to be used from
-                   multipe service threads, as a result lws_context_destroy()
-                   is not thread safe. More over, on different platforms the
+                   multiple service threads, as a result lws_context_destroy()
+                   is not thread safe. Moreover, on different platforms the
                    function behaves in different ways. Call of
                    lws_context_destroy() leads to several calls of
                    bws_cli_websocket_event() callback (LWS_CALLBACK_CLOSED,

--- a/ports/linux/websocket-srv.c
+++ b/ports/linux/websocket-srv.c
@@ -605,8 +605,8 @@ static void *bws_srv_worker(void *arg)
                 "user_param = %p\n",
                 ctx->wsctx, ctx, ctx->user_param);
             /* TRICKY: Libwebsockets API is not designed to be used from
-                       multipe service threads, as a result
-               lws_context_destroy() is not thread safe.More over, on different
+                       multiple service threads, as a result
+               lws_context_destroy() is not thread safe. Moreover, on different
                platforms the function behaves in different ways. Call of
                        lws_context_destroy() leads to several calls of
                        bws_srv_websocket_event() callback (LWS_CALLBACK_CLOSED,
@@ -792,8 +792,8 @@ BSC_WEBSOCKET_RET bws_srv_start(
 
     if (r) {
         /* TRICKY: Libwebsockets API is not designed to be used from
-                   multipe service threads, as a result lws_context_destroy()
-                   is not thread safe. More over, on different platforms the
+                   multiple service threads, as a result lws_context_destroy()
+                   is not thread safe. Moreover, on different platforms the
                    function behaves in different ways. Call of
                    lws_context_destroy() leads to several calls of
                    bws_srv_websocket_event() callback (LWS_CALLBACK_CLOSED,

--- a/ports/win32/websocket-cli.c
+++ b/ports/win32/websocket-cli.c
@@ -460,8 +460,8 @@ static DWORD WINAPI bws_cli_worker(LPVOID arg)
             DEBUG_PRINTF("bws_cli_worker() process disconnecting event\n");
             DEBUG_PRINTF("bws_cli_worker() destroy ctx %p\n", conn->ctx);
             /* TRICKY: Libwebsockets API is not designed to be used from
-                       multipe service threads, as a result
-               lws_context_destroy() is not thread safe. More over, on different
+                       multiple service threads, as a result
+               lws_context_destroy() is not thread safe. Moreover, on different
                platforms the function behaves in different ways. Call of
                        lws_context_destroy() leads to several calls of
                        bws_cli_websocket_event() callback (LWS_CALLBACK_CLOSED,
@@ -647,8 +647,8 @@ BSC_WEBSOCKET_RET bws_cli_connect(
 
     if (thread == NULL) {
         /* TRICKY: Libwebsockets API is not designed to be used from
-                   multipe service threads, as a result lws_context_destroy()
-                   is not thread safe. More over, on different platforms the
+                   multiple service threads, as a result lws_context_destroy()
+                   is not thread safe. Moreover, on different platforms the
                    function behaves in different ways. Call of
                    lws_context_destroy() leads to several calls of
                    bws_cli_websocket_event() callback (LWS_CALLBACK_CLOSED,

--- a/ports/win32/websocket-srv.c
+++ b/ports/win32/websocket-srv.c
@@ -590,8 +590,8 @@ static DWORD WINAPI bws_srv_worker(LPVOID arg)
                 "user_param = %p\n",
                 ctx->wsctx, ctx, ctx->user_param);
             /* TRICKY: Libwebsockets API is not designed to be used from
-                       multipe service threads, as a result
-               lws_context_destroy() is not thread safe.More over, on different
+                       multiple service threads, as a result
+               lws_context_destroy() is not thread safe. Moreover, on different
                platforms the function behaves in different ways. Call of
                        lws_context_destroy() leads to several calls of
                        bws_srv_websocket_event() callback (LWS_CALLBACK_CLOSED,
@@ -768,8 +768,8 @@ BSC_WEBSOCKET_RET bws_srv_start(
 
     if (thread == NULL) {
         /* TRICKY: Libwebsockets API is not designed to be used from
-                   multipe service threads, as a result lws_context_destroy()
-                   is not thread safe. More over, on different platforms the
+                   multiple service threads, as a result lws_context_destroy()
+                   is not thread safe. Moreover, on different platforms the
                    function behaves in different ways. Call of
                    lws_context_destroy() leads to several calls of
                    bws_srv_websocket_event() callback (LWS_CALLBACK_CLOSED,

--- a/src/bacnet/basic/client/bac-discover.c
+++ b/src/bacnet/basic/client/bac-discover.c
@@ -1118,7 +1118,7 @@ void bacnet_discover_dest_set(const BACNET_ADDRESS *dest)
 }
 
 /**
- * @brief Get the the BACnet address of target
+ * @brief Get the BACnet address of target
  * @return BACnet address
  */
 const BACNET_ADDRESS *bacnet_discover_dest(void)

--- a/src/bacnet/basic/object/lc.c
+++ b/src/bacnet/basic/object/lc.c
@@ -1561,7 +1561,7 @@ bool Load_Control_Write_Property(BACNET_WRITE_PROPERTY_DATA *wp_data)
         wp_data->error_code = ERROR_CODE_VALUE_OUT_OF_RANGE;
         return false;
     }
-    /* decode the the request or the first element in array */
+    /* decode the request or the first element in array */
     len = bacapp_decode_known_property(
         wp_data->application_data, wp_data->application_data_len, &value,
         wp_data->object_type, wp_data->object_property);

--- a/src/bacnet/basic/object/netport.c
+++ b/src/bacnet/basic/object/netport.c
@@ -3583,7 +3583,7 @@ uint32_t Network_Port_IP_DHCP_Lease_Time_Remaining(uint32_t object_instance)
 }
 
 /**
- * @brief Get the the address of the DHCP server from which the last DHCP
+ * @brief Get the address of the DHCP server from which the last DHCP
  *  lease was obtained for the port. If the address of the DHCP server
  *  cannot be determined, the value of this property shall be X'00000000'.
  * @param object_instance [in] BACnet network port object instance number

--- a/src/bacnet/basic/object/sc_netport.c
+++ b/src/bacnet/basic/object/sc_netport.c
@@ -803,7 +803,7 @@ uint8_t Network_Port_Routing_Table_Count(uint32_t object_instance)
 }
 
 /**
- * @brief Handle a request to encode all the the routing table entries
+ * @brief Handle a request to encode all the routing table entries
  * @param apdu [out] Buffer in which the APDU contents are built.
  * @param max_apdu [in] Max length of the APDU buffer.
  *
@@ -1252,7 +1252,7 @@ int Network_Port_SC_Hub_Function_Connection_Status_Count(
 }
 
 /**
- * @brief Handle a request to encode all the the entries
+ * @brief Handle a request to encode all the entries
  * @param object_instance [in] BACnet network port object instance number
  * @param apdu [out] Buffer in which the APDU contents are built.
  * @param max_apdu [in] Max length of the APDU buffer.
@@ -1742,7 +1742,7 @@ int Network_Port_SC_Direct_Connect_Connection_Status_Count(
 }
 
 /**
- * @brief Handle a request to encode all the the entries
+ * @brief Handle a request to encode all the entries
  * @param object_instance [in] BACnet network port object instance number
  * @param apdu [out] Buffer in which the APDU contents are built.
  * @param max_apdu [in] Max length of the APDU buffer.
@@ -1860,7 +1860,7 @@ int Network_Port_SC_Failed_Connection_Requests_Count(uint32_t object_instance)
 }
 
 /**
- * @brief Handle a request to encode all the the entries
+ * @brief Handle a request to encode all the entries
  * @param object_instance [in] BACnet network port object instance number
  * @param apdu [out] Buffer in which the APDU contents are built.
  * @param max_apdu [in] Max length of the APDU buffer.

--- a/src/bacnet/basic/program/ubasic/README.md
+++ b/src/bacnet/basic/program/ubasic/README.md
@@ -168,7 +168,7 @@ first line of the script.
 - *pinmode(pin,mode,speed), a=dread(pin), dwrite(pin,state)*
 
   Allows direct control over digital pins. The pin, mode, speed, and state
-  designations accept an 8-bit value passed to the the hardware abstraction.
+  designations accept an 8-bit value passed to the hardware abstraction.
 
 - *awrite_conf(prescaler,period), awrite(channel,value), awrite(channel)*
 

--- a/src/bacnet/basic/service/h_apdu.c
+++ b/src/bacnet/basic/service/h_apdu.c
@@ -297,7 +297,7 @@ bool apdu_confirmed_simple_ack_service(BACNET_CONFIRMED_SERVICE service_choice)
 }
 
 /**
- * @brief Set the the BACnet Simple Ack Service handler
+ * @brief Set the BACnet Simple Ack Service handler
  * @param service_choice [in] BACnet confirmed service choice
  * @param pFunction [in] handler for the service
  */
@@ -311,7 +311,7 @@ void apdu_set_confirmed_simple_ack_handler(
 }
 
 /**
- * @brief Set the the BACnet Confirmed Ack Service handler
+ * @brief Set the BACnet Confirmed Ack Service handler
  * @param service_choice [in] BACnet confirmed service choice
  * @param pFunction [in] handler for the service
  */

--- a/src/bacnet/basic/service/s_readrange.c
+++ b/src/bacnet/basic/service/s_readrange.c
@@ -69,7 +69,7 @@ uint8_t Send_ReadRange_Request(
         }
 
         pdu_len += len;
-        /* is it small enough for the the destination to receive?
+        /* is it small enough for the destination to receive?
            note: if there is a bottleneck router in between
            us and the destination, we won't know unless
            we have a way to check for that and update the

--- a/src/bacnet/basic/sys/dst.h
+++ b/src/bacnet/basic/sys/dst.h
@@ -1,6 +1,6 @@
 /**
  * @file
- * @brief This file contains the function prototypes for for the module.
+ * @brief This file contains the function prototypes for the module.
  * @author Steve Karg <skarg@users.sourceforge.net>
  * @date 1997
  * @note Public domain algorithms from ACM

--- a/test/bacnet/bacaudit/src/main.c
+++ b/test/bacnet/bacaudit/src/main.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * @brief Unit test for for BACnetAuditNotification and BACnetAuditLogRecord
+ * @brief Unit test for BACnetAuditNotification and BACnetAuditLogRecord
  * @author Steve Karg <skarg@users.sourceforge.net>
  * @date November 2024
  * @copyright SPDX-License-Identifier: MIT

--- a/test/bacnet/baclog/src/main.c
+++ b/test/bacnet/baclog/src/main.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * @brief Unit test for for BACnetAuditNotification and BACnetAuditLogRecord
+ * @brief Unit test for BACnetAuditNotification and BACnetAuditLogRecord
  * @author Steve Karg <skarg@users.sourceforge.net>
  * @date November 2024
  * @copyright SPDX-License-Identifier: MIT


### PR DESCRIPTION
Summary:
- Fix repeated words in project docs and comments.
- Fix misspellings in websocket comments across BSD, Linux, and Win32 ports.

Testing:
- git diff --check origin/master...HEAD

No runtime tests were run because this only changes comments and documentation text.