### PR TITLE
Append PROP_PROPERTY_LIST to RPM ALL requests

### DIFF
--- a/src/bacnet/basic/service/h_rpm.c
+++ b/src/bacnet/basic/service/h_rpm.c
@@ -44,6 +44,9 @@ static uint8_t Temp_Buf[MAX_APDU] = { 0 };
  * to fetch.
  * @param index The index of the property to fetch.
  * @return The property ID or -1 if not found.
+ * @note For PROP_ALL with protocol revision >= 14, PROP_PROPERTY_LIST is
+ * appended as the last entry, since it is intentionally absent from the
+ * Required/Optional/Proprietary lists.
  */
 static BACNET_PROPERTY_ID RPM_Object_Property(
     struct special_property_list_t *pPropertyList,
@@ -65,6 +68,10 @@ static BACNET_PROPERTY_ID RPM_Object_Property(
         } else if (index < (required + optional + proprietary)) {
             index -= (required + optional);
             property = pPropertyList->Proprietary.pList[index];
+#if (BACNET_PROTOCOL_REVISION >= 14)
+        } else if (index == (required + optional + proprietary)) {
+            property = PROP_PROPERTY_LIST;
+#endif
         }
     } else if (special_property == PROP_REQUIRED) {
         if (index < required) {
@@ -88,6 +95,9 @@ static BACNET_PROPERTY_ID RPM_Object_Property(
  * @param special_property The special property ALL, REQUIRED, or OPTIONAL
  * to fetch.
  * @return The number of properties.
+ * @note For PROP_ALL with protocol revision >= 14, the count includes
+ * PROP_PROPERTY_LIST, which is intentionally absent from the Required/
+ * Optional/Proprietary lists.
  */
 static unsigned RPM_Object_Property_Count(
     struct special_property_list_t *pPropertyList,
@@ -98,6 +108,10 @@ static unsigned RPM_Object_Property_Count(
     if (special_property == PROP_ALL) {
         count = pPropertyList->Required.count + pPropertyList->Optional.count +
             pPropertyList->Proprietary.count;
+#if (BACNET_PROTOCOL_REVISION >= 14)
+        /* account for the implicit PROP_PROPERTY_LIST entry */
+        count += 1;
+#endif
     } else if (special_property == PROP_REQUIRED) {
         count = pPropertyList->Required.count;
     } else if (special_property == PROP_OPTIONAL) {


### PR DESCRIPTION
`Propery_List` property is special, it is voluntary not part of required/optional/proprietary properties lists but it still exists since protocol 14.

Automatically return it for special `Read_property_Multiple ALL` requests (still not returning it in all other RPM requests).

Do it by altering both RPM_Object_Property and RPM_Object_Property_Count