### PR TITLE
fix(Analog Output): reserve priority 6 in present-value primitives

### DIFF
--- a/src/bacnet/basic/object/ao.c
+++ b/src/bacnet/basic/object/ao.c
@@ -364,6 +364,7 @@ bool Analog_Output_Present_Value_Set(
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
         if ((priority >= 1) && (priority <= BACNET_MAX_PRIORITY) &&
+            (priority != 6 /* reserved */) &&
             isgreaterequal(value, pObject->Min_Pres_Value) &&
             islessequal(value, pObject->Max_Pres_Value)) {
             pObject->Relinquished[priority - 1] = false;
@@ -391,7 +392,8 @@ bool Analog_Output_Present_Value_Relinquish(
 
     pObject = Keylist_Data(Object_List, object_instance);
     if (pObject) {
-        if ((priority >= 1) && (priority <= BACNET_MAX_PRIORITY)) {
+        if ((priority >= 1) && (priority <= BACNET_MAX_PRIORITY) &&
+            (priority != 6 /* reserved */)) {
             pObject->Relinquished[priority - 1] = true;
             pObject->Priority_Array[priority - 1] = 0.0f;
             Analog_Output_Present_Value_COV_Detect(

--- a/test/bacnet/basic/object/ao/src/main.c
+++ b/test/bacnet/basic/object/ao/src/main.c
@@ -166,6 +166,48 @@ static void testAnalogOutput_Writable_Properties(void)
     Analog_Output_Delete(instance);
     Analog_Output_Cleanup();
 }
+
+/**
+ * @brief Test that priority 6 (reserved for the Minimum On/Off algorithm
+ *  per the BACnet standard's recommended priority assignments) is rejected
+ *  by the present-value priority-array primitives, and that other priority
+ *  levels are unaffected
+ */
+#if defined(CONFIG_ZTEST_NEW_API)
+ZTEST(ao_tests, testAnalogOutput_Priority_6_Reserved)
+#else
+static void testAnalogOutput_Priority_6_Reserved(void)
+#endif
+{
+    const uint32_t instance = 789;
+    bool status = false;
+
+    Analog_Output_Init();
+    zassert_not_equal(
+        Analog_Output_Create(instance), BACNET_MAX_INSTANCE, NULL);
+
+    /* priority 6 is reserved: Set must be rejected and the slot must stay
+       relinquished */
+    status = Analog_Output_Present_Value_Set(instance, 42.0f, 6);
+    zassert_false(status, NULL);
+    zassert_true(Analog_Output_Priority_Array_Relinquished(instance, 6), NULL);
+
+    /* priority 6 is reserved: Relinquish must be rejected too (nothing to
+       relinquish, no false report of a state change) */
+    status = Analog_Output_Present_Value_Relinquish(instance, 6);
+    zassert_false(status, NULL);
+
+    /* a non-reserved priority is unaffected by the above */
+    status = Analog_Output_Present_Value_Set(instance, 42.0f, 5);
+    zassert_true(status, NULL);
+    zassert_false(Analog_Output_Priority_Array_Relinquished(instance, 5), NULL);
+    status = Analog_Output_Present_Value_Relinquish(instance, 5);
+    zassert_true(status, NULL);
+    zassert_true(Analog_Output_Priority_Array_Relinquished(instance, 5), NULL);
+
+    Analog_Output_Delete(instance);
+    Analog_Output_Cleanup();
+}
 /**
  * @}
  */
@@ -178,7 +220,8 @@ void test_main(void)
     ztest_test_suite(
         ao_tests, ztest_unit_test(testAnalogOutput),
         ztest_unit_test(testAnalogOutput_name_description_write),
-        ztest_unit_test(testAnalogOutput_Writable_Properties));
+        ztest_unit_test(testAnalogOutput_Writable_Properties),
+        ztest_unit_test(testAnalogOutput_Priority_6_Reserved));
 
     ztest_run_test_suite(ao_tests);
 }


### PR DESCRIPTION
Analog_Output_Present_Value_Set() and Analog_Output_Present_Value_Relinquish() silently accept writes at priority 6, unlike Binary Output's equivalents (Binary_Output_Present_Value_Set/_Relinquish in bo.c), which reject it via `priority != 6 /* reserved */`.

Add a regression test asserting priority 6 is rejected by both primitives and that other priorities are unaffected.

The same could be fixed in mso.c, though out of my current testing scope.

This associates with Issue #1486