### PR TITLE
Add What-Is-Network-Number support to h_routed_npdu

### DIFF
--- a/src/bacnet/basic/npdu/h_npdu.c
+++ b/src/bacnet/basic/npdu/h_npdu.c
@@ -70,6 +70,28 @@ void npdu_network_number_set(uint16_t net)
 }
 
 /**
+ * @brief get the local network number status
+ * @return local network number status
+ * @see NETWORK_NUMBER_LEARNED
+ * @see NETWORK_NUMBER_ASSIGNED
+ */
+uint8_t npdu_network_number_status(void)
+{
+    return Local_Network_Number_Status;
+}
+
+/**
+ * @brief set the local network number status
+ * @param status - local network number status
+ * @see NETWORK_NUMBER_LEARNED
+ * @see NETWORK_NUMBER_ASSIGNED
+ */
+void npdu_network_number_status_set(uint8_t status)
+{
+    Local_Network_Number_Status = status;
+}
+
+/**
  * @brief send the local network number is message
  * @param dst - the destination address for the message
  * @param net - local network number

--- a/src/bacnet/basic/npdu/h_npdu.h
+++ b/src/bacnet/basic/npdu/h_npdu.h
@@ -29,6 +29,10 @@ uint16_t npdu_network_number(void);
 BACNET_STACK_EXPORT
 void npdu_network_number_set(uint16_t net);
 BACNET_STACK_EXPORT
+uint8_t npdu_network_number_status(void);
+BACNET_STACK_EXPORT
+void npdu_network_number_status_set(uint8_t status);
+BACNET_STACK_EXPORT
 int npdu_send_network_number_is(
     BACNET_ADDRESS *dst, uint16_t net, uint8_t status);
 BACNET_STACK_EXPORT

--- a/src/bacnet/basic/npdu/h_routed_npdu.c
+++ b/src/bacnet/basic/npdu/h_routed_npdu.c
@@ -18,6 +18,7 @@
 #include "bacnet/npdu.h"
 #include "bacnet/apdu.h"
 #include "bacnet/bactext.h"
+#include "bacnet/basic/npdu/h_npdu.h"
 #include "bacnet/basic/object/device.h"
 #include "bacnet/basic/sys/debug.h"
 #include "bacnet/basic/services.h"
@@ -148,7 +149,21 @@ static void network_control_handler(
             /* Do nothing - don't support PTP half-router control */
             break;
         case NETWORK_MESSAGE_WHAT_IS_NETWORK_NUMBER:
-            /* FIXME: add procedure for this message */
+            if (src->net == 0) {
+                if (npdu_network_number()) {
+                    npdu_send_network_number_is(
+                        src, npdu_network_number(),
+                        npdu_network_number_status());
+                } else {
+                    /*  Upon receipt of a What-Is-Network-Number message,
+                        a device that does not know the local network number
+                        shall discard the message. */
+                }
+            } else {
+                /*  Devices shall ignore What-Is-Network-Number messages
+                    that contain SNET/SADR or DNET/DADR information in
+                    the NPCI. */
+            }
             break;
         case NETWORK_MESSAGE_NETWORK_NUMBER_IS:
             /* FIXME: add procedure for this message */


### PR DESCRIPTION
`What-Is-Network-Number` is/was only supported by `h_npdu`, not yet by `h_routed_npdu`.

This PR adds this support to `h_routed_npdu`, basically copying `h_npdu` support and relying on `h_npdu` configuration, in order to not also copy configuration variables themselves. Therefore `h_routed_npdu.c` now depends on `h_npdu`.

Note that `h_npdu` static `network_control_handler` can't be called by `h_routed_npdu` `network_control_handler`, hence the code duplicate.

In this first proposal, I also chosen to not export shared code into a new `h_npdu` public method (such as `npdu_handle_what_is_network_number` or the like) but of course this PR is a proposal subjected to remarks and adjustments, and this can be done if preferred for maintainability.