### PR TITLE
CSV: Changed flag should not be cleared upon write

### DIFF
--- a/src/bacnet/basic/object/csv.c
+++ b/src/bacnet/basic/object/csv.c
@@ -377,8 +377,9 @@ bool CharacterString_Value_Present_Value_Set(
         CharacterString_Value_Object(object_instance);
 
     if (pObject) {
-        pObject->Changed =
-            !characterstring_same(&pObject->Present_Value, present_value);
+        if (!characterstring_same(&pObject->Present_Value, present_value)) {
+            pObject->Changed = true;
+        }
 
         status = characterstring_copy(&pObject->Present_Value, present_value);
     }


### PR DESCRIPTION
A remote peer must not be able to clear Changed flag of a CSV by writing current value to it, since this would break COV if COV handler is not executed upon every single recv loop