### PR TITLE
fix(gateway2): Do not announce virtual network as real network

### DIFF
--- a/apps/gateway2/main.c
+++ b/apps/gateway2/main.c
@@ -293,7 +293,6 @@ int main(int argc, char *argv[])
     /* broadcast an I-am-router-to-network on startup */
     printf("Remote Network DNET Number %d \n", DNET_list[0]);
     Send_I_Am_Router_To_Network(DNET_list);
-    Send_Network_Number_Is(NULL, DNET_list[0], NETWORK_NUMBER_CONFIGURED);
 
     handler_cov_init();
 

--- a/src/bacnet/basic/object/netport.c
+++ b/src/bacnet/basic/object/netport.c
@@ -485,7 +485,7 @@ void Network_Port_Writable_Property_List(
  * @param pRequired - pointer to list of int terminated by -1, of
  * BACnet required properties for this object.
  * @param pOptional - pointer to list of int terminated by -1, of
- * BACnet optkional properties for this object.
+ * BACnet optional properties for this object.
  * @param pProprietary - pointer to list of int terminated by -1, of
  * BACnet proprietary properties for this object.
  */


### PR DESCRIPTION
Gateway2 app creates a virtual network with virtual devices on it.

It announces itself as a router to that virtual network. I_Am_Router_To_Network anounce is broadcasted onto the local real network. OK.

But it must not announce virtual network number inside a Network_Number_Is message, whose goal is to announce the real network number if known by the router (and likely useless to broadcast on boot).

Remove this line, gateway2 do not even know its localnetwork number.