### PR TITLE
fix: avoid use-after-free on JSON parse errors

### DIFF
--- a/apps/modbus-gateway/point_table.c
+++ b/apps/modbus-gateway/point_table.c
@@ -217,12 +217,11 @@ static cJSON *load_json_file(const char *filename)
     fclose(fp);
 
     root = cJSON_Parse(buf);
-    free(buf);
-
     if (!root) {
         fprintf(
             stderr, "[PT] JSON parse error near: %s\n", cJSON_GetErrorPtr());
     }
+    free(buf);
     return root;
 }
 


### PR DESCRIPTION
## Summary

Fix a use-after-free in `apps/modbus-gateway/point_table.c`.

When JSON parsing fails, `cJSON_GetErrorPtr()` can point into the input buffer.
The buffer was freed before the error pointer was printed, so malformed JSON
could trigger a heap-use-after-free during error reporting.

This change moves `free(buf)` until after the parse error is logged.

## Verification

Built `modbusgw` with AddressSanitizer and tested with malformed JSON input.

Before this change, AddressSanitizer reported a heap-use-after-free.
After this change, the program reports the JSON parse error without an ASan
use-after-free report.

## Scope

This is a minimal error-path lifetime fix. It does not change JSON parsing
behavior or valid-input handling.