### PR TITLE
fix: bacnet_action_command_decode() truncates Post_Delay to 8 bits

### DIFF
--- a/src/bacnet/bacaction.c
+++ b/src/bacnet/bacaction.c
@@ -487,7 +487,7 @@ int bacnet_action_command_decode(
     if (len > 0) {
         apdu_len += len;
         if (entry) {
-            entry->Post_Delay = (uint8_t)unsigned_value;
+            entry->Post_Delay = (uint32_t)unsigned_value;
         }
     } else {
         /* wrong tag or malformed - optional - skip apdu_len increment */


### PR DESCRIPTION
## Summary

`BACNET_ACTION_LIST.Post_Delay` is declared `uint32_t` in `src/bacnet/bacaction.h`, and `bacnet_action_command_encode()` in `src/bacnet/bacaction.c` writes the full 32-bit value for the `postDelay [6]` context tag (no masking). However `bacnet_action_command_decode()` stored the decoded value through a stray `(uint8_t)` cast:

```c
entry->Post_Delay = (uint8_t)unsigned_value;
```

So any `Post_Delay >= 256` is silently truncated to its low 8 bits on decode, corrupting round-tripped Command object Action list entries (e.g. an encoded `Post_Delay` of `1000` decodes back as `232`, and `65536` decodes back as `0`).

This is unrelated to the `Priority` field just above it in the same function, which is genuinely `uint8_t` and is correctly range-checked (1..16) before its own `(uint8_t)` cast — `Post_Delay` has no such range restriction anywhere in the codebase.

## Fix

One-line change: cast to `(uint32_t)` instead of `(uint8_t)`, matching the field's declared type and the encoder's existing behavior.

## Verification

Wrote a standalone repro that round-trips a `BACNET_ACTION_LIST` through `bacnet_action_command_encode()` -> `bacnet_action_command_decode()`, linked against the same source files `test/bacnet/basic/object/command` uses.

Before the fix:
```
Post_Delay in  = 1000
Post_Delay out = 232
BUG CONFIRMED: Post_Delay corrupted by round-trip encode/decode (1000 -> 232)
Post_Delay=65536 round trip -> 0 (BUG)
```

After the fix:
```
Post_Delay in  = 1000
Post_Delay out = 1000
OK: Post_Delay round-tripped correctly
Post_Delay=255 round trip -> 255 (OK)
Post_Delay=65536 round trip -> 65536 (OK)
```

Existing tests in `test/bacnet/basic/object/command/src/main.c` only ever exercise `Post_Delay` values of 0, 1, or 10 — never >= 256 — which is why this wasn't previously caught.