### PR TITLE
expose Notification_Class_I_Am_Router_To_Network_Handler so it can be called from custom handler

### DIFF
--- a/src/bacnet/basic/object/nc.c
+++ b/src/bacnet/basic/object/nc.c
@@ -101,7 +101,7 @@ void Notification_Class_Writable_Property_List(
  * @param src - source address of the router
  * @param network - network number of the router
  */
-static void Notification_Class_I_Am_Router_To_Network_Handler(
+void Notification_Class_I_Am_Router_To_Network_Handler(
     BACNET_ADDRESS *src, uint16_t network)
 {
     NOTIFICATION_CLASS_INFO *notification;

--- a/src/bacnet/basic/object/nc.h
+++ b/src/bacnet/basic/object/nc.h
@@ -58,7 +58,8 @@ void Notification_Class_Property_Lists(
 BACNET_STACK_EXPORT
 void Notification_Class_Writable_Property_List(
     uint32_t object_instance, const int32_t **properties);
-
+void Notification_Class_I_Am_Router_To_Network_Handler(
+    BACNET_ADDRESS *src, uint16_t network);
 BACNET_STACK_EXPORT
 void Notification_Class_Init(void);
 


### PR DESCRIPTION
`npdu_set_i_am_router_to_network_handler` only stores one callback, which `Notification_Class_I_Am_Router_To_Network_Handler` is installed into by `Notification_Class_Init`

This makes `Notification_Class_I_Am_Router_To_Network_Handler` public so a custom `i_am_router_to_network_handler` can be installed and still invoke `Notification_Class_I_Am_Router_To_Network_Handler` from the custom handler.