### PR TITLE
fix: skip GCC-only -Wno-variadic-macros option when building with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,7 +258,10 @@ if(BACDL_BSC)
   find_package(PkgConfig)
   pkg_check_modules(LIB_WEBSOCKETS REQUIRED libwebsockets)
   #libwebsocket need C99 with variadic-macros
-  add_compile_options(-Wno-variadic-macros)
+  #MSVC has no such warning and rejects the option as an invalid argument
+  if(NOT MSVC)
+    add_compile_options(-Wno-variadic-macros)
+  endif()
   find_package(OpenSSL)
 endif()
 


### PR DESCRIPTION
Fixes #1449

`-Wno-variadic-macros` is GCC-only and MSVC rejects it with `error D8021`, so every `BACDL_BSC=ON` build fails under MSVC before anything is compiled. Guarded with `if(NOT MSVC)`.

Verified on Windows with MSVC 19.44, libwebsockets 4.3.3 and OpenSSL 3.5.3: library, `sc-hub` and `server` all build and run.
