### PR TITLE
Fix router SysV message queue ABI on 64-bit platforms

### DIFF
--- a/apps/router/msgqueue.c
+++ b/apps/router/msgqueue.c
@@ -32,7 +32,7 @@ bool send_to_msgbox(MSGBOX_ID dest, BACMSG *msg)
 {
     int err;
 
-    err = msgsnd(dest, msg, sizeof(BACMSG) - sizeof(MSGTYPE), 0);
+    err = msgsnd(dest, msg, sizeof(BACMSG) - sizeof(long), 0);
     if (err) {
         return false;
     }
@@ -43,7 +43,7 @@ BACMSG *recv_from_msgbox(MSGBOX_ID src, BACMSG *msg, int flags)
 {
     int recv_bytes;
 
-    recv_bytes = msgrcv(src, msg, sizeof(BACMSG) - sizeof(MSGTYPE), 0, flags);
+    recv_bytes = msgrcv(src, msg, sizeof(BACMSG) - sizeof(long), 0, flags);
     if (recv_bytes > 0) {
         return msg;
     } else {

--- a/apps/router/msgqueue.h
+++ b/apps/router/msgqueue.h
@@ -32,7 +32,7 @@ typedef enum { DATA = 1, SERVICE } MSGTYPE;
 typedef enum { SHUTDOWN, CHG_IP, CHG_MAC } MSGSUBTYPE;
 
 typedef struct _message {
-    MSGTYPE type;
+    long type;
     MSGBOX_ID origin;
     MSGSUBTYPE subtype;
     void *data;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -256,6 +256,7 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   message(STATUS "Added ports specific tests for linux")
 
   list(APPEND testdirs
+  apps/router/msgqueue
   ports/linux/bsc_event
   ports/linux/bip_subnet
   ports/bip_broadcast_port

--- a/test/apps/router/msgqueue/CMakeLists.txt
+++ b/test/apps/router/msgqueue/CMakeLists.txt
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+
+get_filename_component(basename ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(test_${basename}
+    VERSION 1.0.0
+    LANGUAGES C)
+
+string(REGEX REPLACE
+    "/test/apps/router/msgqueue$"
+    ""
+    ROOT_DIR
+    ${CMAKE_CURRENT_SOURCE_DIR})
+
+find_package(Threads REQUIRED)
+
+include_directories(
+    ${ROOT_DIR}/apps/router
+    ${ROOT_DIR}/src
+    )
+
+add_executable(${PROJECT_NAME}
+    ${ROOT_DIR}/apps/router/msgqueue.c
+    ./src/main.c
+    )
+
+target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads)

--- a/test/apps/router/msgqueue/src/main.c
+++ b/test/apps/router/msgqueue/src/main.c
@@ -1,0 +1,90 @@
+/**
+ * @file
+ * @brief Tests for the router System V message queue ABI
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include <assert.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <sys/msg.h>
+
+#include "msgqueue.h"
+
+typedef struct {
+    long type;
+    MSGBOX_ID origin;
+    MSGSUBTYPE subtype;
+    void *data;
+} SYSV_MESSAGE;
+
+static size_t sysv_payload_size(void)
+{
+    return sizeof(SYSV_MESSAGE) - sizeof(long);
+}
+
+static void test_sysv_layout(void)
+{
+    BACMSG message = { 0 };
+
+    assert(offsetof(BACMSG, type) == 0);
+    assert(sizeof(message.type) == sizeof(long));
+}
+
+static void test_wrapper_send_to_raw_receive(void)
+{
+    MSGBOX_ID queue = create_msgbox();
+    BACMSG sent = { 0 };
+    SYSV_MESSAGE received = { 0 };
+    ssize_t received_size;
+
+    assert(queue != INVALID_MSGBOX_ID);
+    sent.type = DATA;
+    sent.origin = 42;
+    sent.subtype = CHG_IP;
+    sent.data = &sent;
+
+    assert(send_to_msgbox(queue, &sent));
+    received_size =
+        msgrcv(queue, &received, sysv_payload_size(), 0, IPC_NOWAIT);
+    assert(received_size == (ssize_t)sysv_payload_size());
+    assert(received.type == DATA);
+    assert(received.origin == sent.origin);
+    assert(received.subtype == sent.subtype);
+    assert(received.data == sent.data);
+
+    del_msgbox(queue);
+}
+
+static void test_raw_send_to_wrapper_receive(void)
+{
+    MSGBOX_ID queue = create_msgbox();
+    SYSV_MESSAGE sent = { 0 };
+    BACMSG received = { 0 };
+
+    assert(queue != INVALID_MSGBOX_ID);
+    sent.type = SERVICE;
+    sent.origin = 84;
+    sent.subtype = CHG_MAC;
+    sent.data = &sent;
+
+    assert(msgsnd(queue, &sent, sysv_payload_size(), 0) == 0);
+    assert(recv_from_msgbox(queue, &received, IPC_NOWAIT) == &received);
+    assert(received.type == SERVICE);
+    assert(received.origin == sent.origin);
+    assert(received.subtype == sent.subtype);
+    assert(received.data == sent.data);
+
+    del_msgbox(queue);
+}
+
+int main(void)
+{
+    test_wrapper_send_to_raw_receive();
+    test_raw_send_to_wrapper_receive();
+    test_sysv_layout();
+
+    printf("router msgqueue SysV ABI tests passed\n");
+    return 0;
+}

--- a/test/apps/router/msgqueue/src/main.c
+++ b/test/apps/router/msgqueue/src/main.c
@@ -14,6 +14,9 @@
 
 #include "msgqueue.h"
 
+#define SYSV_MESSAGE_OVERFLOW_BYTES \
+    ((sizeof(long) > sizeof(MSGTYPE)) ? (sizeof(long) - sizeof(MSGTYPE)) : 1U)
+
 typedef struct {
     long type;
     MSGBOX_ID origin;
@@ -23,12 +26,12 @@ typedef struct {
 
 typedef struct {
     SYSV_MESSAGE message;
-    uint8_t trailing[sizeof(long) - sizeof(MSGTYPE)];
+    uint8_t trailing[SYSV_MESSAGE_OVERFLOW_BYTES];
 } OVERSIZED_SYSV_MESSAGE;
 
 typedef struct {
     BACMSG message;
-    uint8_t canary[sizeof(long) - sizeof(MSGTYPE)];
+    uint8_t canary[SYSV_MESSAGE_OVERFLOW_BYTES];
 } GUARDED_BACMSG;
 
 static size_t sysv_payload_size(void)
@@ -93,11 +96,14 @@ static void test_raw_send_to_wrapper_receive(void)
 
 static void test_oversized_raw_message_is_not_received(void)
 {
+    if (sizeof(long) <= sizeof(MSGTYPE)) {
+        return;
+    }
+
     MSGBOX_ID queue = create_msgbox();
     OVERSIZED_SYSV_MESSAGE sent = { 0 };
     GUARDED_BACMSG guarded = { 0 };
 
-    assert(sizeof(long) > sizeof(MSGTYPE));
     assert(queue != INVALID_MSGBOX_ID);
     sent.message.type = SERVICE;
     sent.message.origin = 126;

--- a/test/apps/router/msgqueue/src/main.c
+++ b/test/apps/router/msgqueue/src/main.c
@@ -5,9 +5,11 @@
  * SPDX-License-Identifier: MIT
  */
 #include <assert.h>
+#include <errno.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <pthread.h>
+#include <string.h>
 #include <sys/msg.h>
 
 #include "msgqueue.h"
@@ -18,6 +20,16 @@ typedef struct {
     MSGSUBTYPE subtype;
     void *data;
 } SYSV_MESSAGE;
+
+typedef struct {
+    SYSV_MESSAGE message;
+    uint8_t trailing[sizeof(long) - sizeof(MSGTYPE)];
+} OVERSIZED_SYSV_MESSAGE;
+
+typedef struct {
+    BACMSG message;
+    uint8_t canary[sizeof(long) - sizeof(MSGTYPE)];
+} GUARDED_BACMSG;
 
 static size_t sysv_payload_size(void)
 {
@@ -79,10 +91,39 @@ static void test_raw_send_to_wrapper_receive(void)
     del_msgbox(queue);
 }
 
+static void test_oversized_raw_message_is_not_received(void)
+{
+    MSGBOX_ID queue = create_msgbox();
+    OVERSIZED_SYSV_MESSAGE sent = { 0 };
+    GUARDED_BACMSG guarded = { 0 };
+
+    assert(sizeof(long) > sizeof(MSGTYPE));
+    assert(queue != INVALID_MSGBOX_ID);
+    sent.message.type = SERVICE;
+    sent.message.origin = 126;
+    sent.message.subtype = CHG_MAC;
+    sent.message.data = &sent;
+    memset(sent.trailing, 0x5A, sizeof(sent.trailing));
+    memset(guarded.canary, 0xA5, sizeof(guarded.canary));
+
+    assert(
+        msgsnd(queue, &sent, sysv_payload_size() + sizeof(sent.trailing), 0) ==
+        0);
+    errno = 0;
+    assert(recv_from_msgbox(queue, &guarded.message, IPC_NOWAIT) == NULL);
+    assert(errno == E2BIG);
+    for (size_t i = 0; i < sizeof(guarded.canary); i++) {
+        assert(guarded.canary[i] == 0xA5);
+    }
+
+    del_msgbox(queue);
+}
+
 int main(void)
 {
     test_wrapper_send_to_raw_receive();
     test_raw_send_to_wrapper_receive();
+    test_oversized_raw_message_is_not_received();
     test_sysv_layout();
 
     printf("router msgqueue SysV ABI tests passed\n");


### PR DESCRIPTION
## Summary

- store the SysV message type as the required leading `long mtype`
- pass only the message-text payload size to `msgsnd()` and `msgrcv()`
- preserve the existing `DATA` and `SERVICE` enum semantics
- add a Linux-only regression test for raw/wrapper interoperability in both directions, oversized receive rejection, and equal-width ABI compatibility

## Root cause

SysV message queue buffers must start with a `long mtype`, and `msgsz` must exclude that leading `long`. `BACMSG` previously stored its first field as `MSGTYPE`, which is normally a 4-byte enum, and calculated the payload size by subtracting `sizeof(MSGTYPE)`.

On LP64 platforms, `long` is wider than the enum. The kernel therefore interpreted the message layout differently from the application, and the supplied size included bytes beyond the actual `BACMSG` payload. ASan confirmed the resulting out-of-bounds access.

## Changes

- change `BACMSG.type` to `long`
- use `sizeof(BACMSG) - sizeof(long)` for both send and receive operations
- register a Linux-only router message queue test
- verify wrapper-to-raw and raw-to-wrapper interoperation
- verify an oversized raw message is rejected with `E2BIG` without overwriting an adjacent canary
- keep the width-difference test portable to equal-width/ILP32 ABIs

## Validation

- Ubuntu 24.04 ARM64 reproduction: old implementation failed 3/3 runs
- focused normal CTest on ARM64: 2/2 passed
- ASan/UBSan CTest on ARM64: 2/2 passed
- ARM64 router clean build: passed
- current focused CMake build and test: passed (`router msgqueue SysV ABI tests passed`)
- `uvx pre-commit run --files ...`: all hooks passed
- clang-format dry-run: passed
- `git diff --check upstream/master...HEAD`: passed

Related to #793.

PR #808 changed the optimization level and avoided the observed symptom, but it did not correct the SysV message structure ABI.
