### PR TITLE
fix: bounds check missing when parsing Weekly_Schedule day entries from ASCII

### DIFF
--- a/src/bacnet/bacapp.c
+++ b/src/bacnet/bacapp.c
@@ -4391,6 +4391,11 @@ parse_weeklyschedule(const char *str, BACNET_APPLICATION_DATA_VALUE *value)
                 *sp = '\0';
                 v = bacnet_ltrim(sp + 1, " ");
 
+                if (tvnum >= BACNET_DAILY_SCHEDULE_TIME_VALUES_SIZE) {
+                    /* too many time-value pairs for one day */
+                    return false;
+                }
+
                 /* Parse time directly into the Time_Value slot */
                 if (!datetime_time_init_ascii(
                         &dsch->Time_Values[tvnum].Time, t)) {

--- a/test/bacnet/bacapp/src/main.c
+++ b/test/bacnet/bacapp/src/main.c
@@ -1739,11 +1739,13 @@ static void test_parse_weeklyschedule(void)
 
         for (i = 0; i < 41; i++) {
             snprintf(
-                pair, sizeof(pair), "%s%02d:%02d:%02d.00 TRUE", (i == 0) ? "" : ", ",
-                (i / 3600) % 24, (i / 60) % 60, i % 60);
+                pair, sizeof(pair), "%s%02d:%02d:%02d.00 TRUE",
+                (i == 0) ? "" : ", ", (i / 3600) % 24, (i / 60) % 60, i % 60);
             strcat(too_many, pair);
         }
-        strcat(too_many, "]; Tue: []; Wed: []; Thu: []; Fri: []; Sat: []; Sun: [])");
+        strcat(
+            too_many,
+            "]; Tue: []; Wed: []; Thu: []; Fri: []; Sat: []; Sun: [])");
 
         memset(&value, 0, sizeof(value));
         status = bacapp_parse_application_data(

--- a/test/bacnet/bacapp/src/main.c
+++ b/test/bacnet/bacapp/src/main.c
@@ -6,6 +6,7 @@
  * @copyright SPDX-License-Identifier: MIT
  */
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 #include <zephyr/ztest.h>
 #include <bacnet/bacdcode.h>
@@ -1725,6 +1726,33 @@ static void test_parse_weeklyschedule(void)
     status = bacapp_parse_application_data(
         BACNET_APPLICATION_TAG_WEEKLY_SCHEDULE, "(NoSuchTag; Mon: [])", &value);
     zassert_false(status, NULL);
+
+    /* invalid: one day with more time-value pairs than
+       BACNET_DAILY_SCHEDULE_TIME_VALUES_SIZE (40) fits in Time_Values[].
+       Without a bounds check, the parser keeps writing past the end of
+       weeklySchedule[0].Time_Values[] and corrupts the following days in
+       the same array instead of rejecting the input. */
+    {
+        char too_many[2048] = "(Boolean; Mon: [";
+        char pair[24];
+        int i;
+
+        for (i = 0; i < 41; i++) {
+            snprintf(
+                pair, sizeof(pair), "%s%02d:%02d:%02d.00 TRUE", (i == 0) ? "" : ", ",
+                (i / 3600) % 24, (i / 60) % 60, i % 60);
+            strcat(too_many, pair);
+        }
+        strcat(too_many, "]; Tue: []; Wed: []; Thu: []; Fri: []; Sat: []; Sun: [])");
+
+        memset(&value, 0, sizeof(value));
+        status = bacapp_parse_application_data(
+            BACNET_APPLICATION_TAG_WEEKLY_SCHEDULE, too_many, &value);
+        zassert_false(status, NULL);
+        /* Tuesday's schedule must stay untouched by Monday's overflow */
+        zassert_equal(
+            value.type.Weekly_Schedule.weeklySchedule[1].TV_Count, 0, NULL);
+    }
 #endif
 }
 


### PR DESCRIPTION
`bacapp_parse_application_data()` builds a `BACnetWeeklySchedule` value out of an ASCII string (this is what `bacwp` and similar demo apps use to turn a `--value` argument into something that can go out in a WriteProperty request). For each day it walks the comma-separated time/value tokens and writes them straight into `dsch->Time_Values[tvnum]`, but nothing checks `tvnum` against the array size (`BACNET_DAILY_SCHEDULE_TIME_VALUES_SIZE`, 40) before writing. If a day's brackets contain more than 40 entries, the loop just keeps going and writes past the end of that day's `Time_Values[]` into whatever sits next in memory - the following day's schedule inside `weeklySchedule[]`, and beyond that if you feed it enough entries.

I checked this against the real parser rather than a synthetic reproduction. Feeding a schedule with, say, 60 time-value pairs on Monday and empty brackets for the rest of the week corrupts the following days - Tuesday's `Time_Values[0]` ends up holding data that only Monday's input produced, even though the string said `Tue: []` - and the function still reports success. With a few hundred entries in one day it runs past the local `BACNET_APPLICATION_DATA_VALUE` entirely and crashes.

The sibling parser for `BACnetSpecialEvent` day-schedules (`daily_schedule_from_ascii`, a bit further down in the same file) already guards against exactly this - it looks like the check was simply missed when `parse_weeklyschedule()` was written. This patch adds the same guard: once a day already has `BACNET_DAILY_SCHEDULE_TIME_VALUES_SIZE` entries, reject the string instead of writing past the array.

Added a test next to the existing `test_parse_weeklyschedule` cases that feeds 41 entries for one day and checks both that parsing is now rejected and that the next day's data is left untouched. Ran the full `test_bacapp` suite before and after: without the fix the new case fails (parser reports success on the oversized input); with the fix it passes and nothing else in the suite changed.

One clarification since Weekly_Schedule shows up a lot in past advisories here: this is the ASCII/CLI-side parser, not the wire decoder. `bacnet_dailyschedule_context_decode()` in dailyschedule.c already passes `ARRAY_SIZE()` through correctly, so this isn't reachable by decoding a WriteProperty request off the network - it only affects code that builds a Weekly_Schedule value from a string through this API.
