### PR TITLE
fix: implement accumulator name API

### DIFF
--- a/src/bacnet/basic/object/acc.c
+++ b/src/bacnet/basic/object/acc.c
@@ -187,6 +187,45 @@ unsigned Accumulator_Instance_To_Index(uint32_t object_instance)
 }
 
 /**
+ * For a given object instance-number, returns the object-name
+ *
+ * @param  object_instance - object-instance number of the object
+ *
+ * @return object-name C string, or NULL if not found.
+ */
+char *Accumulator_Name(uint32_t object_instance)
+{
+    char *name = NULL;
+    struct object_data *pObject = Object_Data(object_instance);
+
+    if (pObject) {
+        name = characterstring_value(&pObject->Object_Name);
+    }
+
+    return name;
+}
+
+/**
+ * For a given object instance-number, sets the object-name from a C string
+ *
+ * @param  object_instance - object-instance number of the object
+ * @param  new_name - holds the object-name to be set
+ *
+ * @return  true if object-name was set
+ */
+bool Accumulator_Name_Set(uint32_t object_instance, char *new_name)
+{
+    bool status = false;
+    struct object_data *pObject = Object_Data(object_instance);
+
+    if (pObject) {
+        status = characterstring_init_ansi(&pObject->Object_Name, new_name);
+    }
+
+    return status;
+}
+
+/**
  * For a given object instance-number, loads the object-name into
  * a characterstring. Note that the object name must be unique
  * within this device.

--- a/test/bacnet/basic/object/acc/src/main.c
+++ b/test/bacnet/basic/object/acc/src/main.c
@@ -5,6 +5,7 @@
  * @date 2017
  * @copyright SPDX-License-Identifier: MIT
  */
+#include <string.h>
 #include <zephyr/ztest.h>
 #include <bacnet/basic/object/acc.h>
 #include <bacnet/bactext.h>
@@ -37,6 +38,8 @@ static void test_Accumulator(void)
     bool status = false;
     const int32_t *writable_properties;
     const int32_t skip_fail_property_list[] = { -1 };
+    char test_name[] = "Test Accumulator Name";
+    char *name = NULL;
     char *sample_context = "context";
 
     Accumulator_Init();
@@ -86,6 +89,14 @@ static void test_Accumulator(void)
     }
     status = Accumulator_Description_Set(instance, "Test Accumulator");
     zassert_true(status, NULL);
+    status = Accumulator_Name_Set(instance, test_name);
+    zassert_true(status, NULL);
+    name = Accumulator_Name(instance);
+    zassert_not_null(name, NULL);
+    zassert_equal(strcmp(name, test_name), 0, NULL);
+    status = Accumulator_Name_Set(instance - 1, test_name);
+    zassert_false(status, NULL);
+    zassert_is_null(Accumulator_Name(instance - 1), NULL);
     Accumulator_Writable_Property_List(instance, &writable_properties);
     zassert_not_null(writable_properties, NULL);
     /* context API */


### PR DESCRIPTION
## Summary
- Implement `Accumulator_Name()` and `Accumulator_Name_Set()`, which are declared in `acc.h` and referenced by `ACCUMULATOR_OBJ_FUNCTIONS`.
- Add accumulator object test coverage for the public C string name API on valid and invalid instances.

## Testing
- `git diff --check HEAD~1..HEAD`
- `git ls-files --eol src/bacnet/basic/object/acc.c test/bacnet/basic/object/acc/src/main.c`

Not run: CMake/unit tests, because this Windows environment does not have `cmake`, `make`, `gcc`, `clang`, or `cl` available.